### PR TITLE
feat: `eth_newPayloadV3`: fetch cancun time from db for timestamp validation

### DIFF
--- a/crates/rpc/engine/mod.rs
+++ b/crates/rpc/engine/mod.rs
@@ -45,7 +45,10 @@ pub fn forkchoice_updated_v3() -> Result<Value, RpcErr> {
     }))
 }
 
-pub fn new_payload_v3(request: NewPayloadV3Request, storage: Store) -> Result<PayloadStatus, RpcErr> {
+pub fn new_payload_v3(
+    request: NewPayloadV3Request,
+    storage: Store,
+) -> Result<PayloadStatus, RpcErr> {
     let block_hash = request.payload.block_hash;
 
     info!("Received new payload with block hash: {}", block_hash);
@@ -66,7 +69,7 @@ pub fn new_payload_v3(request: NewPayloadV3Request, storage: Store) -> Result<Pa
 
     // Check timestamp does not fall within the time frame of the Cancun fork
     match storage.get_cancun_time().map_err(|_| RpcErr::Internal)? {
-        Some(cancun_time) if block_header.timestamp > cancun_time => {},
+        Some(cancun_time) if block_header.timestamp > cancun_time => {}
         _ => return Err(RpcErr::UnsuportedFork),
     }
 

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -141,9 +141,8 @@ pub fn map_requests(req: &RpcRequest, storage: Store) -> Result<Value, RpcErr> {
         }
         "engine_forkchoiceUpdatedV3" => engine::forkchoice_updated_v3(),
         "engine_newPayloadV3" => {
-            let request =
-                parse_new_payload_v3_request(req.params.as_ref().ok_or(RpcErr::BadParams)?)?;
-            Ok(serde_json::to_value(engine::new_payload_v3(request)?).unwrap())
+            let request = NewPayloadV3Request::parse(&req.params).ok_or(RpcErr::BadParams)?;
+            Ok(serde_json::to_value(engine::new_payload_v3(request, storage)?).unwrap())
         }
         "admin_nodeInfo" => admin::node_info(),
         _ => Err(RpcErr::MethodNotFound),
@@ -177,22 +176,6 @@ where
             .unwrap(),
         ),
     }
-}
-
-fn parse_new_payload_v3_request(params: &[Value]) -> Result<NewPayloadV3Request, RpcErr> {
-    if params.len() != 3 {
-        return Err(RpcErr::BadParams);
-    }
-    let payload = serde_json::from_value(params[0].clone()).map_err(|_| RpcErr::BadParams)?;
-    let expected_blob_versioned_hashes =
-        serde_json::from_value(params[1].clone()).map_err(|_| RpcErr::BadParams)?;
-    let parent_beacon_block_root =
-        serde_json::from_value(params[2].clone()).map_err(|_| RpcErr::BadParams)?;
-    Ok(NewPayloadV3Request {
-        payload,
-        expected_blob_versioned_hashes,
-        parent_beacon_block_root,
-    })
 }
 
 #[cfg(test)]

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -168,9 +168,9 @@ pub trait StoreEngine: Debug + Send {
     /// Obtain the current chain id
     fn get_chain_id(&self) -> Result<Option<U256>, StoreError>;
 
-/// Updates the value of the timestamp at which the cancun fork was activated
-fn update_cancun_time(&mut self, cancun_time: u64) -> Result<(), StoreError>;
+    /// Updates the value of the timestamp at which the cancun fork was activated
+    fn update_cancun_time(&mut self, cancun_time: u64) -> Result<(), StoreError>;
 
-/// Obtain the timestamp at which the cancun fork was activated
-fn get_cancun_time(&self) -> Result<Option<u64>, StoreError>;
+    /// Obtain the timestamp at which the cancun fork was activated
+    fn get_cancun_time(&self) -> Result<Option<u64>, StoreError>;
 }

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -161,9 +161,16 @@ pub trait StoreEngine: Debug + Send {
         }
         Ok(())
     }
+
     /// Updates the value of the chain id
     fn update_chain_id(&mut self, chain_id: U256) -> Result<(), StoreError>;
 
     /// Obtain the current chain id
     fn get_chain_id(&self) -> Result<Option<U256>, StoreError>;
+
+/// Updates the value of the timestamp at which the cancun fork was activated
+fn update_cancun_time(&mut self, cancun_time: u64) -> Result<(), StoreError>;
+
+/// Obtain the timestamp at which the cancun fork was activated
+fn get_cancun_time(&self) -> Result<Option<u64>, StoreError>;
 }

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -4,8 +4,8 @@ use bytes::Bytes;
 use ethereum_types::{Address, H256, U256};
 
 use ethereum_rust_core::types::{
-    Account, AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, Index, Receipt,
-    Transaction,
+    Account, AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, ChainConfig, Index,
+    Receipt, Transaction,
 };
 
 use crate::error::StoreError;
@@ -170,14 +170,12 @@ pub trait StoreEngine: Debug + Send {
         Ok(())
     }
 
-    /// Updates the value of the chain id
-    fn update_chain_id(&mut self, chain_id: U256) -> Result<(), StoreError>;
+    /// Stores the chain configuration values, should only be called once after reading the genesis file
+    /// Ignores previously stored values if present
+    fn set_chain_config(&mut self, chain_config: &ChainConfig) -> Result<(), StoreError>;
 
     /// Obtain the current chain id
     fn get_chain_id(&self) -> Result<Option<U256>, StoreError>;
-
-    /// Updates the value of the timestamp at which the cancun fork was activated
-    fn update_cancun_time(&mut self, cancun_time: u64) -> Result<(), StoreError>;
 
     /// Obtain the timestamp at which the cancun fork was activated
     fn get_cancun_time(&self) -> Result<Option<u64>, StoreError>;

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -1,7 +1,7 @@
 use crate::error::StoreError;
 use bytes::Bytes;
 use ethereum_rust_core::types::{
-    AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, Index, Receipt,
+    AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, ChainConfig, Index, Receipt,
 };
 use ethereum_types::{Address, H256, U256};
 use std::{collections::HashMap, fmt::Debug};
@@ -170,18 +170,16 @@ impl StoreEngine for Store {
         Ok(())
     }
 
-    fn update_chain_id(&mut self, chain_id: U256) -> Result<(), StoreError> {
-        self.chain_data.chain_id.replace(chain_id);
+    fn set_chain_config(&mut self, chain_config: &ChainConfig) -> Result<(), StoreError> {
+        // Store cancun timestamp
+        self.chain_data.cancun_time = chain_config.cancun_time;
+        // Store chain id
+        self.chain_data.chain_id.replace(chain_config.chain_id);
         Ok(())
     }
 
     fn get_chain_id(&self) -> Result<Option<U256>, StoreError> {
         Ok(self.chain_data.chain_id)
-    }
-
-    fn update_cancun_time(&mut self, cancun_time: u64) -> Result<(), StoreError> {
-        self.chain_data.cancun_time.replace(cancun_time);
-        Ok(())
     }
 
     fn get_cancun_time(&self) -> Result<Option<u64>, StoreError> {

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -26,6 +26,7 @@ pub struct Store {
 #[derive(Default)]
 struct ChainData {
     chain_id: Option<U256>,
+    cancun_time: Option<u64>,
 }
 
 impl Store {
@@ -176,6 +177,15 @@ impl StoreEngine for Store {
 
     fn get_chain_id(&self) -> Result<Option<U256>, StoreError> {
         Ok(self.chain_data.chain_id)
+    }
+
+    fn update_cancun_time(&mut self, cancun_time: u64) -> Result<(), StoreError> {
+        self.chain_data.cancun_time.replace(cancun_time);
+        Ok(())
+    }
+
+    fn get_cancun_time(&self) -> Result<Option<u64>, StoreError> {
+        Ok(self.chain_data.cancun_time)
     }
 }
 

--- a/crates/storage/engines/libmdbx.rs
+++ b/crates/storage/engines/libmdbx.rs
@@ -213,22 +213,11 @@ impl StoreEngine for Store {
     }
 
     fn update_cancun_time(&mut self, cancun_time: u64) -> Result<(), StoreError> {
-        // Overwrites previous value if present
-        let txn = self
-            .db
-            .begin_readwrite()
-            .map_err(StoreError::LibmdbxError)?;
-        txn.upsert::<ChainData>(ChainDataIndex::CancunTime, cancun_time.encode_to_vec())
-            .map_err(StoreError::LibmdbxError)?;
-        txn.commit().map_err(StoreError::LibmdbxError)
+        self.write::<ChainData>(ChainDataIndex::CancunTime, cancun_time.encode_to_vec())
     }
 
     fn get_cancun_time(&self) -> Result<Option<u64>, StoreError> {
-        let txn = self.db.begin_read().map_err(StoreError::LibmdbxError)?;
-        match txn
-            .get::<ChainData>(ChainDataIndex::CancunTime)
-            .map_err(StoreError::LibmdbxError)?
-        {
+        match self.read::<ChainData>(ChainDataIndex::CancunTime)? {
             None => Ok(None),
             Some(ref rlp) => RLPDecode::decode(rlp)
                 .map(Some)

--- a/crates/storage/engines/libmdbx.rs
+++ b/crates/storage/engines/libmdbx.rs
@@ -9,7 +9,7 @@ use bytes::Bytes;
 use ethereum_rust_core::rlp::decode::RLPDecode;
 use ethereum_rust_core::rlp::encode::RLPEncode;
 use ethereum_rust_core::types::{
-    AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, Index, Receipt,
+    AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, ChainConfig, Index, Receipt,
 };
 use ethereum_types::{Address, H256, U256};
 use libmdbx::orm::{Decodable, Encodable};
@@ -199,8 +199,16 @@ impl StoreEngine for Store {
         self.remove::<AccountStorages>(address.into())
     }
 
-    fn update_chain_id(&mut self, chain_id: U256) -> Result<(), StoreError> {
-        self.write::<ChainData>(ChainDataIndex::ChainId, chain_id.encode_to_vec())
+    fn set_chain_config(&mut self, chain_config: &ChainConfig) -> Result<(), StoreError> {
+        // Store cancun timestamp
+        if let Some(cancun_time) = chain_config.cancun_time {
+            self.write::<ChainData>(ChainDataIndex::CancunTime, cancun_time.encode_to_vec())?;
+        };
+        // Store chain id
+        self.write::<ChainData>(
+            ChainDataIndex::ChainId,
+            chain_config.chain_id.encode_to_vec(),
+        )
     }
 
     fn get_chain_id(&self) -> Result<Option<U256>, StoreError> {
@@ -210,10 +218,6 @@ impl StoreEngine for Store {
                 .map(Some)
                 .map_err(|_| StoreError::DecodeError),
         }
-    }
-
-    fn update_cancun_time(&mut self, cancun_time: u64) -> Result<(), StoreError> {
-        self.write::<ChainData>(ChainDataIndex::CancunTime, cancun_time.encode_to_vec())
     }
 
     fn get_cancun_time(&self) -> Result<Option<u64>, StoreError> {

--- a/crates/storage/engines/libmdbx.rs
+++ b/crates/storage/engines/libmdbx.rs
@@ -313,15 +313,6 @@ impl StoreEngine for Store {
     }
 }
 
-impl Store {
-
-fn upsert<T: libmdbx::orm::Table>(&self, table: T, key: T::Key, value: T::Value) -> Result<(), StoreError> {
-    let txn = self.db.begin_readwrite().map_err(StoreError::LibmdbxError)?;
-    txn.upsert::<T>(key, value).map_err(StoreError::LibmdbxError)?;
-    txn.commit().map_err(StoreError::LibmdbxError)
-}
-}
-
 impl Debug for Store {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Libmdbx Store").finish()

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -305,6 +305,14 @@ impl Store {
     pub fn get_chain_id(&self) -> Result<Option<U256>, StoreError> {
         self.engine.lock().unwrap().get_chain_id()
     }
+
+    pub fn update_cancun_time(&self, cancun_time: u64) -> Result<(), StoreError> {
+        self.engine.lock().unwrap().update_cancun_time(cancun_time)
+    }
+
+    pub fn get_cancun_time(&self) -> Result<Option<u64>, StoreError> {
+        self.engine.lock().unwrap().get_cancun_time()
+    }
 }
 
 #[cfg(test)]

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -247,6 +247,9 @@ impl Store {
         }
 
         // Store chain info
+        if let Some(cancun_time) = genesis.config.cancun_time {
+            self.update_cancun_time(cancun_time)?;
+        }
         self.update_chain_id(genesis.config.chain_id)
     }
 


### PR DESCRIPTION
**Motivation**

Fetch cancun time from DB when validating payload v3 timestamp

<!-- Why does this pull request exist? What are its goals? -->

**Description**

* Store cancun_time in db
* Use the stored cancun_time when validating payload timestamp in `eth_newPayloadV3`
* Replace update methods for chain data in `Store` with `set_chain_config`

Bonus:

* Move `NewPayloadV3Request` to its corresponding module and update is parsing to match the rest of the codebase

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but is part of #51 

