### PR TITLE
feat: extend `Store` api with block functionality

### DIFF
--- a/crates/core/src/types/block.rs
+++ b/crates/core/src/types/block.rs
@@ -166,7 +166,7 @@ impl BlockBody {
                 // Value: tx_type || RLP(tx)  if tx_type != 0
                 //                   RLP(tx)  else
                 let mut v = Vec::new();
-                tx.encode_with_type(&mut v);
+                tx.encode(&mut v);
 
                 (k, v)
             })
@@ -234,9 +234,15 @@ impl RLPDecode for BlockBody {
         let (transactions, decoder) = decoder.decode_field("transactions")?;
         let (ommers, decoder) = decoder.decode_field("ommers")?;
         let (withdrawals, decoder) = decoder.decode_field("withdrawals")?;
-        Ok((BlockBody { transactions, ommers, withdrawals }, decoder.finish()?))
+        Ok((
+            BlockBody {
+                transactions,
+                ommers,
+                withdrawals,
+            },
+            decoder.finish()?,
+        ))
     }
-
 }
 
 impl BlockHeader {

--- a/crates/core/src/types/block.rs
+++ b/crates/core/src/types/block.rs
@@ -3,7 +3,11 @@ use super::{
     GAS_LIMIT_MINIMUM,
 };
 use crate::{
-    rlp::{encode::RLPEncode, structs::Encoder},
+    rlp::{
+        decode::RLPDecode,
+        encode::RLPEncode,
+        structs::{Decoder, Encoder},
+    },
     types::Receipt,
     Address, H256, U256,
 };
@@ -75,6 +79,59 @@ impl RLPEncode for BlockHeader {
             .encode_field(&self.excess_blob_gas)
             .encode_field(&self.parent_beacon_block_root)
             .finish();
+    }
+}
+
+impl RLPDecode for BlockHeader {
+    fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), crate::rlp::error::RLPDecodeError> {
+        let decoder = Decoder::new(rlp)?;
+        let (parent_hash, decoder) = decoder.decode_field("parent_hash")?;
+        let (ommers_hash, decoder) = decoder.decode_field("parent_hash")?;
+        let (coinbase, decoder) = decoder.decode_field("coinbase")?;
+        let (state_root, decoder) = decoder.decode_field("state_root")?;
+        let (transactions_root, decoder) = decoder.decode_field("transactions_root")?;
+        let (receipt_root, decoder) = decoder.decode_field("receipt_root")?;
+        let (logs_bloom, decoder) = decoder.decode_field("logs_bloom")?;
+        let (difficulty, decoder) = decoder.decode_field("difficulty")?;
+        let (number, decoder) = decoder.decode_field("number")?;
+        let (gas_limit, decoder) = decoder.decode_field("gas_limit")?;
+        let (gas_used, decoder) = decoder.decode_field("gas_used")?;
+        let (timestamp, decoder) = decoder.decode_field("timestamp")?;
+        let (extra_data, decoder) = decoder.decode_field("extra_data")?;
+        let (prev_randao, decoder) = decoder.decode_field("prev_randao")?;
+        let (nonce, decoder) = decoder.decode_field("nonce")?;
+        let nonce = u64::from_be_bytes(nonce);
+        let (base_fee_per_gas, decoder) = decoder.decode_field("base_fee_per_gas")?;
+        let (withdrawals_root, decoder) = decoder.decode_field("withdrawals_root")?;
+        let (blob_gas_used, decoder) = decoder.decode_field("blob_gas_used")?;
+        let (excess_blob_gas, decoder) = decoder.decode_field("excess_blob_gas")?;
+        let (parent_beacon_block_root, decoder) =
+            decoder.decode_field("parent_beacon_block_root")?;
+        Ok((
+            BlockHeader {
+                parent_hash,
+                ommers_hash,
+                coinbase,
+                state_root,
+                transactions_root,
+                receipt_root,
+                logs_bloom,
+                difficulty,
+                number,
+                gas_limit,
+                gas_used,
+                timestamp,
+                extra_data,
+                prev_randao,
+                nonce,
+                base_fee_per_gas,
+                withdrawals_root,
+                blob_gas_used,
+                excess_blob_gas,
+                parent_beacon_block_root,
+            },
+            decoder.finish()?,
+        ))
     }
 }
 

--- a/crates/core/src/types/block.rs
+++ b/crates/core/src/types/block.rs
@@ -86,7 +86,7 @@ impl RLPDecode for BlockHeader {
     fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), crate::rlp::error::RLPDecodeError> {
         let decoder = Decoder::new(rlp)?;
         let (parent_hash, decoder) = decoder.decode_field("parent_hash")?;
-        let (ommers_hash, decoder) = decoder.decode_field("parent_hash")?;
+        let (ommers_hash, decoder) = decoder.decode_field("ommers_hash")?;
         let (coinbase, decoder) = decoder.decode_field("coinbase")?;
         let (state_root, decoder) = decoder.decode_field("state_root")?;
         let (transactions_root, decoder) = decoder.decode_field("transactions_root")?;
@@ -226,6 +226,17 @@ impl RLPEncode for BlockBody {
             .encode_field(&self.withdrawals)
             .finish();
     }
+}
+
+impl RLPDecode for BlockBody {
+    fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), crate::rlp::error::RLPDecodeError> {
+        let decoder = Decoder::new(rlp)?;
+        let (transactions, decoder) = decoder.decode_field("transactions")?;
+        let (ommers, decoder) = decoder.decode_field("ommers")?;
+        let (withdrawals, decoder) = decoder.decode_field("withdrawals")?;
+        Ok((BlockBody { transactions, ommers, withdrawals }, decoder.finish()?))
+    }
+
 }
 
 impl BlockHeader {

--- a/crates/core/src/types/block.rs
+++ b/crates/core/src/types/block.rs
@@ -275,6 +275,25 @@ impl RLPEncode for Withdrawal {
     }
 }
 
+impl RLPDecode for Withdrawal {
+    fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), crate::rlp::error::RLPDecodeError> {
+        let decoder = Decoder::new(rlp)?;
+        let (index, decoder) = decoder.decode_field("index")?;
+        let (validator_index, decoder) = decoder.decode_field("validator_index")?;
+        let (address, decoder) = decoder.decode_field("address")?;
+        let (amount, decoder) = decoder.decode_field("amount")?;
+        Ok((
+            Withdrawal {
+                index,
+                validator_index,
+                address,
+                amount,
+            },
+            decoder.finish()?,
+        ))
+    }
+}
+
 // Checks that the gas_limit fits the gas bounds set by its parent block
 fn check_gas_limit(gas_limit: u64, parent_gas_limit: u64) -> bool {
     let max_adjustment_delta = parent_gas_limit / GAS_LIMIT_ADJUSTMENT_FACTOR;

--- a/crates/core/src/types/engine/payload.rs
+++ b/crates/core/src/types/engine/payload.rs
@@ -7,8 +7,7 @@ use crate::rlp::decode::RLPDecode;
 use crate::{rlp::error::RLPDecodeError, serde_utils};
 
 use crate::types::{
-    compute_withdrawals_root, BlockBody, BlockHeader, EIP1559Transaction, EIP2930Transaction,
-    EIP4844Transaction, LegacyTransaction, Transaction, Withdrawal, DEFAULT_OMMERS_HASH,
+    compute_withdrawals_root, BlockBody, BlockHeader, Transaction, Withdrawal, DEFAULT_OMMERS_HASH,
 };
 
 #[allow(unused)]
@@ -64,35 +63,7 @@ impl EncodedTransaction {
     /// A) `TransactionType || Transaction` (Where Transaction type is an 8-bit number between 0 and 0x7f, and Transaction is an rlp encoded transaction of type TransactionType)
     /// B) `LegacyTransaction` (An rlp encoded LegacyTransaction)
     fn decode(&self) -> Result<Transaction, RLPDecodeError> {
-        // Look at the first byte to check if it corresponds to a TransactionType
-        match self.0.first() {
-            // First byte is a valid TransactionType
-            Some(tx_type) if *tx_type < 0x7f => {
-                // Decode tx based on type
-                let tx_bytes = &self.0.as_ref()[1..];
-                match *tx_type {
-                    // Legacy
-                    0x0 => LegacyTransaction::decode(tx_bytes).map(Transaction::LegacyTransaction), // TODO: check if this is a real case scenario
-                    // EIP2930
-                    0x1 => {
-                        EIP2930Transaction::decode(tx_bytes).map(Transaction::EIP2930Transaction)
-                    }
-                    // EIP1559
-                    0x2 => {
-                        EIP1559Transaction::decode(tx_bytes).map(Transaction::EIP1559Transaction)
-                    }
-                    // EIP4844
-                    0x3 => {
-                        EIP4844Transaction::decode(tx_bytes).map(Transaction::EIP4844Transaction)
-                    }
-                    ty => Err(RLPDecodeError::Custom(format!(
-                        "Invalid transaction type: {ty}"
-                    ))),
-                }
-            }
-            // LegacyTransaction
-            _ => LegacyTransaction::decode(self.0.as_ref()).map(Transaction::LegacyTransaction),
-        }
+        Transaction::decode(self.0.as_ref())
     }
 }
 

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -116,12 +116,7 @@ impl Transaction {
 
 impl RLPEncode for Transaction {
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
-        match self {
-            Transaction::LegacyTransaction(t) => t.encode(buf),
-            Transaction::EIP2930Transaction(t) => t.encode(buf),
-            Transaction::EIP1559Transaction(t) => t.encode(buf),
-            Transaction::EIP4844Transaction(t) => t.encode(buf),
-        };
+        self.encode_with_type(buf)
     }
 }
 

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -92,18 +92,6 @@ pub enum TxType {
 }
 
 impl Transaction {
-    pub fn encode_with_type(&self, buf: &mut dyn bytes::BufMut) {
-        // tx_type || RLP(tx)  if tx_type != 0
-        //            RLP(tx)  else
-        match self {
-            // Legacy transactions don't have a prefix
-            Transaction::LegacyTransaction(_) => {}
-            _ => buf.put_u8(self.tx_type() as u8),
-        }
-
-        self.encode(buf);
-    }
-
     pub fn tx_type(&self) -> TxType {
         match self {
             Transaction::LegacyTransaction(_) => TxType::Legacy,
@@ -115,8 +103,59 @@ impl Transaction {
 }
 
 impl RLPEncode for Transaction {
+    /// Based on [EIP-2718]
+    /// Transactions can be encoded in the following formats:
+    /// A) `TransactionType || Transaction` (Where Transaction type is an 8-bit number between 0 and 0x7f, and Transaction is an rlp encoded transaction of type TransactionType)
+    /// B) `LegacyTransaction` (An rlp encoded LegacyTransaction)
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
-        self.encode_with_type(buf)
+        match self {
+            // Legacy transactions don't have a prefix
+            Transaction::LegacyTransaction(_) => {}
+            _ => buf.put_u8(self.tx_type() as u8),
+        }
+        match self {
+            Transaction::LegacyTransaction(t) => t.encode(buf),
+            Transaction::EIP2930Transaction(t) => t.encode(buf),
+            Transaction::EIP1559Transaction(t) => t.encode(buf),
+            Transaction::EIP4844Transaction(t) => t.encode(buf),
+        };
+    }
+}
+
+impl RLPDecode for Transaction {
+    /// Based on [EIP-2718]
+    /// Transactions can be encoded in the following formats:
+    /// A) `TransactionType || Transaction` (Where Transaction type is an 8-bit number between 0 and 0x7f, and Transaction is an rlp encoded transaction of type TransactionType)
+    /// B) `LegacyTransaction` (An rlp encoded LegacyTransaction)
+    fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), RLPDecodeError> {
+        // Look at the first byte to check if it corresponds to a TransactionType
+        match rlp.first() {
+            // First byte is a valid TransactionType
+            Some(tx_type) if *tx_type < 0x7f => {
+                // Decode tx based on type
+                let tx_bytes = &rlp.as_ref()[1..];
+                match *tx_type {
+                    // Legacy
+                    0x0 => LegacyTransaction::decode_unfinished(tx_bytes)
+                        .map(|(tx, rem)| (Transaction::LegacyTransaction(tx), rem)), // TODO: check if this is a real case scenario
+                    // EIP2930
+                    0x1 => EIP2930Transaction::decode_unfinished(tx_bytes)
+                        .map(|(tx, rem)| (Transaction::EIP2930Transaction(tx), rem)),
+                    // EIP1559
+                    0x2 => EIP1559Transaction::decode_unfinished(tx_bytes)
+                        .map(|(tx, rem)| (Transaction::EIP1559Transaction(tx), rem)),
+                    // EIP4844
+                    0x3 => EIP4844Transaction::decode_unfinished(tx_bytes)
+                        .map(|(tx, rem)| (Transaction::EIP4844Transaction(tx), rem)),
+                    ty => Err(RLPDecodeError::Custom(format!(
+                        "Invalid transaction type: {ty}"
+                    ))),
+                }
+            }
+            // LegacyTransaction
+            _ => LegacyTransaction::decode_unfinished(rlp)
+                .map(|(tx, rem)| (Transaction::LegacyTransaction(tx), rem)),
+        }
     }
 }
 

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -133,7 +133,7 @@ impl RLPDecode for Transaction {
             // First byte is a valid TransactionType
             Some(tx_type) if *tx_type < 0x7f => {
                 // Decode tx based on type
-                let tx_bytes = &rlp.as_ref()[1..];
+                let tx_bytes = &rlp[1..];
                 match *tx_type {
                     // Legacy
                     0x0 => LegacyTransaction::decode_unfinished(tx_bytes)

--- a/crates/storage/src/in_memory.rs
+++ b/crates/storage/src/in_memory.rs
@@ -1,21 +1,20 @@
 use super::{Key, StoreEngine, Value};
 use crate::error::StoreError;
-use ethereum_rust_core::types::AccountInfo;
+use ethereum_rust_core::types::{AccountInfo, BlockBody, BlockHeader, BlockNumber};
 use ethereum_types::Address;
 use std::{collections::HashMap, fmt::Debug};
 
 #[derive(Default)]
 pub struct Store {
     account_infos: HashMap<Address, AccountInfo>,
+    bodies: HashMap<BlockNumber, BlockBody>,
+    headers: HashMap<BlockNumber, BlockHeader>,
     values: HashMap<Key, Value>,
 }
 
 impl Store {
     pub fn new() -> Result<Self, StoreError> {
-        Ok(Self {
-            account_infos: HashMap::new(),
-            values: HashMap::new(),
-        })
+        Ok(Self::default())
     }
 }
 
@@ -40,6 +39,14 @@ impl StoreEngine for Store {
 
     fn get_value(&self, key: Key) -> Result<Option<Vec<u8>>, StoreError> {
         Ok(self.values.get(&key).cloned())
+    }
+
+    fn get_block_header(&self, block_number: u64) -> Result<Option<BlockHeader>, StoreError> {
+        Ok(self.headers.get(&block_number).cloned())
+    }
+
+    fn get_block_body(&self, block_number: u64) -> Result<Option<BlockBody>, StoreError> {
+        Ok(self.bodies.get(&block_number).cloned())
     }
 }
 

--- a/crates/storage/src/in_memory.rs
+++ b/crates/storage/src/in_memory.rs
@@ -48,6 +48,24 @@ impl StoreEngine for Store {
     fn get_block_body(&self, block_number: u64) -> Result<Option<BlockBody>, StoreError> {
         Ok(self.bodies.get(&block_number).cloned())
     }
+
+    fn add_block_header(
+        &mut self,
+        block_number: BlockNumber,
+        block_header: BlockHeader,
+    ) -> Result<(), StoreError> {
+        self.headers.insert(block_number, block_header);
+        Ok(())
+    }
+
+    fn add_block_body(
+        &mut self,
+        block_number: BlockNumber,
+        block_body: BlockBody,
+    ) -> Result<(), StoreError> {
+        self.bodies.insert(block_number, block_body);
+        Ok(())
+    }
 }
 
 impl Debug for Store {

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -13,7 +13,7 @@ use self::libmdbx::Store as LibmdbxStore;
 use self::rocksdb::Store as RocksDbStore;
 #[cfg(feature = "sled")]
 use self::sled::Store as SledStore;
-use ethereum_rust_core::types::{AccountInfo, BlockBody, BlockHeader};
+use ethereum_rust_core::types::{AccountInfo, BlockBody, BlockHeader, BlockNumber};
 use ethereum_types::Address;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
@@ -44,11 +44,28 @@ pub trait StoreEngine: Debug + Send {
     /// Obtain account info
     fn get_account_info(&self, address: Address) -> Result<Option<AccountInfo>, StoreError>;
 
-    // Obtain block header
-    fn get_block_header(&self, block_number: u64) -> Result<Option<BlockHeader>, StoreError>;
+    /// Add block header
+    fn add_block_header(
+        &self,
+        block_number: BlockNumber,
+        block_header: BlockHeader,
+    ) -> Result<(), StoreError>;
 
-    // Obtain block body
-    fn get_block_body(&self, block_number: u64) -> Result<Option<BlockBody>, StoreError>;
+    /// Obtain block header
+    fn get_block_header(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<Option<BlockHeader>, StoreError>;
+
+    /// Add block body
+    fn add_block_body(
+        &self,
+        block_number: BlockNumber,
+        block_body: BlockBody,
+    ) -> Result<(), StoreError>;
+
+    /// Obtain block body
+    fn get_block_body(&self, block_number: BlockNumber) -> Result<Option<BlockBody>, StoreError>;
 
     /// Set an arbitrary value (used for eventual persistent values: eg. current_block_height)
     fn set_value(&mut self, key: Key, value: Value) -> Result<(), StoreError>;
@@ -117,7 +134,10 @@ impl Store {
             .get_account_info(address)
     }
 
-    pub fn get_block_header(&self, block_number: u64) -> Result<Option<BlockHeader>, StoreError> {
+    pub fn add_block_header(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<Option<BlockHeader>, StoreError> {
         self.engine
             .clone()
             .lock()
@@ -125,7 +145,32 @@ impl Store {
             .get_block_header(block_number)
     }
 
-    pub fn get_block_body(&self, block_number: u64) -> Result<Option<BlockBody>, StoreError> {
+    pub fn get_block_header(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<Option<BlockHeader>, StoreError> {
+        self.engine
+            .clone()
+            .lock()
+            .unwrap()
+            .get_block_header(block_number)
+    }
+
+    pub fn add_block_body(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<Option<BlockBody>, StoreError> {
+        self.engine
+            .clone()
+            .lock()
+            .unwrap()
+            .get_block_body(block_number)
+    }
+
+    pub fn get_block_body(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<Option<BlockBody>, StoreError> {
         self.engine
             .clone()
             .lock()

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -46,7 +46,7 @@ pub trait StoreEngine: Debug + Send {
 
     /// Add block header
     fn add_block_header(
-        &self,
+        &mut self,
         block_number: BlockNumber,
         block_header: BlockHeader,
     ) -> Result<(), StoreError>;
@@ -59,7 +59,7 @@ pub trait StoreEngine: Debug + Send {
 
     /// Add block body
     fn add_block_body(
-        &self,
+        &mut self,
         block_number: BlockNumber,
         block_body: BlockBody,
     ) -> Result<(), StoreError>;

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -13,7 +13,7 @@ use self::libmdbx::Store as LibmdbxStore;
 use self::rocksdb::Store as RocksDbStore;
 #[cfg(feature = "sled")]
 use self::sled::Store as SledStore;
-use ethereum_rust_core::types::AccountInfo;
+use ethereum_rust_core::types::{AccountInfo, BlockBody, BlockHeader};
 use ethereum_types::Address;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
@@ -43,6 +43,12 @@ pub trait StoreEngine: Debug + Send {
 
     /// Obtain account info
     fn get_account_info(&self, address: Address) -> Result<Option<AccountInfo>, StoreError>;
+
+    // Obtain block header
+    fn get_block_header(&self, block_number: u64) -> Result<Option<BlockHeader>, StoreError>;
+
+    // Obtain block body
+    fn get_block_body(&self, block_number: u64) -> Result<Option<BlockBody>, StoreError>;
 
     /// Set an arbitrary value (used for eventual persistent values: eg. current_block_height)
     fn set_value(&mut self, key: Key, value: Value) -> Result<(), StoreError>;
@@ -109,6 +115,22 @@ impl Store {
             .lock()
             .unwrap()
             .get_account_info(address)
+    }
+
+    pub fn get_block_header(&self, block_number: u64) -> Result<Option<BlockHeader>, StoreError> {
+        self.engine
+            .clone()
+            .lock()
+            .unwrap()
+            .get_block_header(block_number)
+    }
+
+    pub fn get_block_body(&self, block_number: u64) -> Result<Option<BlockBody>, StoreError> {
+        self.engine
+            .clone()
+            .lock()
+            .unwrap()
+            .get_block_body(block_number)
     }
 }
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -137,12 +137,13 @@ impl Store {
     pub fn add_block_header(
         &self,
         block_number: BlockNumber,
-    ) -> Result<Option<BlockHeader>, StoreError> {
+        block_header: BlockHeader,
+    ) -> Result<(), StoreError> {
         self.engine
             .clone()
             .lock()
             .unwrap()
-            .get_block_header(block_number)
+            .add_block_header(block_number, block_header)
     }
 
     pub fn get_block_header(
@@ -159,12 +160,13 @@ impl Store {
     pub fn add_block_body(
         &self,
         block_number: BlockNumber,
-    ) -> Result<Option<BlockBody>, StoreError> {
+        block_body: BlockBody,
+    ) -> Result<(), StoreError> {
         self.engine
             .clone()
             .lock()
             .unwrap()
-            .get_block_body(block_number)
+            .add_block_body(block_number, block_body)
     }
 
     pub fn get_block_body(
@@ -181,11 +183,14 @@ impl Store {
 
 #[cfg(test)]
 mod tests {
-    use std::{env, fs};
+    use std::{env, fs, str::FromStr};
 
     use bytes::Bytes;
-    use ethereum_rust_core::types;
-    use ethereum_types::U256;
+    use ethereum_rust_core::{
+        rlp::decode::RLPDecode,
+        types::{self, Bloom, Transaction},
+    };
+    use ethereum_types::{H256, U256};
 
     use super::*;
 
@@ -194,6 +199,7 @@ mod tests {
     fn test_in_memory_store() {
         let store = Store::new("test", EngineType::InMemory).unwrap();
         test_store_account(store.clone());
+        test_store_block(store.clone());
     }
 
     #[cfg(feature = "libmdbx")]
@@ -203,6 +209,7 @@ mod tests {
         remove_test_dbs("test.mdbx");
         let store = Store::new("test.mdbx", EngineType::Libmdbx).unwrap();
         test_store_account(store.clone());
+        test_store_block(store.clone());
 
         remove_test_dbs("test.mdbx");
     }
@@ -214,6 +221,7 @@ mod tests {
         remove_test_dbs("test.sled");
         let store = Store::new("test.sled", EngineType::Sled).unwrap();
         test_store_account(store.clone());
+        // test_store_block(store.clone()); Unimplemented
 
         remove_test_dbs("test.sled");
     }
@@ -225,6 +233,7 @@ mod tests {
         remove_test_dbs("test.rocksdb");
         let store = Store::new("test.rocksdb", EngineType::Sled).unwrap();
         test_store_account(store.clone());
+        // test_store_block(store.clone()); Unimplemented
 
         remove_test_dbs("test.rocksdb");
     }
@@ -268,5 +277,73 @@ mod tests {
                 fs::remove_dir_all(entry.unwrap().path()).unwrap();
             }
         }
+    }
+
+    fn test_store_block(store: Store) {
+        let (block_header, block_body) = create_block_for_testing();
+        let block_number = 6;
+
+        store
+            .add_block_header(block_number, block_header.clone())
+            .unwrap();
+        store
+            .add_block_body(block_number, block_body.clone())
+            .unwrap();
+
+        let stored_header = store.get_block_header(block_number).unwrap().unwrap();
+        let stored_body = store.get_block_body(block_number).unwrap().unwrap();
+
+        assert_eq!(stored_header, block_header);
+        assert_eq!(stored_body, block_body);
+    }
+
+    fn create_block_for_testing() -> (BlockHeader, BlockBody) {
+        let block_header = BlockHeader {
+            parent_hash: H256::from_str(
+                "0x1ac1bf1eef97dc6b03daba5af3b89881b7ae4bc1600dc434f450a9ec34d44999",
+            )
+            .unwrap(),
+            ommers_hash: H256::from_str(
+                "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            )
+            .unwrap(),
+            coinbase: Address::from_str("0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba").unwrap(),
+            state_root: H256::from_str(
+                "0x9de6f95cb4ff4ef22a73705d6ba38c4b927c7bca9887ef5d24a734bb863218d9",
+            )
+            .unwrap(),
+            transactions_root: H256::from_str(
+                "0x578602b2b7e3a3291c3eefca3a08bc13c0d194f9845a39b6f3bcf843d9fed79d",
+            )
+            .unwrap(),
+            receipt_root: H256::from_str(
+                "0x035d56bac3f47246c5eed0e6642ca40dc262f9144b582f058bc23ded72aa72fa",
+            )
+            .unwrap(),
+            logs_bloom: Bloom::from([0; 256]),
+            difficulty: U256::zero(),
+            number: 1,
+            gas_limit: 0x016345785d8a0000,
+            gas_used: 0xa8de,
+            timestamp: 0x03e8,
+            extra_data: Bytes::new(),
+            prev_randao: H256::zero(),
+            nonce: 0x0000000000000000,
+            base_fee_per_gas: 0x07,
+            withdrawals_root: H256::from_str(
+                "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            )
+            .unwrap(),
+            blob_gas_used: 0x00,
+            excess_blob_gas: 0x00,
+            parent_beacon_block_root: H256::zero(),
+        };
+        let block_body = BlockBody {
+            transactions: vec![Transaction::decode(&hex::decode("02f86c8330182480114e82f618946177843db3138ae69679a54b95cf345ed759450d870aa87bee53800080c080a0151ccc02146b9b11adf516e6787b59acae3e76544fdcd75e77e67c6b598ce65da064c5dd5aae2fbb535830ebbdad0234975cd7ece3562013b63ea18cc0df6c97d4").unwrap()).unwrap(),
+            Transaction::decode(&hex::decode("f86d80843baa0c4082f618946177843db3138ae69679a54b95cf345ed759450d870aa87bee538000808360306ba0151ccc02146b9b11adf516e6787b59acae3e76544fdcd75e77e67c6b598ce65da064c5dd5aae2fbb535830ebbdad0234975cd7ece3562013b63ea18cc0df6c97d4").unwrap()).unwrap()],
+            ommers: Default::default(),
+            withdrawals: Default::default(),
+        };
+        (block_header, block_body)
     }
 }

--- a/crates/storage/src/libmdbx.rs
+++ b/crates/storage/src/libmdbx.rs
@@ -57,6 +57,21 @@ impl StoreEngine for Store {
         }
     }
 
+    fn get_block_body(
+        &self,
+        block_number: u64,
+    ) -> std::result::Result<Option<ethereum_rust_core::types::BlockBody>, StoreError> {
+        // Read block body from mdbx
+        let read_value = {
+            let txn = self.db.begin_read().unwrap();
+            txn.get::<Bodies>(block_number.into())
+        };
+        match read_value {
+            Ok(value) => Ok(value.map(|a| a.to())),
+            Err(err) => Err(StoreError::LibmdbxError(err)),
+        }
+    }
+
     fn set_value(&mut self, _key: Key, _value: Value) -> Result<(), StoreError> {
         todo!()
     }

--- a/crates/storage/src/libmdbx.rs
+++ b/crates/storage/src/libmdbx.rs
@@ -179,22 +179,10 @@ pub fn init_db(path: Option<impl AsRef<Path>>) -> Database {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use bytes::Bytes;
-    use ethereum_rust_core::{
-        rlp::decode::RLPDecode,
-        types::{BlockBody, BlockHeader, Bloom, Transaction},
-    };
-    use ethereum_types::{Address, H256, U256};
     use libmdbx::{
         orm::{table, Database, Decodable, Encodable},
         table_info,
     };
-
-    use crate::StoreEngine;
-
-    use super::init_db;
 
     #[test]
     fn mdbx_smoke_test() {
@@ -289,75 +277,5 @@ mod tests {
             txn.get::<StructsExample>(key).unwrap()
         };
         assert_eq!(read_value, Some(value));
-    }
-
-    #[test]
-    fn store_and_fetch_block() {
-        // Create block
-        let block_header = BlockHeader {
-            parent_hash: H256::from_str(
-                "0x1ac1bf1eef97dc6b03daba5af3b89881b7ae4bc1600dc434f450a9ec34d44999",
-            )
-            .unwrap(),
-            ommers_hash: H256::from_str(
-                "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-            )
-            .unwrap(),
-            coinbase: Address::from_str("0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba").unwrap(),
-            state_root: H256::from_str(
-                "0x9de6f95cb4ff4ef22a73705d6ba38c4b927c7bca9887ef5d24a734bb863218d9",
-            )
-            .unwrap(),
-            transactions_root: H256::from_str(
-                "0x578602b2b7e3a3291c3eefca3a08bc13c0d194f9845a39b6f3bcf843d9fed79d",
-            )
-            .unwrap(),
-            receipt_root: H256::from_str(
-                "0x035d56bac3f47246c5eed0e6642ca40dc262f9144b582f058bc23ded72aa72fa",
-            )
-            .unwrap(),
-            logs_bloom: Bloom::from([0; 256]),
-            difficulty: U256::zero(),
-            number: 1,
-            gas_limit: 0x016345785d8a0000,
-            gas_used: 0xa8de,
-            timestamp: 0x03e8,
-            extra_data: Bytes::new(),
-            prev_randao: H256::zero(),
-            nonce: 0x0000000000000000,
-            base_fee_per_gas: 0x07,
-            withdrawals_root: H256::from_str(
-                "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            )
-            .unwrap(),
-            blob_gas_used: 0x00,
-            excess_blob_gas: 0x00,
-            parent_beacon_block_root: H256::zero(),
-        };
-        let block_body = BlockBody {
-            transactions: vec![Transaction::decode(&hex::decode("02f86c8330182480114e82f618946177843db3138ae69679a54b95cf345ed759450d870aa87bee53800080c080a0151ccc02146b9b11adf516e6787b59acae3e76544fdcd75e77e67c6b598ce65da064c5dd5aae2fbb535830ebbdad0234975cd7ece3562013b63ea18cc0df6c97d4").unwrap()).unwrap(),
-            Transaction::decode(&hex::decode("f86d80843baa0c4082f618946177843db3138ae69679a54b95cf345ed759450d870aa87bee538000808360306ba0151ccc02146b9b11adf516e6787b59acae3e76544fdcd75e77e67c6b598ce65da064c5dd5aae2fbb535830ebbdad0234975cd7ece3562013b63ea18cc0df6c97d4").unwrap()).unwrap()],
-            ommers: Default::default(),
-            withdrawals: Default::default(),
-        };
-
-        let block_number = 6;
-
-        let mut storage = super::Store {
-            db: init_db(None::<String>),
-        };
-
-        storage
-            .add_block_body(block_number, block_body.clone())
-            .unwrap();
-        storage
-            .add_block_header(block_number, block_header.clone())
-            .unwrap();
-
-        let fetched_body = storage.get_block_body(block_number).unwrap().unwrap();
-        let fetched_header = storage.get_block_header(block_number).unwrap().unwrap();
-
-        assert_eq!(block_body, fetched_body);
-        assert_eq!(block_header, fetched_header);
     }
 }

--- a/crates/storage/src/libmdbx.rs
+++ b/crates/storage/src/libmdbx.rs
@@ -58,7 +58,7 @@ impl StoreEngine for Store {
     }
 
     fn add_block_header(
-        &self,
+        &mut self,
         block_number: BlockNumber,
         block_header: BlockHeader,
     ) -> std::result::Result<(), StoreError> {
@@ -89,7 +89,7 @@ impl StoreEngine for Store {
     }
 
     fn add_block_body(
-        &self,
+        &mut self,
         block_number: BlockNumber,
         block_body: BlockBody,
     ) -> std::result::Result<(), StoreError> {
@@ -179,10 +179,22 @@ pub fn init_db(path: Option<impl AsRef<Path>>) -> Database {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
+    use bytes::Bytes;
+    use ethereum_rust_core::{
+        rlp::decode::RLPDecode,
+        types::{BlockBody, BlockHeader, Bloom, Transaction},
+    };
+    use ethereum_types::{Address, H256, U256};
     use libmdbx::{
         orm::{table, Database, Decodable, Encodable},
         table_info,
     };
+
+    use crate::StoreEngine;
+
+    use super::init_db;
 
     #[test]
     fn mdbx_smoke_test() {
@@ -277,5 +289,75 @@ mod tests {
             txn.get::<StructsExample>(key).unwrap()
         };
         assert_eq!(read_value, Some(value));
+    }
+
+    #[test]
+    fn store_and_fetch_block() {
+        // Create block
+        let block_header = BlockHeader {
+            parent_hash: H256::from_str(
+                "0x1ac1bf1eef97dc6b03daba5af3b89881b7ae4bc1600dc434f450a9ec34d44999",
+            )
+            .unwrap(),
+            ommers_hash: H256::from_str(
+                "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            )
+            .unwrap(),
+            coinbase: Address::from_str("0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba").unwrap(),
+            state_root: H256::from_str(
+                "0x9de6f95cb4ff4ef22a73705d6ba38c4b927c7bca9887ef5d24a734bb863218d9",
+            )
+            .unwrap(),
+            transactions_root: H256::from_str(
+                "0x578602b2b7e3a3291c3eefca3a08bc13c0d194f9845a39b6f3bcf843d9fed79d",
+            )
+            .unwrap(),
+            receipt_root: H256::from_str(
+                "0x035d56bac3f47246c5eed0e6642ca40dc262f9144b582f058bc23ded72aa72fa",
+            )
+            .unwrap(),
+            logs_bloom: Bloom::from([0; 256]),
+            difficulty: U256::zero(),
+            number: 1,
+            gas_limit: 0x016345785d8a0000,
+            gas_used: 0xa8de,
+            timestamp: 0x03e8,
+            extra_data: Bytes::new(),
+            prev_randao: H256::zero(),
+            nonce: 0x0000000000000000,
+            base_fee_per_gas: 0x07,
+            withdrawals_root: H256::from_str(
+                "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            )
+            .unwrap(),
+            blob_gas_used: 0x00,
+            excess_blob_gas: 0x00,
+            parent_beacon_block_root: H256::zero(),
+        };
+        let block_body = BlockBody {
+            transactions: vec![Transaction::decode(&hex::decode("02f86c8330182480114e82f618946177843db3138ae69679a54b95cf345ed759450d870aa87bee53800080c080a0151ccc02146b9b11adf516e6787b59acae3e76544fdcd75e77e67c6b598ce65da064c5dd5aae2fbb535830ebbdad0234975cd7ece3562013b63ea18cc0df6c97d4").unwrap()).unwrap(),
+            Transaction::decode(&hex::decode("f86d80843baa0c4082f618946177843db3138ae69679a54b95cf345ed759450d870aa87bee538000808360306ba0151ccc02146b9b11adf516e6787b59acae3e76544fdcd75e77e67c6b598ce65da064c5dd5aae2fbb535830ebbdad0234975cd7ece3562013b63ea18cc0df6c97d4").unwrap()).unwrap()],
+            ommers: Default::default(),
+            withdrawals: Default::default(),
+        };
+
+        let block_number = 6;
+
+        let mut storage = super::Store {
+            db: init_db(None::<String>),
+        };
+
+        storage
+            .add_block_body(block_number, block_body.clone())
+            .unwrap();
+        storage
+            .add_block_header(block_number, block_header.clone())
+            .unwrap();
+
+        let fetched_body = storage.get_block_body(block_number).unwrap().unwrap();
+        let fetched_header = storage.get_block_header(block_number).unwrap().unwrap();
+
+        assert_eq!(block_body, fetched_body);
+        assert_eq!(block_header, fetched_header);
     }
 }

--- a/crates/storage/src/libmdbx.rs
+++ b/crates/storage/src/libmdbx.rs
@@ -57,11 +57,27 @@ impl StoreEngine for Store {
         }
     }
 
+    fn add_block_header(
+        &self,
+        block_number: BlockNumber,
+        block_header: BlockHeader,
+    ) -> std::result::Result<(), StoreError> {
+        // Write block header to mdbx
+        {
+            let txn = self.db.begin_readwrite().unwrap();
+            match txn.upsert::<Headers>(block_number.into(), block_header.into()) {
+                Ok(_) => txn.commit().unwrap(),
+                Err(err) => return Err(StoreError::LibmdbxError(err)),
+            }
+        }
+        Ok(())
+    }
+
     fn get_block_header(
         &self,
-        block_number: u64,
+        block_number: BlockNumber,
     ) -> std::result::Result<Option<BlockHeader>, StoreError> {
-        // Read block body from mdbx
+        // Read block header from mdbx
         let read_value = {
             let txn = self.db.begin_read().unwrap();
             txn.get::<Headers>(block_number.into())
@@ -72,9 +88,25 @@ impl StoreEngine for Store {
         }
     }
 
+    fn add_block_body(
+        &self,
+        block_number: BlockNumber,
+        block_body: BlockBody,
+    ) -> std::result::Result<(), StoreError> {
+        // Write block body to mdbx
+        {
+            let txn = self.db.begin_readwrite().unwrap();
+            match txn.upsert::<Bodies>(block_number.into(), block_body.into()) {
+                Ok(_) => txn.commit().unwrap(),
+                Err(err) => return Err(StoreError::LibmdbxError(err)),
+            }
+        }
+        Ok(())
+    }
+
     fn get_block_body(
         &self,
-        block_number: u64,
+        block_number: BlockNumber,
     ) -> std::result::Result<Option<BlockBody>, StoreError> {
         // Read block body from mdbx
         let read_value = {

--- a/crates/storage/src/libmdbx.rs
+++ b/crates/storage/src/libmdbx.rs
@@ -65,7 +65,7 @@ impl StoreEngine for Store {
         // Write block header to mdbx
         {
             let txn = self.db.begin_readwrite().unwrap();
-            match txn.upsert::<Headers>(block_number.into(), block_header.into()) {
+            match txn.upsert::<Headers>(block_number, block_header.into()) {
                 Ok(_) => txn.commit().unwrap(),
                 Err(err) => return Err(StoreError::LibmdbxError(err)),
             }
@@ -80,7 +80,7 @@ impl StoreEngine for Store {
         // Read block header from mdbx
         let read_value = {
             let txn = self.db.begin_read().unwrap();
-            txn.get::<Headers>(block_number.into())
+            txn.get::<Headers>(block_number)
         };
         match read_value {
             Ok(value) => Ok(value.map(|a| a.to())),
@@ -96,7 +96,7 @@ impl StoreEngine for Store {
         // Write block body to mdbx
         {
             let txn = self.db.begin_readwrite().unwrap();
-            match txn.upsert::<Bodies>(block_number.into(), block_body.into()) {
+            match txn.upsert::<Bodies>(block_number, block_body.into()) {
                 Ok(_) => txn.commit().unwrap(),
                 Err(err) => return Err(StoreError::LibmdbxError(err)),
             }
@@ -111,7 +111,7 @@ impl StoreEngine for Store {
         // Read block body from mdbx
         let read_value = {
             let txn = self.db.begin_read().unwrap();
-            txn.get::<Bodies>(block_number.into())
+            txn.get::<Bodies>(block_number)
         };
         match read_value {
             Ok(value) => Ok(value.map(|a| a.to())),

--- a/crates/storage/src/rocksdb.rs
+++ b/crates/storage/src/rocksdb.rs
@@ -1,7 +1,7 @@
 use super::{Key, StoreEngine, Value};
 use crate::error::StoreError;
 use crate::rlp::{AccountInfoRLP, AddressRLP};
-use ethereum_rust_core::types::AccountInfo;
+use ethereum_rust_core::types::{AccountInfo, BlockBody, BlockHeader, BlockNumber};
 use ethereum_types::Address;
 use libmdbx::orm::{Decodable, Encodable};
 use std::fmt::Debug;
@@ -104,6 +104,33 @@ impl StoreEngine for Store {
                 Ok(value) => Ok(Some(value.to())),
                 Err(_) => Err(StoreError::DecodeError),
             })
+    }
+
+    fn add_block_header(
+        &mut self,
+        _block_number: BlockNumber,
+        _block_header: BlockHeader,
+    ) -> Result<(), StoreError> {
+        todo!()
+    }
+
+    fn get_block_header(
+        &self,
+        _block_number: BlockNumber,
+    ) -> Result<Option<BlockHeader>, StoreError> {
+        todo!()
+    }
+
+    fn add_block_body(
+        &mut self,
+        _block_number: BlockNumber,
+        _block_body: BlockBody,
+    ) -> Result<(), StoreError> {
+        todo!()
+    }
+
+    fn get_block_body(&self, _block_number: BlockNumber) -> Result<Option<BlockBody>, StoreError> {
+        todo!()
     }
 
     fn set_value(&mut self, key: Key, value: Value) -> Result<(), StoreError> {

--- a/crates/storage/src/sled.rs
+++ b/crates/storage/src/sled.rs
@@ -1,7 +1,7 @@
 use super::{Key, StoreEngine, Value};
 use crate::error::StoreError;
 use crate::rlp::{AccountInfoRLP, AddressRLP};
-use ethereum_rust_core::types::AccountInfo;
+use ethereum_rust_core::types::{AccountInfo, BlockBody, BlockHeader, BlockNumber};
 use ethereum_types::Address;
 use libmdbx::orm::{Decodable, Encodable};
 use sled::Db;
@@ -44,6 +44,33 @@ impl StoreEngine for Store {
                 Ok(value) => Ok(Some(value.to())),
                 Err(_) => Err(StoreError::DecodeError),
             })
+    }
+
+    fn add_block_header(
+        &mut self,
+        _block_number: BlockNumber,
+        _block_header: BlockHeader,
+    ) -> Result<(), StoreError> {
+        todo!()
+    }
+
+    fn get_block_header(
+        &self,
+        _block_number: BlockNumber,
+    ) -> Result<Option<BlockHeader>, StoreError> {
+        todo!()
+    }
+
+    fn add_block_body(
+        &mut self,
+        _block_number: BlockNumber,
+        _block_body: BlockBody,
+    ) -> Result<(), StoreError> {
+        todo!()
+    }
+
+    fn get_block_body(&self, _block_number: BlockNumber) -> Result<Option<BlockBody>, StoreError> {
+        todo!()
     }
 
     fn set_value(&mut self, key: Key, value: Value) -> Result<(), StoreError> {


### PR DESCRIPTION
**Motivation**

Being able to store and fetch blocks from the db via `Store` api

**Description**

* Replace `Transaction::encode` with `Transaction::encode_with_type` logic (Reasoning: We cannot decode the transactions without knowing their type with the current behaviour, making it impossible to implement `RLPDecode` for `Transaction`)
* Implement `RLPDecode` for `Transaction` (Using the logic that was previoulsy used in `EncodedTransaction::decode` (payload module))
* Implement `RLPDecode` for `Withdrawal`, `BlockHeader` and `BlockBody`
* Add the folloewng methods to `Store` and `StoreEngine`: `add_block_header`, `add_block_body`, `get_block_header`, `get_block_body`, and implement them for `InMemory` and `Libmdbx` engine types

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but is needed for #145 

