### PR TITLE
feat: add support for separate engine and rpc apis

### DIFF
--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -10,5 +10,6 @@ axum = "0.7.5"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 tokio = { version = "1.38.0", features = ["full"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/rpc/src/engine/capabilities.rs
+++ b/crates/rpc/src/engine/capabilities.rs
@@ -1,9 +1,9 @@
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use crate::RpcErr;
 
 // type ExchangeCapabilities = Vec<String>;
 
 pub fn exchange_capabilities() -> Result<Value, RpcErr> {
-    Ok(Value::Array(vec![]))
+    Ok(json!([]))
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1,3 +1,5 @@
+use std::future::IntoFuture;
+
 use axum::{routing::post, Json, Router};
 use engine::capabilities::exchange_capabilities;
 use eth::{
@@ -5,35 +7,76 @@ use eth::{
     client::{chain_id, syncing},
 };
 use serde_json::Value;
+use tokio::net::TcpListener;
 use tracing::info;
-use utils::{RpcErr, RpcErrorResponse, RpcRequest, RpcSuccessResponse};
+use utils::{RpcErr, RpcErrorMetadata, RpcErrorResponse, RpcRequest, RpcSuccessResponse};
 
 mod engine;
 mod eth;
 mod utils;
 
 #[tokio::main]
-pub async fn start_api() {
-    let app = Router::new().route("/", post(handle_request));
+pub async fn start_api(http_addr: &str, http_port: &str, authrpc_addr: &str, authrpc_port: &str) {
+    let http_router = Router::new().route("/", post(handle_http_request));
+    let http_url = create_url(http_addr, http_port);
+    let http_listener = TcpListener::bind(&http_url).await.unwrap();
 
-    let url = "0.0.0.0:8551";
-    let listener = tokio::net::TcpListener::bind(url).await.unwrap();
-    info!("RPC server listening on: {}", url);
+    let authrpc_router = Router::new().route("/", post(handle_authrpc_request));
+    let authrpc_url = create_url(authrpc_addr, authrpc_port);
+    let authrpc_listener = TcpListener::bind(&authrpc_url).await.unwrap();
 
-    axum::serve(listener, app).await.unwrap();
+    let authrpc_server = axum::serve(authrpc_listener, authrpc_router)
+        .with_graceful_shutdown(shutdown_signal())
+        .into_future();
+    let http_server = axum::serve(http_listener, http_router)
+        .with_graceful_shutdown(shutdown_signal())
+        .into_future();
+
+    let res = tokio::try_join!(authrpc_server, http_server);
+    match res {
+        Ok(_) => {}
+        Err(e) => info!("Error shutting down servers: {:?}", e),
+    }
 }
 
-pub async fn handle_request(body: String) -> Json<Value> {
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to install Ctrl+C handler");
+}
+
+fn create_url(addr: &str, port: &str) -> String {
+    format!("{}:{}", addr, port)
+}
+
+pub async fn handle_authrpc_request(body: String) -> Json<Value> {
     let req: RpcRequest = serde_json::from_str(&body).unwrap();
 
     let res: Result<Value, RpcErr> = match req.method.as_str() {
         "engine_exchangeCapabilities" => exchange_capabilities(),
+        _ => Err(RpcErr::MethodNotFound),
+    };
+
+    rpc_response(req, res)
+}
+
+pub async fn handle_http_request(body: String) -> Json<Value> {
+    let req: RpcRequest = serde_json::from_str(&body).unwrap();
+
+    let res: Result<Value, RpcErr> = match req.method.as_str() {
         "eth_chainId" => chain_id(),
         "eth_syncing" => syncing(),
         "eth_getBlockByNumber" => get_block_by_number(),
         _ => Err(RpcErr::MethodNotFound),
     };
 
+    rpc_response(req, res)
+}
+
+fn rpc_response<E>(req: RpcRequest, res: Result<Value, E>) -> Json<Value>
+where
+    E: Into<RpcErrorMetadata>,
+{
     match res {
         Ok(result) => Json(
             serde_json::to_value(&RpcSuccessResponse {

--- a/ethereum_rust/Cargo.toml
+++ b/ethereum_rust/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 tracing.workspace = true
 tracing-subscriber.workspace = true
 rpc.workspace = true
+clap = { version = "4.5.4", features = ["cargo"] }

--- a/ethereum_rust/src/cli.rs
+++ b/ethereum_rust/src/cli.rs
@@ -1,0 +1,35 @@
+use clap::{Arg, ArgAction, Command};
+
+pub fn cli() -> Command {
+    Command::new("Ethereum Rust")
+        .about("Ethereum Execution client in Rust")
+        .author("Lambdaclass")
+        .arg(
+            Arg::new("http.addr")
+                .long("http.addr")
+                .default_value("localhost")
+                .value_name("ADDRESS")
+                .action(ArgAction::Set),
+        )
+        .arg(
+            Arg::new("http.port")
+                .long("http.port")
+                .default_value("8545")
+                .value_name("PORT")
+                .action(ArgAction::Set),
+        )
+        .arg(
+            Arg::new("authrpc.addr")
+                .long("authrpc.addr")
+                .default_value("localhost")
+                .value_name("ADDRESS")
+                .action(ArgAction::Set),
+        )
+        .arg(
+            Arg::new("authrpc.port")
+                .long("authrpc.port")
+                .default_value("8551")
+                .value_name("PORT")
+                .action(ArgAction::Set),
+        )
+}

--- a/ethereum_rust/src/main.rs
+++ b/ethereum_rust/src/main.rs
@@ -1,5 +1,7 @@
-use tracing::{info, Level};
+use tracing::Level;
 use tracing_subscriber::FmtSubscriber;
+
+mod cli;
 fn main() {
     let subscriber = FmtSubscriber::builder()
         .with_max_level(Level::DEBUG)
@@ -7,7 +9,20 @@ fn main() {
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    info!("Starting Ethereum Rust application");
+    let matches = cli::cli().get_matches();
 
-    rpc::start_api();
+    let http_addr = matches
+        .get_one::<String>("http.addr")
+        .expect("http.addr is required");
+    let http_port = matches
+        .get_one::<String>("http.port")
+        .expect("http.port is required");
+    let authrpc_addr = matches
+        .get_one::<String>("authrpc.addr")
+        .expect("authrpc.addr is required");
+    let authrpc_port = matches
+        .get_one::<String>("authrpc.port")
+        .expect("authrpc.port is required");
+
+    rpc::start_api(http_addr, http_port, authrpc_addr, authrpc_port);
 }


### PR DESCRIPTION
**Description**
Per spec, we have different endpoints for the engine api and the rpc api. This PR adds support for them and to customize endpoint addresses and ports via command line args.
