### PR TITLE
ci: fix test command 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,9 +48,9 @@ jobs:
         run: |
           just download-vectors
 
-      - name: Run cargo test
+      - name: Run tests
         run: |
-          cargo test
+          just test-all
       
   docker-build:
     name: Build Docker image

--- a/crates/core/types/genesis.rs
+++ b/crates/core/types/genesis.rs
@@ -214,7 +214,7 @@ mod tests {
         let addr_a = Address::from_str("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02").unwrap();
         assert!(genesis.alloc.contains_key(&addr_a));
         let expected_account_a = GenesisAccount {
-        code: Bytes::from(String::from("0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500")),
+        code: Bytes::from(hex::decode("3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500").unwrap()),
         balance: 0.into(),
         nonce: 1,
         storage: Default::default(),


### PR DESCRIPTION
**Motivation**

The CI is currently not running any of the project's tests in the run tests step

**Description**

 Replaces `cargo test` command with `just test-all` command in CI. This will make sure all of the project's tests are being ran in each PR

<!-- Link to issues: Resolves #111, Resolves #222 -->

