### PR TITLE
test: add EF shanghai blockchain tests.

### DIFF
--- a/cmd/ef_tests/Cargo.toml
+++ b/cmd/ef_tests/Cargo.toml
@@ -21,3 +21,7 @@ path = "./ef_tests.rs"
 [[test]]
 name = "cancun"
 harness = false
+
+[[test]]
+name = "shanghai"
+harness = false

--- a/cmd/ef_tests/tests/shanghai.rs
+++ b/cmd/ef_tests/tests/shanghai.rs
@@ -1,0 +1,28 @@
+use std::path::Path;
+
+use ef_tests::test_runner::{execute_test, parse_test_file, validate_test};
+
+fn parse_and_execute(path: &Path) -> datatest_stable::Result<()> {
+    let tests = parse_test_file(path);
+
+    for (test_key, test) in tests {
+        validate_test(&test);
+        execute_test(&test_key, &test);
+    }
+    Ok(())
+}
+
+datatest_stable::harness!(
+    parse_and_execute,
+    "vectors/shanghai/eip3855_push0/",
+    r"^.*/*",
+    parse_and_execute,
+    "vectors/shanghai/eip3651_warm_coinbase/",
+    r"^.*/*",
+    // parse_and_execute,
+    // "vectors/shanghai/eip3860_initcode/",
+    // r"^.*/*",
+    // parse_and_execute,
+    // "vectors/shanghai/eip4895_withdrawals/",
+    // r"^.*/*",
+);


### PR DESCRIPTION
**Motivation**
We should be able to support the shanghai fork

**Description**
Added Shanghai tests, commented the ones that are not passing. For `eip4895` it is expected since we haven't started with withdrawals implementation. For `eip3860` it's weird, it should work since it's only a new opcode and we're using revm

