### PR TITLE
fix: transaction sender method for type 0 and 1 transactions

### DIFF
--- a/cmd/ef_tests/test_runner.rs
+++ b/cmd/ef_tests/test_runner.rs
@@ -12,27 +12,29 @@ use ethereum_rust_storage::{EngineType, Store};
 
 pub fn execute_test(test_key: &str, test: &TestUnit) {
     let mut evm_state = build_evm_state_from_prestate(&test.pre);
-    let block = test.blocks.first().unwrap();
-    let block_header = block.block_header.clone().unwrap();
-    let transactions = block.transactions.as_ref().unwrap();
-    for transaction in transactions.iter() {
-        assert_eq!(
-            transaction.clone().sender,
-            CoreTransaction::from(transaction.clone()).sender(),
-            "Expected sender address differs from derived sender address on test: {}",
-            test_key
-        );
-        assert!(
-            execute_tx(
-                &transaction.clone().into(),
-                &block_header.clone().clone().into(),
-                &mut evm_state,
-                SpecId::CANCUN,
-            )
-            .is_ok(), //TODO: Assert ExecutionResult depending on test case
-            "Transaction execution failed on test: {}",
-            test_key
-        );
+    let blocks = test.blocks.clone();
+    for block in blocks.iter() {
+        let block_header = block.block_header.clone().unwrap();
+        let transactions = block.transactions.as_ref().unwrap();
+        for transaction in transactions.iter() {
+            assert_eq!(
+                transaction.clone().sender,
+                CoreTransaction::from(transaction.clone()).sender(),
+                "Expected sender address differs from derived sender address on test: {}",
+                test_key
+            );
+            assert!(
+                execute_tx(
+                    &transaction.clone().into(),
+                    &block_header.clone().clone().into(),
+                    &mut evm_state,
+                    SpecId::CANCUN,
+                )
+                .is_ok(), //TODO: Assert ExecutionResult depending on test case
+                "Transaction execution failed on test: {}",
+                test_key
+            );
+        }
     }
 }
 

--- a/cmd/ef_tests/test_runner.rs
+++ b/cmd/ef_tests/test_runner.rs
@@ -11,8 +11,9 @@ use ethereum_rust_evm::{evm_state, execute_tx, EvmState, SpecId};
 use ethereum_rust_storage::{EngineType, Store};
 
 pub fn execute_test(test_key: &str, test: &TestUnit) {
-    // TODO: Add support for multiple blocks and multiple transactions per block.
+    let mut evm_state = build_evm_state_from_prestate(&test.pre);
     let block = test.blocks.first().unwrap();
+    let block_header = block.block_header.clone().unwrap();
     let transactions = block.transactions.as_ref().unwrap();
     for transaction in transactions.iter() {
         assert_eq!(
@@ -24,16 +25,8 @@ pub fn execute_test(test_key: &str, test: &TestUnit) {
         assert!(
             execute_tx(
                 &transaction.clone().into(),
-                &test
-                    .blocks
-                    .first()
-                    .as_ref()
-                    .unwrap()
-                    .block_header
-                    .clone()
-                    .unwrap()
-                    .into(),
-                &mut build_evm_state_from_prestate(&test.pre),
+                &block_header.clone().clone().into(),
+                &mut evm_state,
                 SpecId::CANCUN,
             )
             .is_ok(), //TODO: Assert ExecutionResult depending on test case

--- a/cmd/ef_tests/test_runner.rs
+++ b/cmd/ef_tests/test_runner.rs
@@ -26,7 +26,7 @@ pub fn execute_test(test_key: &str, test: &TestUnit) {
             assert!(
                 execute_tx(
                     &transaction.clone().into(),
-                    &block_header.clone().clone().into(),
+                    &block_header.clone().into(),
                     &mut evm_state,
                     SpecId::CANCUN,
                 )

--- a/cmd/ef_tests/test_runner.rs
+++ b/cmd/ef_tests/test_runner.rs
@@ -58,7 +58,7 @@ pub fn validate_test(test: &TestUnit) {
     let decoded_block = CoreBlock::decode(&genesis_rlp).unwrap();
     assert_eq!(
         decoded_block.header,
-        test.genesis_block_header.clone().into(),
+        test.genesis_block_header.clone().into()
     );
 
     // check that blocks can be decoded

--- a/cmd/ef_tests/tests/cancun.rs
+++ b/cmd/ef_tests/tests/cancun.rs
@@ -22,8 +22,6 @@ fn parse_and_validate(path: &Path) -> datatest_stable::Result<()> {
     Ok(())
 }
 
-//TODO: eip6780_selfdestruct tests are not passing, probably because they
-//      test using several transactions one after the other.
 //TODO: eip4844_blobs tests are not passing because they expect exceptions.
 datatest_stable::harness!(
     parse_and_execute,

--- a/cmd/ef_tests/tests/cancun.rs
+++ b/cmd/ef_tests/tests/cancun.rs
@@ -23,20 +23,24 @@ fn parse_and_validate(path: &Path) -> datatest_stable::Result<()> {
 }
 
 datatest_stable::harness!(
+    // Uncomment to run all tests in ef_tests/vectors/cancun:
+    //parse_and_execute,
+    //"vectors/cancun/",
+    //r"eip1153_tstore/.*/.*\.json",
     parse_and_execute,
     "vectors/cancun/",
-    r"eip4844_blobs/point_evaluation_precompile/valid_precompile_calls.json",
-    parse_and_execute,
-    "vectors/cancun/",
-    r"eip4788_beacon_root/beacon_root_contract/beacon_root_contract_calls.json",
-    parse_and_execute,
-    "vectors/cancun/",
-    r"eip5656_mcopy/mcopy_memory_expansion/mcopy_huge_memory_expansion.json",
-    parse_and_execute,
-    "vectors/cancun/",
-    r"eip4788_beacon_root/beacon_root_contract/invalid_beacon_root_calldata_value.json",
-    parse_and_validate,
-    "vectors/cancun/",
-    // we ignore `create_selfdestruct_same_tx.json` because it has some errors in the encoding
-    r"^(?!.*create_selfdestruct_same_tx.json)(.*.json)",
+    r"eip4788_beacon_root/beacon_root_contract/tx_to_beacon_root_contract\.json",
+    //parse_and_execute,
+    //"vectors/cancun/",
+    //r"eip4844_blobs/point_evaluation_precompile/valid_precompile_calls.json",
+    //parse_and_execute,
+    //"vectors/cancun/",
+    //r"eip5656_mcopy/.*/.*\.json",
+    //parse_and_execute,
+    //"vectors/cancun/",
+    //r"eip6780_selfdestruct/.*/.*\.json",
+    //parse_and_validate,
+    //"vectors/cancun/",
+    //r"eip7516_blobgasfee/.*/.*\.json" // we ignore `create_selfdestruct_same_tx.json` because it has some errors in the encoding
+    //r"^(?!.*create_selfdestruct_same_tx.json)(.*.json)",
 );

--- a/cmd/ef_tests/tests/cancun.rs
+++ b/cmd/ef_tests/tests/cancun.rs
@@ -22,6 +22,9 @@ fn parse_and_validate(path: &Path) -> datatest_stable::Result<()> {
     Ok(())
 }
 
+//TODO: eip6780_selfdestruct tests are not passing, probably because they
+//      test using several transactions one after the other.
+//TODO: eip4844_blobs tests are not passing because they expect exceptions.
 datatest_stable::harness!(
     parse_and_execute,
     "vectors/cancun/",
@@ -29,18 +32,10 @@ datatest_stable::harness!(
     parse_and_execute,
     "vectors/cancun/",
     r"eip4788_beacon_root/.*/.*\.json",
-    //parse_and_execute,
-    //"vectors/cancun/",
-    //r"eip4844_blobs/point_evaluation_precompile/valid_precompile_calls.json",
     parse_and_execute,
     "vectors/cancun/",
     r"eip5656_mcopy/.*/.*\.json",
-    //parse_and_execute,
-    //"vectors/cancun/",
-    //r"eip6780_selfdestruct/.*/.*\.json",
-    //parse_and_validate,
-    //"vectors/cancun/",
-    //r"eip7516_blobgasfee/.*/.*\.json"
-    //we ignore `create_selfdestruct_same_tx.json` because it has some errors in the encoding
-    //r"^(?!.*create_selfdestruct_same_tx.json)(.*.json)",
+    parse_and_execute,
+    "vectors/cancun/",
+    r"eip7516_blobgasfee/.*/.*\.json"
 );

--- a/cmd/ef_tests/tests/cancun.rs
+++ b/cmd/ef_tests/tests/cancun.rs
@@ -5,9 +5,9 @@ use ef_tests::test_runner::{execute_test, parse_test_file, validate_test};
 fn parse_and_execute(path: &Path) -> datatest_stable::Result<()> {
     let tests = parse_test_file(path);
 
-    for (_k, test) in tests {
+    for (test_key, test) in tests {
         validate_test(&test);
-        execute_test(&test)
+        execute_test(&test_key, &test)
     }
     Ok(())
 }
@@ -23,24 +23,24 @@ fn parse_and_validate(path: &Path) -> datatest_stable::Result<()> {
 }
 
 datatest_stable::harness!(
-    // Uncomment to run all tests in ef_tests/vectors/cancun:
-    //parse_and_execute,
-    //"vectors/cancun/",
-    //r"eip1153_tstore/.*/.*\.json",
     parse_and_execute,
     "vectors/cancun/",
-    r"eip4788_beacon_root/beacon_root_contract/tx_to_beacon_root_contract\.json",
+    r"eip1153_tstore/.*/.*\.json",
+    parse_and_execute,
+    "vectors/cancun/",
+    r"eip4788_beacon_root/.*/.*\.json",
     //parse_and_execute,
     //"vectors/cancun/",
     //r"eip4844_blobs/point_evaluation_precompile/valid_precompile_calls.json",
-    //parse_and_execute,
-    //"vectors/cancun/",
-    //r"eip5656_mcopy/.*/.*\.json",
+    parse_and_execute,
+    "vectors/cancun/",
+    r"eip5656_mcopy/.*/.*\.json",
     //parse_and_execute,
     //"vectors/cancun/",
     //r"eip6780_selfdestruct/.*/.*\.json",
     //parse_and_validate,
     //"vectors/cancun/",
-    //r"eip7516_blobgasfee/.*/.*\.json" // we ignore `create_selfdestruct_same_tx.json` because it has some errors in the encoding
+    //r"eip7516_blobgasfee/.*/.*\.json"
+    //we ignore `create_selfdestruct_same_tx.json` because it has some errors in the encoding
     //r"^(?!.*create_selfdestruct_same_tx.json)(.*.json)",
 );

--- a/cmd/ef_tests/tests/cancun.rs
+++ b/cmd/ef_tests/tests/cancun.rs
@@ -37,5 +37,8 @@ datatest_stable::harness!(
     r"eip5656_mcopy/.*/.*\.json",
     parse_and_execute,
     "vectors/cancun/",
-    r"eip7516_blobgasfee/.*/.*\.json"
+    r"eip7516_blobgasfee/.*/.*\.json",
+    parse_and_execute,
+    "vectors/cancun/",
+    r"eip6780_selfdestruct/.*/.*\.json"
 );

--- a/crates/core/types/transaction.rs
+++ b/crates/core/types/transaction.rs
@@ -442,6 +442,7 @@ impl Transaction {
             Transaction::EIP2930Transaction(tx) => {
                 let mut buf = vec![self.tx_type() as u8];
                 Encoder::new(&mut buf)
+                    .encode_field(&tx.chain_id)
                     .encode_field(&tx.nonce)
                     .encode_field(&tx.gas_price)
                     .encode_field(&tx.gas_limit)
@@ -449,9 +450,6 @@ impl Transaction {
                     .encode_field(&tx.value)
                     .encode_field(&tx.data)
                     .encode_field(&tx.access_list)
-                    .encode_field(&tx.signature_y_parity)
-                    .encode_field(&tx.signature_r)
-                    .encode_field(&tx.signature_s)
                     .finish();
                 recover_address(
                     &tx.signature_r,

--- a/crates/core/types/transaction.rs
+++ b/crates/core/types/transaction.rs
@@ -552,7 +552,7 @@ impl Transaction {
 
     pub fn chain_id(&self) -> Option<u64> {
         match self {
-            Transaction::LegacyTransaction(_tx) => None,
+            Transaction::LegacyTransaction(tx) => derive_legacy_chain_id(tx.v),
             Transaction::EIP2930Transaction(tx) => Some(tx.chain_id),
             Transaction::EIP1559Transaction(tx) => Some(tx.chain_id),
             Transaction::EIP4844Transaction(tx) => Some(tx.chain_id),
@@ -646,6 +646,15 @@ fn recover_address(
     // Hash public key to obtain address
     let hash = Keccak256::new_with_prefix(&public.serialize_uncompressed()[1..]).finalize();
     Address::from_slice(&hash[12..])
+}
+
+fn derive_legacy_chain_id(v: U256) -> Option<u64> {
+    let v = v.as_u64(); //TODO: Could panic if v is bigger than Max u64
+    if v == 27 || v == 28 {
+        None
+    } else {
+        Some((v - 35) / 2)
+    }
 }
 
 // Serialization

--- a/crates/core/types/transaction.rs
+++ b/crates/core/types/transaction.rs
@@ -416,14 +416,27 @@ impl Transaction {
                     None => tx.v.as_u64().saturating_sub(27) != 0,
                 };
                 let mut buf = vec![];
-                Encoder::new(&mut buf)
-                    .encode_field(&tx.nonce)
-                    .encode_field(&tx.gas_price)
-                    .encode_field(&tx.gas)
-                    .encode_field(&tx.to)
-                    .encode_field(&tx.value)
-                    .encode_field(&tx.data)
-                    .finish();
+                match self.chain_id() {
+                    None => Encoder::new(&mut buf)
+                        .encode_field(&tx.nonce)
+                        .encode_field(&tx.gas_price)
+                        .encode_field(&tx.gas)
+                        .encode_field(&tx.to)
+                        .encode_field(&tx.value)
+                        .encode_field(&tx.data)
+                        .finish(),
+                    Some(chain_id) => Encoder::new(&mut buf)
+                        .encode_field(&tx.nonce)
+                        .encode_field(&tx.gas_price)
+                        .encode_field(&tx.gas)
+                        .encode_field(&tx.to)
+                        .encode_field(&tx.value)
+                        .encode_field(&tx.data)
+                        .encode_field(&chain_id)
+                        .encode_field(&0u8)
+                        .encode_field(&0u8)
+                        .finish(),
+                }
                 recover_address(&tx.r, &tx.s, signature_y_parity, &Bytes::from(buf))
             }
             Transaction::EIP2930Transaction(tx) => {


### PR DESCRIPTION
**Motivation**

Many of the ef_tests that should be trivial to pass are failing, tests with type 0 and type 1 transactions are failing because the sender of the transactions is being incorrectly derived from the transaction's message and signature.

**Description**

- Introduces the following function to correctly derive the chain_id from the "v" field in legacy transactions (T_w in the yellow paper)
```rust
    fn derive_legacy_chain_id(v: U256) -> Option<u64>
```
- Modifies the sender() method for legacy and eip2930 transactions to calculate the sender correctly.
- Modifies execute_test to run all transactions in every block from the fixture.
- Modifies execute_test to assert that execute_tx returns an Ok result value instead of expecting it to be an ExecutionResult::Success

- Gets the following test suites from ef_test to pass:
  - eip1153_tstore/
  - eip4788_beacon_root/
  - eip5656_mcopy/
  - eip7516_blobgasfee/

<!-- Link to issues: Resolves #111, Resolves #222 -->

Partially closes https://github.com/lambdaclass/ethereum_rust/issues/151