### PR TITLE
refactor: use `map_requests` for `handle_http_requests`

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -83,10 +83,8 @@ pub fn map_requests(req: &RpcRequest) -> Result<Value, RpcErr> {
 }
 
 /// Handle requests from other clients
-pub fn map_internal_requests(req: &RpcRequest) -> Result<Value, RpcErr> {
-    match req.method.as_str() {
-        _ => Err(RpcErr::MethodNotFound),
-    }
+pub fn map_internal_requests(_req: &RpcRequest) -> Result<Value, RpcErr> {
+    Err(RpcErr::MethodNotFound)
 }
 
 fn rpc_response<E>(id: i32, res: Result<Value, E>) -> Json<Value>

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -46,6 +46,12 @@ pub async fn handle_authrpc_request(body: String) -> Json<Value> {
     rpc_response(req.id, res)
 }
 
+pub async fn handle_http_request(body: String) -> Json<Value> {
+    let req: RpcRequest = serde_json::from_str(&body).unwrap();
+    let res = map_requests(&req);
+    rpc_response(req.id, res)
+}
+
 pub fn map_requests(req: &RpcRequest) -> Result<Value, RpcErr> {
     match req.method.as_str() {
         "engine_exchangeCapabilities" => {
@@ -67,22 +73,9 @@ pub fn map_requests(req: &RpcRequest) -> Result<Value, RpcErr> {
                 parse_new_payload_v3_request(req.params.as_ref().ok_or(RpcErr::BadParams)?)?;
             Ok(serde_json::to_value(engine::new_payload_v3(request)?).unwrap())
         }
-        _ => Err(RpcErr::MethodNotFound),
-    }
-}
-
-pub async fn handle_http_request(body: String) -> Json<Value> {
-    let req: RpcRequest = serde_json::from_str(&body).unwrap();
-
-    let res: Result<Value, RpcErr> = match req.method.as_str() {
-        "eth_chainId" => client::chain_id(),
-        "eth_syncing" => client::syncing(),
-        "eth_getBlockByNumber" => block::get_block_by_number(),
         "admin_nodeInfo" => admin::node_info(),
         _ => Err(RpcErr::MethodNotFound),
-    };
-
-    rpc_response(req.id, res)
+    }
 }
 
 fn rpc_response<E>(id: i32, res: Result<Value, E>) -> Json<Value>


### PR DESCRIPTION
**Motivation**

Currently, the `handle_http_requests` doesn't allow us to return an error when handling requests. This can be solved by handling them via a `map_requests` function like in `handle_authrpc_requests`. While `handle_authrpc_requests` handles comunication between clients and `handle_http_requests` handles comunication between the client and users, there are a lot of requests that are handled by both of them. As they both use the same request format, there is little reason to implement two different functions to handle the same requests in the same way. We can use `map_requests` to handle both auth_rpc and http requests, and then implement a  second handler (such as `map_internal_requests`) to handle auth_prc-specific requests.

<!-- Why does this pull request exist? What are its goals? -->

**Description**

Replaces `handle_http_requests` request handling with a call to `map_requests`

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but addresses comment on #145 
