### PR TITLE
feat: update DB with changes resulting from execution

### DIFF
--- a/cmd/ef_tests/test_runner.rs
+++ b/cmd/ef_tests/test_runner.rs
@@ -7,7 +7,7 @@ use ethereum_rust_core::{
     types::{Account as CoreAccount, Block as CoreBlock},
     Address,
 };
-use ethereum_rust_evm::{evm_state, execute_tx, EvmState, SpecId};
+use ethereum_rust_evm::{apply_state_transitions, evm_state, execute_tx, EvmState, SpecId};
 use ethereum_rust_storage::{EngineType, Store};
 
 pub fn execute_test(test: &TestUnit) {
@@ -22,6 +22,9 @@ pub fn execute_test(test: &TestUnit) {
         .first()
         .unwrap();
 
+    // Build pre state
+    let mut state = build_evm_state_from_prestate(&test.pre);
+    // Execute tx
     assert!(execute_tx(
         &transaction.clone().into(),
         &test
@@ -33,11 +36,16 @@ pub fn execute_test(test: &TestUnit) {
             .clone()
             .unwrap()
             .into(),
-        &mut build_evm_state_from_prestate(&test.pre),
+        &mut state,
         SpecId::CANCUN,
     )
     .unwrap()
     .is_success());
+    // Apply state transitions
+    apply_state_transitions(&mut state).expect("Failed to update DB state");
+    // Check post state
+    // TODO
+
 }
 
 pub fn parse_test_file(path: &Path) -> HashMap<String, TestUnit> {

--- a/cmd/ef_tests/test_runner.rs
+++ b/cmd/ef_tests/test_runner.rs
@@ -45,7 +45,6 @@ pub fn execute_test(test: &TestUnit) {
     apply_state_transitions(&mut state).expect("Failed to update DB state");
     // Check post state
     // TODO
-
 }
 
 pub fn parse_test_file(path: &Path) -> HashMap<String, TestUnit> {

--- a/crates/evm/errors.rs
+++ b/crates/evm/errors.rs
@@ -9,7 +9,7 @@ pub enum EvmError {
     #[error("Invalid Header: {0}")]
     Header(String),
     #[error("DB error: {0}")]
-    DB(StoreError),
+    DB(#[from] StoreError),
     #[error("{0}")]
     Custom(String),
     #[error("{0}")]

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -65,7 +65,6 @@ fn run_evm(
             .build();
         evm.transact_commit().map_err(EvmError::from)?
     };
-    apply_state_transitions(state)?;
     Ok(tx_result.into())
 }
 

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -55,14 +55,25 @@ fn run_evm(
             .build();
         evm.transact_commit().map_err(EvmError::from)?
     };
+    apply_state_transitions(state);
     Ok(tx_result.into())
 }
 
 // Merges transitions stored when executing transactions and applies the resulting changes to the DB
 pub fn apply_state_transitions(state: &mut EvmState) {
-    state.0.merge_transitions(BundleRetention::Reverts);
-    let _bundle = state.0.take_bundle();
+    state.0.merge_transitions(BundleRetention::PlainState);
+    let bundle = state.0.take_bundle();
     // TODO: Apply bundle to DB
+    // Update accounts
+    for (address, account) in bundle.state() {
+        if account.status.is_not_modified() {
+            continue
+        }
+        if account.status.was_destroyed() {
+            // Remove account from DB
+        }
+        // Apply changes to DB
+    }
     unimplemented!("Apply state transitions to DB")
 }
 

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -100,7 +100,7 @@ pub fn apply_state_transitions(state: &mut EvmState) -> Result<(), StoreError> {
                     if let Some(code) = new_acc_info.code {
                         state
                             .database()
-                            .add_account_code(code_hash, code.bytecode().clone().0)?;
+                            .add_account_code(code_hash, code.original_bytes().clone().0)?;
                     }
                 }
             }

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -83,7 +83,7 @@ pub fn apply_state_transitions(state: &mut EvmState) -> Result<(), StoreError> {
             state.database().remove_account(address)?;
         }
         // Apply account changes to DB
-        // If the account was changed then both original and current info will be present
+        // If the account was changed then both original and current info will be present in the bundle account
         if account.is_info_changed() {
             // Update account info in DB
             if let Some(new_acc_info) = account.account_info() {

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -73,6 +73,13 @@ pub fn apply_state_transitions(state: &mut EvmState) {
             // Remove account from DB
         }
         // Apply changes to DB
+        // If the account was changed then original info will be present
+        if account.is_info_changed() {
+            // Update account info in DB
+        }
+        if account.is_contract_changed() {
+            // Update code in db
+        }
     }
     unimplemented!("Apply state transitions to DB")
 }

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -79,11 +79,11 @@ pub fn apply_state_transitions(state: &mut EvmState) -> Result<(), StoreError> {
             continue;
         }
         let address = Address::from_slice(address.0.as_slice());
+        // Remove account from DB if destroyed
         if account.status.was_destroyed() {
-            // Remove account from DB
-            //TODO
+            state.database().remove_account(address)?;
         }
-        // Apply changes to DB
+        // Apply account changes to DB
         // If the account was changed then both original and current info will be present
         if account.is_info_changed() {
             // Update account info in DB
@@ -106,8 +106,7 @@ pub fn apply_state_transitions(state: &mut EvmState) -> Result<(), StoreError> {
                 }
             }
         }
-
-        // Update storage
+        // Update account storage in DB
         for (key, slot) in account.storage.iter() {
             if slot.is_changed() {
                 state.database().add_storage_at(

--- a/crates/storage/in_memory.rs
+++ b/crates/storage/in_memory.rs
@@ -42,6 +42,11 @@ impl StoreEngine for Store {
         Ok(self.account_infos.get(&address).cloned())
     }
 
+    fn remove_account_info(&mut self, address: Address) -> Result<(), StoreError> {
+        self.account_infos.remove(&address);
+        Ok(())
+    }
+
     fn set_value(&mut self, key: Key, value: Value) -> Result<(), StoreError> {
         let _ = self.values.insert(key, value);
         Ok(())
@@ -160,6 +165,11 @@ impl StoreEngine for Store {
             .account_storages
             .get(&address)
             .and_then(|entry| entry.get(&storage_key).cloned()))
+    }
+
+    fn remove_account_storage(&mut self, address: Address) -> Result<(), StoreError> {
+        self.account_storages.remove(&address);
+        Ok(())
     }
 }
 

--- a/crates/storage/libmdbx.rs
+++ b/crates/storage/libmdbx.rs
@@ -63,7 +63,7 @@ impl StoreEngine for Store {
             .map_err(StoreError::LibmdbxError)?;
         txn.delete::<AccountInfos>(address.into(), None)
             .map_err(StoreError::LibmdbxError)?;
-        Ok(())
+        txn.commit().map_err(StoreError::LibmdbxError)
     }
 
     fn add_block_header(

--- a/crates/storage/libmdbx.rs
+++ b/crates/storage/libmdbx.rs
@@ -269,14 +269,17 @@ impl StoreEngine for Store {
         // let mut cursor = txn
         //     .cursor::<AccountStorages>()
         //     .map_err(StoreError::LibmdbxError)?;
-        // let address_rlp = address.encode_to_vec();
-        // // Fetch all storage
-        // while let Some((rlp_address, (storage_key_bytes, storage_value_bytes))) =
-        //     cursor.next().map_err(StoreError::LibmdbxError)? {
-
+        let address_rlp = address.into();
+        // while let Some((address, _)) = cursor.next_key().map_err(StoreError::LibmdbxError)? {
+        //     if address == address_rlp {
+        //         cursor
+        //             .delete_current_key()
+        //             .map_err(StoreError::LibmdbxError)?;
+        //         break;
         //     }
-        txn.delete::<AccountStorages>(address.into(), None)
-            .map_err(StoreError::LibmdbxError)?;
+        // }
+        txn.delete::<AccountStorages>(address_rlp, None);
+        txn.commit().map_err(StoreError::LibmdbxError)?;
         Ok(())
     }
 }

--- a/crates/storage/libmdbx.rs
+++ b/crates/storage/libmdbx.rs
@@ -6,7 +6,6 @@ use crate::rlp::{
 };
 use anyhow::Result;
 use bytes::Bytes;
-use ethereum_rust_core::rlp::encode::RLPEncode;
 use ethereum_rust_core::types::{
     AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, Index, Receipt,
 };

--- a/crates/storage/libmdbx.rs
+++ b/crates/storage/libmdbx.rs
@@ -6,6 +6,7 @@ use crate::rlp::{
 };
 use anyhow::Result;
 use bytes::Bytes;
+use ethereum_rust_core::rlp::encode::RLPEncode;
 use ethereum_rust_core::types::{
     AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, Index, Receipt,
 };
@@ -54,6 +55,16 @@ impl StoreEngine for Store {
             .get::<AccountInfos>(address.into())
             .map_err(StoreError::LibmdbxError)?
             .map(|a| a.to()))
+    }
+
+    fn remove_account_info(&mut self, address: Address) -> Result<(), StoreError> {
+        let txn = self
+            .db
+            .begin_readwrite()
+            .map_err(StoreError::LibmdbxError)?;
+        txn.delete::<AccountInfos>(address.into(), None)
+            .map_err(StoreError::LibmdbxError)?;
+        Ok(())
     }
 
     fn add_block_header(
@@ -248,6 +259,25 @@ impl StoreEngine for Store {
             .seek_value(address.into(), storage_key.into())
             .map_err(StoreError::LibmdbxError)?
             .map(|s| s.1.into()))
+    }
+
+    fn remove_account_storage(&mut self, address: Address) -> Result<(), StoreError> {
+        let txn = self
+            .db
+            .begin_readwrite()
+            .map_err(StoreError::LibmdbxError)?;
+        // let mut cursor = txn
+        //     .cursor::<AccountStorages>()
+        //     .map_err(StoreError::LibmdbxError)?;
+        // let address_rlp = address.encode_to_vec();
+        // // Fetch all storage
+        // while let Some((rlp_address, (storage_key_bytes, storage_value_bytes))) =
+        //     cursor.next().map_err(StoreError::LibmdbxError)? {
+
+        //     }
+        txn.delete::<AccountStorages>(address.into(), None)
+            .map_err(StoreError::LibmdbxError)?;
+        Ok(())
     }
 }
 

--- a/crates/storage/libmdbx.rs
+++ b/crates/storage/libmdbx.rs
@@ -266,21 +266,9 @@ impl StoreEngine for Store {
             .db
             .begin_readwrite()
             .map_err(StoreError::LibmdbxError)?;
-        // let mut cursor = txn
-        //     .cursor::<AccountStorages>()
-        //     .map_err(StoreError::LibmdbxError)?;
-        let address_rlp = address.into();
-        // while let Some((address, _)) = cursor.next_key().map_err(StoreError::LibmdbxError)? {
-        //     if address == address_rlp {
-        //         cursor
-        //             .delete_current_key()
-        //             .map_err(StoreError::LibmdbxError)?;
-        //         break;
-        //     }
-        // }
-        txn.delete::<AccountStorages>(address_rlp, None);
-        txn.commit().map_err(StoreError::LibmdbxError)?;
-        Ok(())
+        txn.delete::<AccountStorages>(address.into(), None)
+            .map_err(StoreError::LibmdbxError)?;
+        txn.commit().map_err(StoreError::LibmdbxError)
     }
 }
 

--- a/crates/storage/rocksdb.rs
+++ b/crates/storage/rocksdb.rs
@@ -109,6 +109,10 @@ impl StoreEngine for Store {
             })
     }
 
+    fn remove_account_info(&mut self, address: Address) -> Result<(), StoreError> {
+        todo!()
+    }
+
     fn add_block_header(
         &mut self,
         _block_number: BlockNumber,
@@ -224,6 +228,10 @@ impl StoreEngine for Store {
         _address: Address,
         _storage_key: H256,
     ) -> Result<Option<H256>, StoreError> {
+        todo!()
+    }
+
+    fn remove_account_storage(&mut self, address: Address) -> Result<(), StoreError> {
         todo!()
     }
 }

--- a/crates/storage/rocksdb.rs
+++ b/crates/storage/rocksdb.rs
@@ -109,7 +109,7 @@ impl StoreEngine for Store {
             })
     }
 
-    fn remove_account_info(&mut self, address: Address) -> Result<(), StoreError> {
+    fn remove_account_info(&mut self, _address: Address) -> Result<(), StoreError> {
         todo!()
     }
 
@@ -231,7 +231,7 @@ impl StoreEngine for Store {
         todo!()
     }
 
-    fn remove_account_storage(&mut self, address: Address) -> Result<(), StoreError> {
+    fn remove_account_storage(&mut self, _address: Address) -> Result<(), StoreError> {
         todo!()
     }
 }

--- a/crates/storage/sled.rs
+++ b/crates/storage/sled.rs
@@ -49,7 +49,7 @@ impl StoreEngine for Store {
             })
     }
 
-    fn remove_account_info(&mut self, address: Address) -> Result<(), StoreError> {
+    fn remove_account_info(&mut self, _address: Address) -> Result<(), StoreError> {
         todo!()
     }
 
@@ -159,7 +159,7 @@ impl StoreEngine for Store {
         todo!()
     }
 
-    fn remove_account_storage(&mut self, address: Address) -> Result<(), StoreError> {
+    fn remove_account_storage(&mut self, _address: Address) -> Result<(), StoreError> {
         todo!()
     }
 }

--- a/crates/storage/sled.rs
+++ b/crates/storage/sled.rs
@@ -49,6 +49,10 @@ impl StoreEngine for Store {
             })
     }
 
+    fn remove_account_info(&mut self, address: Address) -> Result<(), StoreError> {
+        todo!()
+    }
+
     fn add_block_header(
         &mut self,
         _block_number: BlockNumber,
@@ -152,6 +156,10 @@ impl StoreEngine for Store {
         _address: Address,
         _storage_key: H256,
     ) -> Result<Option<H256>, StoreError> {
+        todo!()
+    }
+
+    fn remove_account_storage(&mut self, address: Address) -> Result<(), StoreError> {
         todo!()
     }
 }

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -706,7 +706,7 @@ mod tests {
     fn test_remove_account_storage(store: Store) {
         let address_alpha = Address::random();
         let address_beta = Address::random();
-        
+
         let storage_key_a = H256::random();
         let storage_key_b = H256::random();
         let storage_value_a = H256::random();

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -704,25 +704,40 @@ mod tests {
     }
 
     fn test_remove_account_storage(store: Store) {
-        let address = Address::random();
+        let address_alpha = Address::random();
+        let address_beta = Address::random();
+        
         let storage_key_a = H256::random();
         let storage_key_b = H256::random();
         let storage_value_a = H256::random();
         let storage_value_b = H256::random();
 
         store
-            .add_storage_at(address, storage_key_a, storage_value_a)
+            .add_storage_at(address_alpha, storage_key_a, storage_value_a)
             .unwrap();
         store
-            .add_storage_at(address, storage_key_b, storage_value_b)
+            .add_storage_at(address_alpha, storage_key_b, storage_value_b)
             .unwrap();
 
-        store.remove_account_storage(address).unwrap();
+        store
+            .add_storage_at(address_beta, storage_key_a, storage_value_a)
+            .unwrap();
+        store
+            .add_storage_at(address_beta, storage_key_b, storage_value_b)
+            .unwrap();
 
-        let stored_value_a = store.get_storage_at(address, storage_key_a).unwrap();
-        let stored_value_b = store.get_storage_at(address, storage_key_b).unwrap();
+        store.remove_account_storage(address_alpha).unwrap();
 
-        assert!(stored_value_a.is_none());
-        assert!(stored_value_b.is_none());
+        let stored_value_alpha_a = store.get_storage_at(address_alpha, storage_key_a).unwrap();
+        let stored_value_alpha_b = store.get_storage_at(address_alpha, storage_key_b).unwrap();
+
+        let stored_value_beta_a = store.get_storage_at(address_beta, storage_key_a).unwrap();
+        let stored_value_beta_b = store.get_storage_at(address_beta, storage_key_b).unwrap();
+
+        assert!(stored_value_alpha_a.is_none());
+        assert!(stored_value_alpha_b.is_none());
+
+        assert!(stored_value_beta_a.is_some());
+        assert!(stored_value_beta_b.is_some());
     }
 }


### PR DESCRIPTION
**Motivation**

* Updating account info in our DB after executing a transaction or block of transactions

**Description**

* Implement function `apply_state_transitions`, which applies the bundled state changes stored by the evm state to our internal database. 

* Add methods to remove account data from `Store` database

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #202 

