### PR TITLE
docs: remove CI badge.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.78.0
           components: rustfmt, clippy
 
       - name: Set up cargo cache

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Lambda Ethereum Rust Execution Client
 
 [![Telegram Chat][tg-badge]][tg-url]
-[![rust](https://github.com/lambdaclass/ethereum_rust/actions/workflows/ci.yaml/badge.svg)](https://github.com/lambdaclass/ethereum_rust/actions/workflows/ci.yaml)
 [![license](https://img.shields.io/github/license/lambdaclass/ethereum_rust)](/LICENSE)
 
 [tg-badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Frust_ethereum%2F&logo=telegram&label=chat&color=neon


### PR DESCRIPTION
**Motivation**
Sometimes the badge looks broken. Let's remove it for now.

Also lets pin the rust version so that we don't get unexpected failures.

