### PR TITLE
ci: divide `compile` job into `lint` + `test`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  merge_group:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,8 @@ jobs:
         with:
           toolchain: 1.78.0
           components: rustfmt, clippy
-            - name: Setup just
+
+      - name: Setup just
         uses: extractions/setup-just@v2
       
       - name: Download test vectors

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  compile:
-    name: Compile
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -22,9 +22,6 @@ jobs:
         with:
           toolchain: 1.78.0
           components: rustfmt, clippy
-
-      - name: Set up cargo cache
-        uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
         run: cargo check
@@ -40,8 +37,20 @@ jobs:
       - name: Run cargo fmt
         run: |
           cargo fmt --all -- --check
-      
-      - name: Setup just
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Rustup toolchain install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.78.0
+          components: rustfmt, clippy
+            - name: Setup just
         uses: extractions/setup-just@v2
       
       - name: Download test vectors
@@ -51,7 +60,7 @@ jobs:
       - name: Run tests
         run: |
           just test-all
-      
+
   docker-build:
     name: Build Docker image
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.78.0
-          components: rustfmt, clippy
 
       - name: Setup just
         uses: extractions/setup-just@v2

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -14,26 +14,29 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Configure which types are allowed (newline-delimited).
-          # Default: https://github.com/commitizen/conventional-commit-types
-          # Customized based on sections defined in scripts/generate_changelog.mjs
-          types: |
-            feat
-            fix
-            perf
-            refactor
-            revert
-            deps
-            build
-            ci
-            test
-            style
-            chore
-            docs
+      - name: Check PR title
+        # Skip step for events that are not pull request targets as it currenlty fails when ran in the merge queue
+        if: github.event_name == 'pull_request_target'
+        - uses: amannn/action-semantic-pull-request@v5
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            # Configure which types are allowed (newline-delimited).
+            # Default: https://github.com/commitizen/conventional-commit-types
+            # Customized based on sections defined in scripts/generate_changelog.mjs
+            types: |
+              feat
+              fix
+              perf
+              refactor
+              revert
+              deps
+              build
+              ci
+              test
+              style
+              chore
+              docs
 
           # Configure which scopes are allowed (newline-delimited).
           # These are regex patterns auto-wrapped in `^ $`.

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -12,56 +12,55 @@ on:
 jobs:
   main:
     name: Validate PR title
+    # Skip step for events that are not pull request targets as it currenlty fails when ran in the merge queue
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR title
-        # Skip step for events that are not pull request targets as it currenlty fails when ran in the merge queue
-        if: github.event_name == 'pull_request_target'
-        - uses: amannn/action-semantic-pull-request@v5
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            # Configure which types are allowed (newline-delimited).
-            # Default: https://github.com/commitizen/conventional-commit-types
-            # Customized based on sections defined in scripts/generate_changelog.mjs
-            types: |
-              feat
-              fix
-              perf
-              refactor
-              revert
-              deps
-              build
-              ci
-              test
-              style
-              chore
-              docs
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (newline-delimited).
+          # Default: https://github.com/commitizen/conventional-commit-types
+          # Customized based on sections defined in scripts/generate_changelog.mjs
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            revert
+            deps
+            build
+            ci
+            test
+            style
+            chore
+            docs
 
-            # Configure which scopes are allowed (newline-delimited).
-            # These are regex patterns auto-wrapped in `^ $`.
-            #scopes: |
+          # Configure which scopes are allowed (newline-delimited).
+          # These are regex patterns auto-wrapped in `^ $`.
+          #scopes: |
 
-            # Configure that a scope must always be provided.
-            requireScope: false
+          # Configure that a scope must always be provided.
+          requireScope: false
 
-            # Configure which scopes are disallowed in PR titles (newline-delimited).
-            # For instance by setting the value below, `chore(release): ...` (lowercase)
-            # and `ci(e2e,release): ...` (unknown scope) will be rejected.
-            # These are regex patterns auto-wrapped in `^ $`.
-            #disallowScopes: |
+          # Configure which scopes are disallowed in PR titles (newline-delimited).
+          # For instance by setting the value below, `chore(release): ...` (lowercase)
+          # and `ci(e2e,release): ...` (unknown scope) will be rejected.
+          # These are regex patterns auto-wrapped in `^ $`.
+          #disallowScopes: |
 
-            # Configure additional validation for the subject based on a regex.
-            # This example ensures the subject doesn't start with an uppercase character.
-            subjectPattern: ^(?![A-Z]).+$
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          subjectPattern: ^(?![A-Z]).+$
 
-            # If `subjectPattern` is configured, you can use this property to override
-            # the default error message that is shown when the pattern doesn't match.
-            # The variables `subject` and `title` can be used within the message.
-            subjectPatternError: |
-              The subject "{subject}" found in the pull request title "{title}"
-              didn't match the configured pattern. Please ensure that the subject
-              doesn't start with an uppercase character.
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
 
             # If the PR contains one of these newline-delimited labels, the
             # validation is skipped. If you want to rerun the validation when

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -38,35 +38,35 @@ jobs:
               chore
               docs
 
-          # Configure which scopes are allowed (newline-delimited).
-          # These are regex patterns auto-wrapped in `^ $`.
-          #scopes: |
+            # Configure which scopes are allowed (newline-delimited).
+            # These are regex patterns auto-wrapped in `^ $`.
+            #scopes: |
 
-          # Configure that a scope must always be provided.
-          requireScope: false
+            # Configure that a scope must always be provided.
+            requireScope: false
 
-          # Configure which scopes are disallowed in PR titles (newline-delimited).
-          # For instance by setting the value below, `chore(release): ...` (lowercase)
-          # and `ci(e2e,release): ...` (unknown scope) will be rejected.
-          # These are regex patterns auto-wrapped in `^ $`.
-          #disallowScopes: |
+            # Configure which scopes are disallowed in PR titles (newline-delimited).
+            # For instance by setting the value below, `chore(release): ...` (lowercase)
+            # and `ci(e2e,release): ...` (unknown scope) will be rejected.
+            # These are regex patterns auto-wrapped in `^ $`.
+            #disallowScopes: |
 
-          # Configure additional validation for the subject based on a regex.
-          # This example ensures the subject doesn't start with an uppercase character.
-          subjectPattern: ^(?![A-Z]).+$
+            # Configure additional validation for the subject based on a regex.
+            # This example ensures the subject doesn't start with an uppercase character.
+            subjectPattern: ^(?![A-Z]).+$
 
-          # If `subjectPattern` is configured, you can use this property to override
-          # the default error message that is shown when the pattern doesn't match.
-          # The variables `subject` and `title` can be used within the message.
-          subjectPatternError: |
-            The subject "{subject}" found in the pull request title "{title}"
-            didn't match the configured pattern. Please ensure that the subject
-            doesn't start with an uppercase character.
+            # If `subjectPattern` is configured, you can use this property to override
+            # the default error message that is shown when the pattern doesn't match.
+            # The variables `subject` and `title` can be used within the message.
+            subjectPatternError: |
+              The subject "{subject}" found in the pull request title "{title}"
+              didn't match the configured pattern. Please ensure that the subject
+              doesn't start with an uppercase character.
 
-          # If the PR contains one of these newline-delimited labels, the
-          # validation is skipped. If you want to rerun the validation when
-          # labels change, you might want to use the `labeled` and `unlabeled`
-          # event triggers in your workflow.
-          ignoreLabels: |
-            bot
-            ignore-semantic-pull-request
+            # If the PR contains one of these newline-delimited labels, the
+            # validation is skipped. If you want to rerun the validation when
+            # labels change, you might want to use the `labeled` and `unlabeled`
+            # event triggers in your workflow.
+            ignoreLabels: |
+              bot
+              ignore-semantic-pull-request

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -62,10 +62,10 @@ jobs:
             didn't match the configured pattern. Please ensure that the subject
             doesn't start with an uppercase character.
 
-            # If the PR contains one of these newline-delimited labels, the
-            # validation is skipped. If you want to rerun the validation when
-            # labels change, you might want to use the `labeled` and `unlabeled`
-            # event triggers in your workflow.
-            ignoreLabels: |
-              bot
-              ignore-semantic-pull-request
+          # If the PR contains one of these newline-delimited labels, the
+          # validation is skipped. If you want to rerun the validation when
+          # labels change, you might want to use the `labeled` and `unlabeled`
+          # event triggers in your workflow.
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,7 +1,6 @@
 name: "Lint PR title"
 
 on:
-  merge_group:
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,6 +1,7 @@
 name: "Lint PR title"
 
 on:
+  merge_group:
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
**Motivation**

`Compile` job name is not descriptive
<!-- Why does this pull request exist? What are its goals? -->

**Description**

Divides `Compile` job into `Lint` and `Test` jobs
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None

