### PR TITLE
feat: add block serialization

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 tinyvec = "1.6.0"
-ethereum-types = "0.14.1"
+ethereum-types = {version = "0.14.1", features = ["serialize"]}
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/core/src/rlp/decode.rs
+++ b/crates/core/src/rlp/decode.rs
@@ -186,6 +186,13 @@ impl RLPDecode for crate::U256 {
     }
 }
 
+impl RLPDecode for crate::Bloom {
+    fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), RLPDecodeError> {
+        let (value, rest) = RLPDecode::decode_unfinished(rlp)?;
+        Ok((crate::Bloom(value), rest))
+    }
+}
+
 impl RLPDecode for String {
     fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), RLPDecodeError> {
         let (str_bytes, rest) = decode_bytes(rlp)?;

--- a/crates/core/src/rlp/encode.rs
+++ b/crates/core/src/rlp/encode.rs
@@ -357,6 +357,12 @@ impl RLPEncode for ethereum_types::Signature {
     }
 }
 
+impl RLPEncode for ethereum_types::Bloom {
+    fn encode(&self, buf: &mut dyn BufMut) {
+        self.0.encode(buf)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::IpAddr;

--- a/crates/core/src/serde_utils.rs
+++ b/crates/core/src/serde_utils.rs
@@ -35,6 +35,28 @@ pub mod u256 {
 pub mod u64 {
     use super::*;
 
+    pub mod hex_str {
+        use serde::Serializer;
+
+        use super::*;
+
+        pub fn deserialize<'de, D>(d: D) -> Result<u64, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let value = String::deserialize(d)?;
+            u64::from_str_radix(value.trim_start_matches("0x"), 16)
+                .map_err(|_| D::Error::custom("Failed to deserialize u64 value"))
+        }
+
+        pub fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_str(&format!("{:x}", value))
+        }
+    }
+
     pub fn deser_dec_str<'de, D>(d: D) -> Result<u64, D::Error>
     where
         D: Deserializer<'de>,
@@ -42,15 +64,6 @@ pub mod u64 {
         let value = String::deserialize(d)?;
         value
             .parse()
-            .map_err(|_| D::Error::custom("Failed to deserialize u64 value"))
-    }
-
-    pub fn deser_hex_str<'de, D>(d: D) -> Result<u64, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = String::deserialize(d)?;
-        u64::from_str_radix(value.trim_start_matches("0x"), 16)
             .map_err(|_| D::Error::custom("Failed to deserialize u64 value"))
     }
 }

--- a/crates/core/src/serde_utils.rs
+++ b/crates/core/src/serde_utils.rs
@@ -51,7 +51,7 @@ pub mod u64 {
         where
             S: Serializer,
         {
-            serializer.serialize_str(&format!("{:x}", value))
+            serializer.serialize_str(&format!("{:#x}", value))
         }
     }
 
@@ -66,12 +66,13 @@ pub mod u64 {
     }
 }
 
+/// Serializes to and deserializes from 0x prefixed hex string
 pub mod bytes {
     use ::bytes::Bytes;
 
     use super::*;
 
-    pub fn deser_hex_str<'de, D>(d: D) -> Result<Bytes, D::Error>
+    pub fn deserialize<'de, D>(d: D) -> Result<Bytes, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -79,5 +80,12 @@ pub mod bytes {
         let bytes = hex::decode(value.trim_start_matches("0x"))
             .map_err(|e| D::Error::custom(e.to_string()))?;
         Ok(Bytes::from(bytes))
+    }
+
+    pub fn serialize<S>(value: &Bytes, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("0x{:x}", value))
     }
 }

--- a/crates/core/src/serde_utils.rs
+++ b/crates/core/src/serde_utils.rs
@@ -1,4 +1,4 @@
-use serde::{de::Error, Deserialize, Deserializer};
+use serde::{de::Error, Deserialize, Deserializer, Serializer};
 
 pub mod u256 {
     use super::*;
@@ -36,8 +36,6 @@ pub mod u64 {
     use super::*;
 
     pub mod hex_str {
-        use serde::Serializer;
-
         use super::*;
 
         pub fn deserialize<'de, D>(d: D) -> Result<u64, D::Error>

--- a/crates/core/src/types/block.rs
+++ b/crates/core/src/types/block.rs
@@ -40,6 +40,7 @@ pub struct BlockHeader {
     pub receipt_root: H256,
     pub logs_bloom: Bloom,
     pub difficulty: U256,
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub number: BlockNumber,
     #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub gas_limit: u64,
@@ -334,7 +335,7 @@ mod serializable {
                 })
             };
             let hash = header.compute_block_hash();
-            BlockSerializable {hash,  header, body }
+            BlockSerializable { hash, header, body }
         }
     }
 }
@@ -346,6 +347,9 @@ mod test {
 
     use ethereum_types::H160;
     use hex_literal::hex;
+    use serializable::BlockSerializable;
+
+    use crate::types::{EIP1559Transaction, TxKind};
 
     use super::*;
 
@@ -457,5 +461,89 @@ mod test {
             parent_beacon_block_root: H256::zero(),
         };
         assert!(validate_block_header(&block, &parent_block))
+    }
+
+    #[test]
+    fn serialize_block() {
+        let block_header = BlockHeader {
+            parent_hash: H256::from_str(
+                "0x1ac1bf1eef97dc6b03daba5af3b89881b7ae4bc1600dc434f450a9ec34d44999",
+            )
+            .unwrap(),
+            ommers_hash: H256::from_str(
+                "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            )
+            .unwrap(),
+            coinbase: Address::from_str("0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba").unwrap(),
+            state_root: H256::from_str(
+                "0x9de6f95cb4ff4ef22a73705d6ba38c4b927c7bca9887ef5d24a734bb863218d9",
+            )
+            .unwrap(),
+            transactions_root: H256::from_str(
+                "0x578602b2b7e3a3291c3eefca3a08bc13c0d194f9845a39b6f3bcf843d9fed79d",
+            )
+            .unwrap(),
+            receipt_root: H256::from_str(
+                "0x035d56bac3f47246c5eed0e6642ca40dc262f9144b582f058bc23ded72aa72fa",
+            )
+            .unwrap(),
+            logs_bloom: Bloom::from([0; 256]),
+            difficulty: U256::zero(),
+            number: 1,
+            gas_limit: 0x016345785d8a0000,
+            gas_used: 0xa8de,
+            timestamp: 0x03e8,
+            extra_data: Bytes::new(),
+            prev_randao: H256::zero(),
+            nonce: 0x0000000000000000,
+            base_fee_per_gas: 0x07,
+            withdrawals_root: H256::from_str(
+                "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            )
+            .unwrap(),
+            blob_gas_used: 0x00,
+            excess_blob_gas: 0x00,
+            parent_beacon_block_root: H256::zero(),
+        };
+
+        let tx = EIP1559Transaction {
+            nonce: 0,
+            max_fee_per_gas: 78,
+            max_priority_fee_per_gas: 17,
+            to: TxKind::Call(Address::from_slice(
+                &hex::decode("6177843db3138ae69679A54b95cf345ED759450d").unwrap(),
+            )),
+            value: 3000000000000000_u64.into(),
+            data: Bytes::from_static(b"0x1568"),
+            signature_r: U256::from_str_radix(
+                "151ccc02146b9b11adf516e6787b59acae3e76544fdcd75e77e67c6b598ce65d",
+                16,
+            )
+            .unwrap(),
+            signature_s: U256::from_str_radix(
+                "64c5dd5aae2fbb535830ebbdad0234975cd7ece3562013b63ea18cc0df6c97d4",
+                16,
+            )
+            .unwrap(),
+            signature_y_parity: false,
+            chain_id: 3151908,
+            gas_limit: 63000,
+            access_list: vec![(
+                Address::from_slice(
+                    &hex::decode("6177843db3138ae69679A54b95cf345ED759450d").unwrap(),
+                ),
+                vec![],
+            )],
+        };
+
+        let block_body = BlockBody {
+            transactions: vec![Transaction::EIP1559Transaction(tx)],
+            ommers: vec![],
+            withdrawals: vec![],
+        };
+
+        let block = BlockSerializable::from_block(block_header, block_body, true);
+        let expected_block = r#"{"hash":"0x63d6a2504601fc2db0ccf02a28055eb0cdb40c444ecbceec0f613980421a035e","parentHash":"0x1ac1bf1eef97dc6b03daba5af3b89881b7ae4bc1600dc434f450a9ec34d44999","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","miner":"0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba","stateRoot":"0x9de6f95cb4ff4ef22a73705d6ba38c4b927c7bca9887ef5d24a734bb863218d9","transactionsRoot":"0x578602b2b7e3a3291c3eefca3a08bc13c0d194f9845a39b6f3bcf843d9fed79d","receiptRoot":"0x035d56bac3f47246c5eed0e6642ca40dc262f9144b582f058bc23ded72aa72fa","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","difficulty":"0x0","number":"0x1","gasLimit":"0x16345785d8a0000","gasUsed":"0xa8de","timestamp":"0x3e8","extraData":"0x","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","baseFeePerGas":"0x7","withdrawalsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","blobGasUsed":"0x0","excessBlobGas":"0x0","parentBeaconBlockRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","transactions":[{"type":"0x2","nonce":"0x0","to":"0x6177843db3138ae69679a54b95cf345ed759450d","gas":"0xf618","value":"0xaa87bee538000","input":"0x307831353638","maxPriorityFeePerGas":"0x11","maxFeePerGas":"0x4e","gasPrice":"0x4e","accessList":[{"address":"0x6177843db3138ae69679a54b95cf345ed759450d","storageKeys":[]}],"chainId":"0x301824","yParity":"0x0","r":"0x151ccc02146b9b11adf516e6787b59acae3e76544fdcd75e77e67c6b598ce65d","s":"0x64c5dd5aae2fbb535830ebbdad0234975cd7ece3562013b63ea18cc0df6c97d4"}],"uncles":[],"withdrawals":[]}"#;
+        assert_eq!(serde_json::to_string(&block).unwrap(), expected_block)
     }
 }

--- a/crates/core/src/types/block.rs
+++ b/crates/core/src/types/block.rs
@@ -8,6 +8,7 @@ use crate::{
     Address, H256, U256,
 };
 use bytes::Bytes;
+use ethereum_types::Bloom;
 use keccak_hash::keccak;
 use patricia_merkle_tree::PatriciaMerkleTree;
 use serde::{Deserialize, Serialize};
@@ -18,7 +19,6 @@ use std::cmp::{max, Ordering};
 use super::Transaction;
 
 pub type BlockNumber = u64;
-pub type Bloom = [u8; 256];
 
 use lazy_static::lazy_static;
 
@@ -27,7 +27,7 @@ lazy_static! {
 }
 
 /// Header part of a block on the chain.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct BlockHeader {
     pub parent_hash: H256,
     pub ommers_hash: H256, // ommer = uncle
@@ -38,15 +38,21 @@ pub struct BlockHeader {
     pub logs_bloom: Bloom,
     pub difficulty: U256,
     pub number: BlockNumber,
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub gas_limit: u64,
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub gas_used: u64,
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub timestamp: u64,
     pub extra_data: Bytes,
     pub prev_randao: H256,
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub nonce: u64,
     pub base_fee_per_gas: u64,
     pub withdrawals_root: H256,
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub blob_gas_used: u64,
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub excess_blob_gas: u64,
     pub parent_beacon_block_root: H256,
 }

--- a/crates/core/src/types/block.rs
+++ b/crates/core/src/types/block.rs
@@ -28,9 +28,12 @@ lazy_static! {
 
 /// Header part of a block on the chain.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BlockHeader {
     pub parent_hash: H256,
+    #[serde(rename(serialize = "sha3Uncles"))]
     pub ommers_hash: H256, // ommer = uncle
+    #[serde(rename(serialize = "miner"))]
     pub coinbase: Address,
     pub state_root: H256,
     pub transactions_root: H256,
@@ -45,6 +48,7 @@ pub struct BlockHeader {
     #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub timestamp: u64,
     pub extra_data: Bytes,
+    #[serde(rename(serialize = "mixHash"))]
     pub prev_randao: H256,
     #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub nonce: u64,
@@ -290,6 +294,8 @@ mod serializable {
 
     #[derive(Debug, Serialize)]
     pub struct BlockSerializable {
+        hash: H256,
+        #[serde(flatten)]
         header: BlockHeader,
         #[serde(flatten)]
         body: BlockBodyWrapper,
@@ -324,7 +330,8 @@ mod serializable {
                     withdrawals: body.withdrawals,
                 })
             };
-            BlockSerializable { header, body }
+            let hash = header.compute_block_hash();
+            BlockSerializable {hash,  header, body }
         }
     }
 }

--- a/crates/core/src/types/block.rs
+++ b/crates/core/src/types/block.rs
@@ -47,6 +47,7 @@ pub struct BlockHeader {
     pub gas_used: u64,
     #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub timestamp: u64,
+    #[serde(with = "crate::serde_utils::bytes")]
     pub extra_data: Bytes,
     #[serde(rename(serialize = "mixHash"))]
     pub prev_randao: H256,
@@ -94,6 +95,7 @@ impl RLPEncode for BlockHeader {
 pub struct BlockBody {
     pub transactions: Vec<Transaction>,
     // TODO: ommers list is always empty, so we can remove it
+    #[serde(rename(serialize = "uncles"))]
     pub ommers: Vec<BlockHeader>,
     pub withdrawals: Vec<Withdrawal>,
 }
@@ -302,6 +304,7 @@ mod serializable {
     }
 
     #[derive(Debug, Serialize)]
+    #[serde(untagged)]
     enum BlockBodyWrapper {
         Full(BlockBody),
         OnlyHashes(OnlyHashesBlockBody),
@@ -311,7 +314,7 @@ mod serializable {
     struct OnlyHashesBlockBody {
         // Only tx hashes
         pub transactions: Vec<H256>,
-        pub ommers: Vec<BlockHeader>,
+        pub uncles: Vec<BlockHeader>,
         pub withdrawals: Vec<Withdrawal>,
     }
 
@@ -326,7 +329,7 @@ mod serializable {
             } else {
                 BlockBodyWrapper::OnlyHashes(OnlyHashesBlockBody {
                     transactions: body.transactions.iter().map(|t| t.compute_hash()).collect(),
-                    ommers: body.ommers,
+                    uncles: body.ommers,
                     withdrawals: body.withdrawals,
                 })
             };

--- a/crates/core/src/types/engine/payload.rs
+++ b/crates/core/src/types/engine/payload.rs
@@ -121,7 +121,7 @@ impl ExecutionPayloadV3 {
                 state_root: self.state_root,
                 transactions_root: block_body.compute_transactions_root(),
                 receipt_root: self.receipts_root,
-                logs_bloom: self.logs_bloom.into(),
+                logs_bloom: self.logs_bloom,
                 difficulty: 0.into(),
                 number: self.block_number,
                 gas_limit: self.gas_limit,

--- a/crates/core/src/types/engine/payload.rs
+++ b/crates/core/src/types/engine/payload.rs
@@ -21,24 +21,24 @@ pub struct ExecutionPayloadV3 {
     receipts_root: H256,
     logs_bloom: Bloom,
     prev_randao: H256,
-    #[serde(deserialize_with = "crate::serde_utils::u64::deser_hex_str")]
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     block_number: u64,
-    #[serde(deserialize_with = "crate::serde_utils::u64::deser_hex_str")]
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     gas_limit: u64,
-    #[serde(deserialize_with = "crate::serde_utils::u64::deser_hex_str")]
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     gas_used: u64,
-    #[serde(deserialize_with = "crate::serde_utils::u64::deser_hex_str")]
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     timestamp: u64,
     #[serde(deserialize_with = "crate::serde_utils::bytes::deser_hex_str")]
     extra_data: Bytes,
-    #[serde(deserialize_with = "crate::serde_utils::u64::deser_hex_str")]
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     base_fee_per_gas: u64,
     pub block_hash: H256,
     transactions: Vec<EncodedTransaction>,
     withdrawals: Vec<Withdrawal>,
-    #[serde(deserialize_with = "crate::serde_utils::u64::deser_hex_str")]
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     blob_gas_used: u64,
-    #[serde(deserialize_with = "crate::serde_utils::u64::deser_hex_str")]
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     excess_blob_gas: u64,
 }
 

--- a/crates/core/src/types/engine/payload.rs
+++ b/crates/core/src/types/engine/payload.rs
@@ -29,7 +29,7 @@ pub struct ExecutionPayloadV3 {
     gas_used: u64,
     #[serde(with = "crate::serde_utils::u64::hex_str")]
     timestamp: u64,
-    #[serde(deserialize_with = "crate::serde_utils::bytes::deser_hex_str")]
+    #[serde(with = "crate::serde_utils::bytes")]
     extra_data: Bytes,
     #[serde(with = "crate::serde_utils::u64::hex_str")]
     base_fee_per_gas: u64,
@@ -51,7 +51,7 @@ impl<'de> Deserialize<'de> for EncodedTransaction {
     where
         D: serde::Deserializer<'de>,
     {
-        Ok(EncodedTransaction(serde_utils::bytes::deser_hex_str(
+        Ok(EncodedTransaction(serde_utils::bytes::deserialize(
             deserializer,
         )?))
     }

--- a/crates/core/src/types/genesis.rs
+++ b/crates/core/src/types/genesis.rs
@@ -15,9 +15,9 @@ pub struct Genesis {
     pub coinbase: Address,
     pub difficulty: U256,
     pub extra_data: Bytes,
-    #[serde(deserialize_with = "crate::serde_utils::u64::deser_hex_str")]
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub gas_limit: u64,
-    #[serde(deserialize_with = "crate::serde_utils::u64::deser_hex_str")]
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub nonce: u64,
     pub mixhash: H256,
     #[serde(deserialize_with = "crate::serde_utils::u64::deser_dec_str")]

--- a/crates/core/src/types/receipt.rs
+++ b/crates/core/src/types/receipt.rs
@@ -1,7 +1,6 @@
 use crate::rlp::{encode::RLPEncode, structs::Encoder};
-use crate::types::Bloom;
 use bytes::Bytes;
-use ethereum_types::{Address, H256};
+use ethereum_types::{Address, Bloom, H256};
 
 use super::TxType;
 pub type Index = u64;

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -626,7 +626,7 @@ mod serde_impl {
             struct_serializer.serialize_field("to", &self.to)?;
             struct_serializer.serialize_field("gas", &format!("{:#x}", self.gas))?;
             struct_serializer.serialize_field("value", &self.value)?;
-            struct_serializer.serialize_field("input", &format!("{:#x}", self.data))?;
+            struct_serializer.serialize_field("input", &format!("0x{:x}", self.data))?;
             struct_serializer.serialize_field("gasPrice", &format!("{:#x}", self.gas_price))?;
             struct_serializer.serialize_field("chainId", &format!("{:#x}", 1))?; // Mainnet as defaut. TODO: check this
             struct_serializer.serialize_field("v", &self.v)?;
@@ -647,7 +647,7 @@ mod serde_impl {
             struct_serializer.serialize_field("to", &self.to)?;
             struct_serializer.serialize_field("gas", &format!("{:#x}", self.gas_limit))?;
             struct_serializer.serialize_field("value", &self.value)?;
-            struct_serializer.serialize_field("input", &format!("{:#x}", self.data))?;
+            struct_serializer.serialize_field("input", &format!("0x{:x}", self.data))?;
             struct_serializer.serialize_field("gasPrice", &format!("{:#x}", self.gas_price))?;
             struct_serializer.serialize_field(
                 "accessList",
@@ -677,7 +677,7 @@ mod serde_impl {
             struct_serializer.serialize_field("to", &self.to)?;
             struct_serializer.serialize_field("gas", &format!("{:#x}", self.gas_limit))?;
             struct_serializer.serialize_field("value", &self.value)?;
-            struct_serializer.serialize_field("input", &format!("{:#x}", self.data))?;
+            struct_serializer.serialize_field("input", &format!("0x{:x}", self.data))?;
             struct_serializer.serialize_field(
                 "maxPriorityFeePerGas",
                 &format!("{:#x}", self.max_priority_fee_per_gas),

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -600,7 +600,7 @@ mod serde_impl {
         where
             S: serde::Serializer,
         {
-            serializer.serialize_str(&format!("{:#x}", dbg!(*self as u8)))
+            serializer.serialize_str(&format!("{:#x}", *self as u8))
         }
     }
 

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -713,8 +713,8 @@ mod serde_impl {
         where
             S: serde::Serializer,
         {
-            let mut struct_serializer = serializer.serialize_struct("Eip1559Transaction", 14)?;
-            struct_serializer.serialize_field("type", &TxType::EIP1559)?;
+            let mut struct_serializer = serializer.serialize_struct("Eip4844Transaction", 15)?;
+            struct_serializer.serialize_field("type", &TxType::EIP4844)?;
             struct_serializer.serialize_field("nonce", &format!("{:#x}", self.nonce))?;
             struct_serializer.serialize_field("to", &self.to)?;
             struct_serializer.serialize_field("gas", &format!("{:#x}", self.gas))?;

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -544,6 +544,10 @@ impl Transaction {
             Transaction::EIP4844Transaction(tx) => Some(tx.max_fee_per_blob_gas),
         }
     }
+
+    pub fn compute_hash(&self) -> H256 {
+        keccak_hash::keccak(self.encode_to_vec())
+    }
 }
 
 fn recover_address(

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -590,7 +590,7 @@ mod serde_impl {
         {
             match self {
                 TxKind::Call(address) => serializer.serialize_str(&format!("{:#x}", address)),
-                TxKind::Create => serializer.serialize_str(&""),
+                TxKind::Create => serializer.serialize_str(""),
             }
         }
     }
@@ -659,7 +659,7 @@ mod serde_impl {
                 &self
                     .access_list
                     .iter()
-                    .map(|tuple| AccessListEntry::from(tuple))
+                    .map(AccessListEntry::from)
                     .collect::<Vec<_>>(),
             )?;
             struct_serializer.serialize_field("chainId", &format!("{:#x}", self.chain_id))?;
@@ -696,7 +696,7 @@ mod serde_impl {
                 &self
                     .access_list
                     .iter()
-                    .map(|tuple| AccessListEntry::from(tuple))
+                    .map(AccessListEntry::from)
                     .collect::<Vec<_>>(),
             )?;
             struct_serializer.serialize_field("chainId", &format!("{:#x}", self.chain_id))?;
@@ -735,7 +735,7 @@ mod serde_impl {
                 &self
                     .access_list
                     .iter()
-                    .map(|tuple| AccessListEntry::from(tuple))
+                    .map(AccessListEntry::from)
                     .collect::<Vec<_>>(),
             )?;
             struct_serializer

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -788,7 +788,7 @@ mod tests {
         let cumulative_gas_used = 0x5208;
         let bloom = [0x00; 256];
         let logs = vec![];
-        let receipt = Receipt::new(tx_type, succeeded, cumulative_gas_used, bloom, logs);
+        let receipt = Receipt::new(tx_type, succeeded, cumulative_gas_used, bloom.into(), logs);
 
         let result = compute_receipts_root(&[receipt]);
         let expected_root =

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -12,7 +12,8 @@ use crate::rlp::{
     structs::{Decoder, Encoder},
 };
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
 pub enum Transaction {
     LegacyTransaction(LegacyTransaction),
     EIP2930Transaction(EIP2930Transaction),

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -702,6 +702,47 @@ mod serde_impl {
             struct_serializer.end()
         }
     }
+
+    impl Serialize for EIP4844Transaction {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let mut struct_serializer = serializer.serialize_struct("Eip1559Transaction", 14)?;
+            struct_serializer.serialize_field("type", &TxType::EIP1559)?;
+            struct_serializer.serialize_field("nonce", &format!("{:#x}", self.nonce))?;
+            struct_serializer.serialize_field("to", &self.to)?;
+            struct_serializer.serialize_field("gas", &format!("{:#x}", self.gas))?;
+            struct_serializer.serialize_field("value", &self.value)?;
+            struct_serializer.serialize_field("input", &format!("0x{:x}", self.data))?;
+            struct_serializer.serialize_field(
+                "maxPriorityFeePerGas",
+                &format!("{:#x}", self.max_priority_fee_per_gas),
+            )?;
+            struct_serializer
+                .serialize_field("maxFeePerGas", &format!("{:#x}", self.max_fee_per_gas))?;
+            struct_serializer.serialize_field(
+                "maxFeePerBlobGas",
+                &format!("{:#x}", self.max_fee_per_blob_gas),
+            )?;
+            struct_serializer.serialize_field(
+                "accessList",
+                &self
+                    .access_list
+                    .iter()
+                    .map(|tuple| AccessListEntry::from(tuple))
+                    .collect::<Vec<_>>(),
+            )?;
+            struct_serializer
+                .serialize_field("blobVersionedHahses", &self.blob_versioned_hashes)?;
+            struct_serializer.serialize_field("chainId", &format!("{:#x}", self.chain_id))?;
+            struct_serializer
+                .serialize_field("yParity", &format!("{:#x}", self.signature_y_parity as u8))?;
+            struct_serializer.serialize_field("r", &self.signature_r)?;
+            struct_serializer.serialize_field("s", &self.signature_s)?;
+            struct_serializer.end()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/types/transaction.rs
+++ b/crates/core/src/types/transaction.rs
@@ -626,7 +626,7 @@ mod serde_impl {
             struct_serializer.serialize_field("to", &self.to)?;
             struct_serializer.serialize_field("gas", &format!("{:#x}", self.gas))?;
             struct_serializer.serialize_field("value", &self.value)?;
-            struct_serializer.serialize_field("input", &self.data)?;
+            struct_serializer.serialize_field("input", &format!("{:#x}", self.data))?;
             struct_serializer.serialize_field("gasPrice", &format!("{:#x}", self.gas_price))?;
             struct_serializer.serialize_field("chainId", &format!("{:#x}", 1))?; // Mainnet as defaut. TODO: check this
             struct_serializer.serialize_field("v", &self.v)?;
@@ -647,7 +647,7 @@ mod serde_impl {
             struct_serializer.serialize_field("to", &self.to)?;
             struct_serializer.serialize_field("gas", &format!("{:#x}", self.gas_limit))?;
             struct_serializer.serialize_field("value", &self.value)?;
-            struct_serializer.serialize_field("input", &self.data)?;
+            struct_serializer.serialize_field("input", &format!("{:#x}", self.data))?;
             struct_serializer.serialize_field("gasPrice", &format!("{:#x}", self.gas_price))?;
             struct_serializer.serialize_field(
                 "accessList",
@@ -677,7 +677,7 @@ mod serde_impl {
             struct_serializer.serialize_field("to", &self.to)?;
             struct_serializer.serialize_field("gas", &format!("{:#x}", self.gas_limit))?;
             struct_serializer.serialize_field("value", &self.value)?;
-            struct_serializer.serialize_field("input", &self.data)?;
+            struct_serializer.serialize_field("input", &format!("{:#x}", self.data))?;
             struct_serializer.serialize_field(
                 "maxPriorityFeePerGas",
                 &format!("{:#x}", self.max_priority_fee_per_gas),

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -188,7 +188,8 @@ mod tests {
     use bytes::Bytes;
     use ethereum_rust_core::{
         rlp::decode::RLPDecode,
-        types::{self, Bloom, Transaction},
+        types::{self, Transaction},
+        Bloom,
     };
     use ethereum_types::{H256, U256};
 

--- a/ef_tests/src/types.rs
+++ b/ef_tests/src/types.rs
@@ -26,7 +26,7 @@ pub struct TestUnit {
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct Account {
     pub balance: U256,
-    #[serde(deserialize_with = "ethereum_rust_core::serde_utils::bytes::deser_hex_str")]
+    #[serde(with = "ethereum_rust_core::serde_utils::bytes")]
     pub code: Bytes,
     pub nonce: U256,
     pub storage: HashMap<U256, U256>,
@@ -100,7 +100,7 @@ pub struct Block {
 pub struct Transaction {
     #[serde(rename = "type")]
     pub transaction_type: Option<U256>,
-    #[serde(deserialize_with = "ethereum_rust_core::serde_utils::bytes::deser_hex_str")]
+    #[serde(with = "ethereum_rust_core::serde_utils::bytes")]
     pub data: Bytes,
     pub gas_limit: U256,
     pub gas_price: Option<U256>,

--- a/ef_tests/src/types.rs
+++ b/ef_tests/src/types.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use ethereum_rust_core::types::{
     code_hash, Account as ethereum_rustAccount, AccountInfo, EIP1559Transaction, LegacyTransaction,
-    Transaction as ethereum_rustTransacion,
+    Transaction as ethereum_rustTransacion, TxKind,
 };
 use ethereum_rust_core::{types::BlockHeader, Address, Bloom, H256, U256, U64};
 use serde::{Deserialize, Serialize};
@@ -164,16 +164,16 @@ impl From<Transaction> for EIP1559Transaction {
         EIP1559Transaction {
             // Note: gas_price is not used in this conversion as it is not part of EIP1559Transaction, this could be a problem
             chain_id: val.chain_id.map(|id| id.as_u64()).unwrap_or(1 /*mainnet*/), // TODO: Consider converting this into Option
-            signer_nonce: val.nonce.as_u64(),
+            nonce: val.nonce.as_u64(),
             max_priority_fee_per_gas: val.max_priority_fee_per_gas.unwrap_or_default().as_u64(), // TODO: Consider converting this into Option
             max_fee_per_gas: val
                 .max_fee_per_gas
                 .unwrap_or(val.gas_price.unwrap_or_default())
                 .as_u64(), // TODO: Consider converting this into Option
             gas_limit: val.gas_limit.as_u64(),
-            destination: val.to,
-            amount: val.value,
-            payload: val.data,
+            to: TxKind::Call(val.to),
+            value: val.value,
+            data: val.data,
             access_list: val
                 .access_list
                 .unwrap_or_default()
@@ -193,7 +193,7 @@ impl From<Transaction> for LegacyTransaction {
             nonce: val.nonce.as_u64(),
             gas_price: val.gas_price.unwrap_or_default().as_u64(), // TODO: Consider converting this into Option
             gas: val.gas_limit.as_u64(),
-            to: ethereum_rust_core::types::TxKind::Call(val.to),
+            to: TxKind::Call(val.to),
             value: val.value,
             data: val.data,
             v: val.v,

--- a/ef_tests/src/types.rs
+++ b/ef_tests/src/types.rs
@@ -129,7 +129,7 @@ impl From<Header> for BlockHeader {
             state_root: val.state_root,
             transactions_root: val.transactions_trie,
             receipt_root: val.receipt_trie,
-            logs_bloom: val.bloom.into(),
+            logs_bloom: val.bloom,
             difficulty: val.difficulty,
             number: val.number.as_u64(),
             gas_limit: val.gas_limit.as_u64(),

--- a/ef_tests/src/types.rs
+++ b/ef_tests/src/types.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use ethereum_rust_core::types::{
     code_hash, Account as ethereum_rustAccount, AccountInfo, EIP1559Transaction, LegacyTransaction,
-    Transaction as ethereum_rustTransacion, TxKind,
+    Transaction as ethereum_rustTransaction, TxKind,
 };
 use ethereum_rust_core::{types::BlockHeader, Address, Bloom, H256, U256, U64};
 use serde::{Deserialize, Serialize};
@@ -147,14 +147,14 @@ impl From<Header> for BlockHeader {
     }
 }
 
-impl From<Transaction> for ethereum_rustTransacion {
+impl From<Transaction> for ethereum_rustTransaction {
     fn from(val: Transaction) -> Self {
         match val.transaction_type {
             Some(tx_type) => match tx_type.as_u64() {
-                2 => ethereum_rustTransacion::EIP1559Transaction(val.into()),
+                2 => ethereum_rustTransaction::EIP1559Transaction(val.into()),
                 _ => unimplemented!(),
             },
-            None => ethereum_rustTransacion::LegacyTransaction(val.into()),
+            None => ethereum_rustTransaction::LegacyTransaction(val.into()),
         }
     }
 }


### PR DESCRIPTION
**Motivation**

Being able to serialize blocks matching the output required by the rpc spec

<!-- Why does this pull request exist? What are its goals? -->

**Description**

*Add struct `BlockSerializable` which can be serialized to match the specifications of the rpc. It can contain either the full transactions or just their hashes.
*Implement serialization for `BlockSerializable`, `BlockHeader`, `BlockBody`, `Withdrawal` and `Transaction`.
Other changes:
*Replace `Bloom` with `ethereum_types::Bloom`
*Rename some fields in `Eip1559Transaction` to match other transaction types' fields


<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but is needed in order to implement #31 

