### PR TITLE
feat: store transaction locations by hash in db

### DIFF
--- a/crates/core/src/evm/mod.rs
+++ b/crates/core/src/evm/mod.rs
@@ -108,7 +108,7 @@ fn tx_env(tx: &Transaction) -> TxEnv {
             .into_iter()
             .map(|hash| B256::from(hash.0))
             .collect(),
-        max_fee_per_blob_gas: tx.max_fee_per_blob_gas().map(|x| U256::from(x)),
+        max_fee_per_blob_gas: tx.max_fee_per_blob_gas().map(U256::from),
     }
 }
 

--- a/crates/storage/src/in_memory.rs
+++ b/crates/storage/src/in_memory.rs
@@ -1,7 +1,9 @@
 use super::{Key, StoreEngine, Value};
 use crate::error::StoreError;
-use ethereum_rust_core::types::{AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber};
-use ethereum_types::Address;
+use ethereum_rust_core::types::{
+    AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, Index,
+};
+use ethereum_types::{Address, H256};
 use std::{collections::HashMap, fmt::Debug};
 
 #[derive(Default)]
@@ -11,6 +13,8 @@ pub struct Store {
     bodies: HashMap<BlockNumber, BlockBody>,
     headers: HashMap<BlockNumber, BlockHeader>,
     values: HashMap<Key, Value>,
+    // Maps transaction hashes to their block number and index within the block
+    transaction_locations: HashMap<H256, (BlockNumber, Index)>,
 }
 
 impl Store {
@@ -79,6 +83,24 @@ impl StoreEngine for Store {
 
     fn get_block_number(&self, block_hash: BlockHash) -> Result<Option<BlockNumber>, StoreError> {
         Ok(self.block_numbers.get(&block_hash).copied())
+    }
+
+    fn add_transaction_location(
+        &mut self,
+        transaction_hash: H256,
+        block_number: BlockNumber,
+        index: Index,
+    ) -> Result<(), StoreError> {
+        self.transaction_locations
+            .insert(transaction_hash, (block_number, index));
+        Ok(())
+    }
+
+    fn get_transaction_location(
+        &self,
+        transaction_hash: H256,
+    ) -> Result<Option<(BlockNumber, Index)>, StoreError> {
+        Ok(self.transaction_locations.get(&transaction_hash).copied())
     }
 }
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -229,6 +229,28 @@ impl Store {
             .unwrap()
             .get_block_number(block_hash)
     }
+
+    pub fn add_transaction_location(
+        &self,
+        transaction_hash: H256,
+        block_number: BlockNumber,
+        index: Index,
+    ) -> Result<(), StoreError> {
+        self.engine
+            .lock()
+            .unwrap()
+            .add_transaction_location(transaction_hash, block_number, index)
+    }
+
+    pub fn get_transaction_location(
+        &self,
+        transaction_hash: H256,
+    ) -> Result<Option<(BlockNumber, Index)>, StoreError> {
+        self.engine
+            .lock()
+            .unwrap()
+            .get_transaction_location(transaction_hash)
+    }
 }
 
 #[cfg(test)]
@@ -286,6 +308,7 @@ mod tests {
         test_store_account(store.clone());
         test_store_block(store.clone());
         test_store_block_number(store.clone());
+        test_store_transaction_location(store.clone());
     }
 
     fn test_store_account(mut store: Store) {
@@ -406,5 +429,22 @@ mod tests {
         let stored_number = store.get_block_number(block_hash).unwrap().unwrap();
 
         assert_eq!(stored_number, block_number);
+    }
+
+    fn test_store_transaction_location(store: Store) {
+        let transaction_hash = H256::random();
+        let block_number = 6;
+        let index = 3;
+
+        store
+            .add_transaction_location(transaction_hash, block_number, index)
+            .unwrap();
+
+        let stored_location = store
+            .get_transaction_location(transaction_hash)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(stored_location, (block_number, index));
     }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -13,8 +13,11 @@ use self::libmdbx::Store as LibmdbxStore;
 use self::rocksdb::Store as RocksDbStore;
 #[cfg(feature = "sled")]
 use self::sled::Store as SledStore;
-use ethereum_rust_core::types::{AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber};
+use ethereum_rust_core::types::{
+    AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, Index,
+};
 use ethereum_types::Address;
+use ethereum_types::H256;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
 
@@ -76,6 +79,20 @@ pub trait StoreEngine: Debug + Send {
 
     /// Obtain block number
     fn get_block_number(&self, block_hash: BlockHash) -> Result<Option<BlockNumber>, StoreError>;
+
+    /// Store transaction location (block number and index of the transaction within the block)
+    fn add_transaction_location(
+        &mut self,
+        transaction_hash: H256,
+        block_number: BlockNumber,
+        index: Index,
+    ) -> Result<(), StoreError>;
+
+    /// Obtain transaction location (block number and index)
+    fn get_transaction_location(
+        &self,
+        transaction_hash: H256,
+    ) -> Result<Option<(BlockNumber, Index)>, StoreError>;
 
     /// Set an arbitrary value (used for eventual persistent values: eg. current_block_height)
     fn set_value(&mut self, key: Key, value: Value) -> Result<(), StoreError>;

--- a/crates/storage/src/libmdbx.rs
+++ b/crates/storage/src/libmdbx.rs
@@ -222,6 +222,7 @@ pub fn init_db(path: Option<impl AsRef<Path>>) -> Database {
         table_info!(AccountStorages),
         table_info!(AccountCodes),
         table_info!(Receipts),
+        table_info!(TransactionLocations),
     ]
     .into_iter()
     .collect();

--- a/crates/storage/src/rlp.rs
+++ b/crates/storage/src/rlp.rs
@@ -6,7 +6,6 @@ use ethereum_rust_core::{
     types::{AccountInfo, BlockBody, BlockHash, BlockHeader, Receipt},
     Address, H256,
 };
-use ethereum_types::H256;
 use libmdbx::orm::{Decodable, Encodable};
 
 // Account types

--- a/crates/storage/src/rlp.rs
+++ b/crates/storage/src/rlp.rs
@@ -5,6 +5,7 @@ use ethereum_rust_core::{
     types::{AccountInfo, BlockBody, BlockHash, BlockHeader, Receipt},
     Address,
 };
+use ethereum_types::H256;
 use libmdbx::orm::{Decodable, Encodable};
 
 // Account types
@@ -25,6 +26,9 @@ pub type BlockBodyRLP = Rlp<BlockBody>;
 
 // Receipt types
 pub type ReceiptRLP = Rlp<Receipt>;
+
+// Transaction types
+pub type TransactionHashRLP = Rlp<H256>;
 
 pub struct Rlp<T>(Vec<u8>, PhantomData<T>);
 

--- a/crates/storage/src/rocksdb.rs
+++ b/crates/storage/src/rocksdb.rs
@@ -1,8 +1,10 @@
 use super::{Key, StoreEngine, Value};
 use crate::error::StoreError;
 use crate::rlp::{AccountInfoRLP, AddressRLP};
-use ethereum_rust_core::types::{AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber};
-use ethereum_types::Address;
+use ethereum_rust_core::types::{
+    AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, Index,
+};
+use ethereum_types::{Address, H256};
 use libmdbx::orm::{Decodable, Encodable};
 use std::fmt::Debug;
 use std::sync::mpsc::{channel, sync_channel, Receiver, Sender, SyncSender};

--- a/crates/storage/src/rocksdb.rs
+++ b/crates/storage/src/rocksdb.rs
@@ -165,6 +165,22 @@ impl StoreEngine for Store {
 
         reply_receiver.recv()?
     }
+
+    fn add_transaction_location(
+        &mut self,
+        _transaction_hash: H256,
+        _block_number: BlockNumber,
+        _index: Index,
+    ) -> Result<(), StoreError> {
+        todo!()
+    }
+
+    fn get_transaction_location(
+        &self,
+        _transaction_hash: H256,
+    ) -> Result<Option<(BlockNumber, Index)>, StoreError> {
+        todo!()
+    }
 }
 
 impl Debug for Store {

--- a/crates/storage/src/sled.rs
+++ b/crates/storage/src/sled.rs
@@ -1,8 +1,10 @@
 use super::{Key, StoreEngine, Value};
 use crate::error::StoreError;
 use crate::rlp::{AccountInfoRLP, AddressRLP};
-use ethereum_rust_core::types::{AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber};
-use ethereum_types::Address;
+use ethereum_rust_core::types::{
+    AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, Index,
+};
+use ethereum_types::{Address, H256};
 use libmdbx::orm::{Decodable, Encodable};
 use sled::Db;
 use std::fmt::Debug;

--- a/crates/storage/src/sled.rs
+++ b/crates/storage/src/sled.rs
@@ -93,6 +93,22 @@ impl StoreEngine for Store {
     fn get_value(&self, key: Key) -> Result<Option<Vec<u8>>, StoreError> {
         Ok(self.values.get(key)?.map(|value| value.to_vec()))
     }
+
+    fn add_transaction_location(
+        &mut self,
+        _transaction_hash: H256,
+        _block_number: BlockNumber,
+        _index: Index,
+    ) -> Result<(), StoreError> {
+        todo!()
+    }
+
+    fn get_transaction_location(
+        &self,
+        _transaction_hash: H256,
+    ) -> Result<Option<(BlockNumber, Index)>, StoreError> {
+        todo!()
+    }
 }
 
 impl Debug for Store {


### PR DESCRIPTION
**Motivation**

Being able to index transactions by hash (by obtaining their block number & index within the block)
<!-- Why does this pull request exist? What are its goals? -->

**Description**

* Add mappings between transaction hash & transaction locations (block number + index) to active db impls
* Add methods to store and fetch transaction locations by hash to `Store` api

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #37

