### PR TITLE
feat: add datatest to consume ef tests.

### DIFF
--- a/ef_tests/Cargo.toml
+++ b/ef_tests/Cargo.toml
@@ -9,3 +9,10 @@ serde.workspace = true
 serde_json.workspace = true
 bytes.workspace = true
 hex = "0.4.3"
+
+[dev-dependencies]
+datatest-stable = "0.2.9"
+
+[[test]]
+name = "cancun"
+harness = false

--- a/ef_tests/tests/cancun.rs
+++ b/ef_tests/tests/cancun.rs
@@ -1,0 +1,14 @@
+use std::path::Path;
+
+mod common;
+
+fn eip4788_tests(path: &Path) -> datatest_stable::Result<()> {
+    common::parse_and_execute_test_file(path);
+    Ok(())
+}
+
+datatest_stable::harness!(
+    eip4788_tests,
+    "vectors/cancun/eip4788_beacon_root",
+    r"^.*beacon_root_contract_calls.json"
+);

--- a/ef_tests/tests/common/mod.rs
+++ b/ef_tests/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, path::Path};
 
 use ::ef_tests::types::TestUnit;
 use ethereum_rust_core::evm::{execute_tx, SpecId};
@@ -38,25 +38,16 @@ fn execute_test(test: &TestUnit) {
     .is_success());
 }
 
-fn parse_test_file(file: &str) -> HashMap<String, TestUnit> {
-    let s: String = std::fs::read_to_string(file).expect("Unable to read file");
+fn parse_test_file(path: &Path) -> HashMap<String, TestUnit> {
+    let s: String = std::fs::read_to_string(path).expect("Unable to read file");
     let tests: HashMap<String, TestUnit> = serde_json::from_str(&s).expect("Unable to parse JSON");
     tests
 }
 
-fn parse_and_execute_test_file(file: &str) {
-    let tests = parse_test_file(file);
+pub fn parse_and_execute_test_file(path: &Path) {
+    let tests = parse_test_file(path);
+
     for (_k, test) in tests {
         execute_test(&test)
-    }
-}
-
-#[cfg(test)]
-mod ef_tests {
-    use crate::parse_and_execute_test_file;
-
-    #[test]
-    fn beacon_root_contract_calls_test() {
-        parse_and_execute_test_file("./vectors/cancun/eip4788_beacon_root/beacon_root_contract/beacon_root_contract_calls.json");
     }
 }


### PR DESCRIPTION
**Motivation**
We want to be able to consume tests from the fixture files provided by the EF

**Description**
Adds datatest boilerplate with one working example.
