### PR TITLE
fix: Withdrawal balance increments should also be written in the State's cache

### DIFF
--- a/cmd/ef_tests/types.rs
+++ b/cmd/ef_tests/types.rs
@@ -344,10 +344,8 @@ impl From<Account> for ethereum_rustAccount {
                 .into_iter()
                 .map(|(k, v)| {
                     let mut k_bytes = [0; 32];
-                    let mut v_bytes = [0; 32];
                     k.to_big_endian(&mut k_bytes);
-                    v.to_big_endian(&mut v_bytes);
-                    (H256(k_bytes), H256(v_bytes))
+                    (H256(k_bytes), v)
                 })
                 .collect(),
         }

--- a/crates/core/types/account.rs
+++ b/crates/core/types/account.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 use bytes::Bytes;
 use ethereum_types::{H256, U256};
@@ -25,7 +25,7 @@ lazy_static! {
 pub struct Account {
     pub info: AccountInfo,
     pub code: Bytes,
-    pub storage: BTreeMap<H256, H256>,
+    pub storage: HashMap<H256, U256>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -124,7 +124,7 @@ impl RLPDecode for AccountState {
     }
 }
 
-pub fn compute_storage_root(storage: &BTreeMap<H256, H256>) -> H256 {
+pub fn compute_storage_root(storage: &HashMap<H256, U256>) -> H256 {
     let mut storage_trie = PatriciaMerkleTree::<Vec<u8>, Vec<u8>, Keccak256>::new();
 
     for (k, v) in storage.iter() {
@@ -145,7 +145,7 @@ pub fn compute_storage_root(storage: &BTreeMap<H256, H256>) -> H256 {
 impl AccountState {
     pub fn from_info_and_storage(
         info: &AccountInfo,
-        storage: &BTreeMap<H256, H256>,
+        storage: &HashMap<H256, U256>,
     ) -> AccountState {
         AccountState {
             nonce: info.nonce,

--- a/crates/core/types/genesis.rs
+++ b/crates/core/types/genesis.rs
@@ -3,7 +3,7 @@ use ethereum_types::{Address, Bloom, H256, U256};
 use patricia_merkle_tree::PatriciaMerkleTree;
 use serde::Deserialize;
 use sha3::{Digest, Keccak256};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use crate::rlp::encode::RLPEncode as _;
 
@@ -89,7 +89,7 @@ pub struct GenesisAccount {
     #[serde(default, with = "crate::serde_utils::bytes")]
     pub code: Bytes,
     #[serde(default)]
-    pub storage: BTreeMap<H256, H256>,
+    pub storage: HashMap<H256, U256>,
     #[serde(deserialize_with = "crate::serde_utils::u256::deser_dec_str")]
     pub balance: U256,
     #[serde(default, deserialize_with = "crate::serde_utils::u64::deser_dec_str")]
@@ -232,7 +232,7 @@ mod tests {
                 .unwrap()
             ),
             Some(
-                &H256::from_str(
+                &U256::from_str(
                     "0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b"
                 )
                 .unwrap()
@@ -246,7 +246,7 @@ mod tests {
                 .unwrap()
             ),
             Some(
-                &H256::from_str(
+                &U256::from_str(
                     "0xe71f0aa83cc32edfbefa9f4d3e0174ca85182eec9f3a09f6a6c0df6377a510d7"
                 )
                 .unwrap()

--- a/crates/evm/db.rs
+++ b/crates/evm/db.rs
@@ -45,7 +45,7 @@ impl revm::Database for StoreWrapper {
                 CoreAddress::from(address.0.as_ref()),
                 CoreH256::from(index.to_be_bytes()),
             )?
-            .map(|value| RevmU256::from_be_bytes(value.0))
+            .map(|value| RevmU256::from_limbs(value.0))
             .unwrap_or_else(|| RevmU256::ZERO))
     }
 

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -233,9 +233,7 @@ pub fn apply_state_transitions(state: &mut EvmState) -> Result<(), StoreError> {
                 state.database().add_storage_at(
                     address,
                     H256::from_uint(&U256::from_little_endian(key.as_le_slice())),
-                    H256::from_uint(&U256::from_little_endian(
-                        slot.present_value().as_le_slice(),
-                    )),
+                    U256::from_little_endian(slot.present_value().as_le_slice()),
                 )?;
             }
         }

--- a/crates/rpc/engine/mod.rs
+++ b/crates/rpc/engine/mod.rs
@@ -2,6 +2,7 @@ use ethereum_rust_core::{
     types::{ExecutionPayloadV3, PayloadStatus, PayloadValidationStatus},
     H256,
 };
+use ethereum_rust_storage::Store;
 use serde_json::{json, Value};
 use tracing::info;
 
@@ -13,6 +14,20 @@ pub struct NewPayloadV3Request {
     pub payload: ExecutionPayloadV3,
     pub expected_blob_versioned_hashes: Vec<H256>,
     pub parent_beacon_block_root: H256,
+}
+
+impl NewPayloadV3Request {
+    pub fn parse(params: &Option<Vec<Value>>) -> Option<NewPayloadV3Request> {
+        let params = params.as_ref()?;
+        if params.len() != 3 {
+            return None;
+        }
+        Some(NewPayloadV3Request {
+            payload: serde_json::from_value(params[0].clone()).ok()?,
+            expected_blob_versioned_hashes: serde_json::from_value(params[1].clone()).ok()?,
+            parent_beacon_block_root: serde_json::from_value(params[2].clone()).ok()?,
+        })
+    }
 }
 
 pub fn exchange_capabilities(capabilities: &ExchangeCapabilitiesRequest) -> Result<Value, RpcErr> {
@@ -30,7 +45,10 @@ pub fn forkchoice_updated_v3() -> Result<Value, RpcErr> {
     }))
 }
 
-pub fn new_payload_v3(request: NewPayloadV3Request) -> Result<PayloadStatus, RpcErr> {
+pub fn new_payload_v3(
+    request: NewPayloadV3Request,
+    storage: Store,
+) -> Result<PayloadStatus, RpcErr> {
     let block_hash = request.payload.block_hash;
 
     info!("Received new payload with block hash: {}", block_hash);
@@ -50,10 +68,11 @@ pub fn new_payload_v3(request: NewPayloadV3Request) -> Result<PayloadStatus, Rpc
     // Payload Validation
 
     // Check timestamp does not fall within the time frame of the Cancun fork
-    let cancun_time = 0; // Placeholder -> we should fetch this from genesis?
-    if block_header.timestamp <= cancun_time {
-        return Err(RpcErr::UnsuportedFork);
+    match storage.get_cancun_time().map_err(|_| RpcErr::Internal)? {
+        Some(cancun_time) if block_header.timestamp > cancun_time => {}
+        _ => return Err(RpcErr::UnsuportedFork),
     }
+
     // Check that block_hash is valid
     let actual_block_hash = block_header.compute_block_hash();
     if block_hash != actual_block_hash {

--- a/crates/rpc/eth/block.rs
+++ b/crates/rpc/eth/block.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use ethereum_rust_evm::{evm_state, ExecutionResult, SpecId};
-use ethereum_rust_storage::Store;
+use ethereum_rust_storage::{error::StoreError, Store};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::info;
@@ -83,6 +83,22 @@ pub enum BlockTag {
     #[default]
     Latest,
     Pending,
+}
+
+pub(crate) fn resolve_block_number(
+    identifier: &BlockIdentifier,
+    storage: &Store,
+) -> Result<Option<BlockNumber>, StoreError> {
+    match identifier {
+        BlockIdentifier::Number(num) => Ok(Some(*num)),
+        BlockIdentifier::Tag(tag) => match tag {
+            BlockTag::Earliest => storage.get_earliest_block_number(),
+            BlockTag::Finalized => storage.get_finalized_block_number(),
+            BlockTag::Safe => storage.get_safe_block_number(),
+            BlockTag::Latest => storage.get_latest_block_number(),
+            BlockTag::Pending => storage.get_pending_block_number(),
+        },
+    }
 }
 
 impl GetBlockByNumberRequest {
@@ -210,9 +226,9 @@ pub fn get_block_by_number(
     storage: Store,
 ) -> Result<Value, RpcErr> {
     info!("Requested block with number: {}", request.block);
-    let block_number = match request.block {
-        BlockIdentifier::Tag(_) => unimplemented!("Obtain block number from tag"),
-        BlockIdentifier::Number(block_number) => block_number,
+    let block_number = match resolve_block_number(&request.block, &storage) {
+        Ok(Some(block_number)) => block_number,
+        _ => return Ok(Value::Null),
     };
     let header = storage.get_block_header(block_number);
     let body = storage.get_block_body(block_number);
@@ -257,9 +273,9 @@ pub fn get_block_transaction_count_by_number(
         "Requested transaction count for block with number: {}",
         request.block
     );
-    let block_number = match request.block {
-        BlockIdentifier::Tag(_) => unimplemented!("Obtain block number from tag"),
-        BlockIdentifier::Number(block_number) => block_number,
+    let block_number = match resolve_block_number(&request.block, &storage) {
+        Ok(Some(block_number)) => block_number,
+        _ => return Ok(Value::Null),
     };
     let block_body = match storage.get_block_body(block_number) {
         Ok(Some(block_body)) => block_body,
@@ -279,9 +295,9 @@ pub fn get_transaction_by_block_number_and_index(
         "Requested transaction at index: {} of block with number: {}",
         request.transaction_index, request.block,
     );
-    let block_number = match request.block {
-        BlockIdentifier::Tag(_) => unimplemented!("Obtain block number from tag"),
-        BlockIdentifier::Number(block_number) => block_number,
+    let block_number = match resolve_block_number(&request.block, &storage) {
+        Ok(Some(block_number)) => block_number,
+        _ => return Ok(Value::Null),
     };
     let block_body = match storage.get_block_body(block_number) {
         Ok(Some(block_body)) => block_body,
@@ -330,9 +346,9 @@ pub fn get_block_receipts(
         "Requested receipts for block with number: {}",
         request.block
     );
-    let block_number = match request.block {
-        BlockIdentifier::Tag(_) => unimplemented!("Obtain block number from tag"),
-        BlockIdentifier::Number(block_number) => block_number,
+    let block_number = match resolve_block_number(&request.block, &storage) {
+        Ok(Some(block_number)) => block_number,
+        _ => return Ok(Value::Null),
     };
     let header = storage.get_block_header(block_number);
     let body = storage.get_block_body(block_number);
@@ -493,6 +509,16 @@ pub fn create_access_list(
     };
 
     serde_json::to_value(result).map_err(|_| RpcErr::Internal)
+}
+
+pub fn block_number(storage: Store) -> Result<Value, RpcErr> {
+    info!("Requested latest block number");
+    match storage.get_latest_block_number() {
+        Ok(Some(block_number)) => {
+            serde_json::to_value(format!("{:#x}", block_number)).map_err(|_| RpcErr::Internal)
+        }
+        _ => Err(RpcErr::Internal),
+    }
 }
 
 impl Display for BlockIdentifier {

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -142,9 +142,8 @@ pub fn map_requests(req: &RpcRequest, storage: Store) -> Result<Value, RpcErr> {
         "eth_blockNumber" => block::block_number(storage),
         "engine_forkchoiceUpdatedV3" => engine::forkchoice_updated_v3(),
         "engine_newPayloadV3" => {
-            let request =
-                parse_new_payload_v3_request(req.params.as_ref().ok_or(RpcErr::BadParams)?)?;
-            Ok(serde_json::to_value(engine::new_payload_v3(request)?).unwrap())
+            let request = NewPayloadV3Request::parse(&req.params).ok_or(RpcErr::BadParams)?;
+            Ok(serde_json::to_value(engine::new_payload_v3(request, storage)?).unwrap())
         }
         "admin_nodeInfo" => admin::node_info(),
         _ => Err(RpcErr::MethodNotFound),
@@ -178,22 +177,6 @@ where
             .unwrap(),
         ),
     }
-}
-
-fn parse_new_payload_v3_request(params: &[Value]) -> Result<NewPayloadV3Request, RpcErr> {
-    if params.len() != 3 {
-        return Err(RpcErr::BadParams);
-    }
-    let payload = serde_json::from_value(params[0].clone()).map_err(|_| RpcErr::BadParams)?;
-    let expected_blob_versioned_hashes =
-        serde_json::from_value(params[1].clone()).map_err(|_| RpcErr::BadParams)?;
-    let parent_beacon_block_root =
-        serde_json::from_value(params[2].clone()).map_err(|_| RpcErr::BadParams)?;
-    Ok(NewPayloadV3Request {
-        payload,
-        expected_blob_versioned_hashes,
-        parent_beacon_block_root,
-    })
 }
 
 #[cfg(test)]

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -139,6 +139,7 @@ pub fn map_requests(req: &RpcRequest, storage: Store) -> Result<Value, RpcErr> {
             let request = CreateAccessListRequest::parse(&req.params).ok_or(RpcErr::BadParams)?;
             block::create_access_list(&request, storage)
         }
+        "eth_blockNumber" => block::block_number(storage),
         "engine_forkchoiceUpdatedV3" => engine::forkchoice_updated_v3(),
         "engine_newPayloadV3" => {
             let request =

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -4,8 +4,8 @@ use bytes::Bytes;
 use ethereum_types::{Address, H256, U256};
 
 use ethereum_rust_core::types::{
-    Account, AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, Index, Receipt,
-    Transaction,
+    Account, AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, ChainConfig, Index,
+    Receipt, Transaction,
 };
 
 use crate::error::StoreError;
@@ -169,11 +169,16 @@ pub trait StoreEngine: Debug + Send {
         }
         Ok(())
     }
-    /// Updates the value of the chain id
-    fn update_chain_id(&mut self, chain_id: U256) -> Result<(), StoreError>;
+
+    /// Stores the chain configuration values, should only be called once after reading the genesis file
+    /// Ignores previously stored values if present
+    fn set_chain_config(&mut self, chain_config: &ChainConfig) -> Result<(), StoreError>;
 
     /// Obtain the current chain id
     fn get_chain_id(&self) -> Result<Option<U256>, StoreError>;
+
+    /// Obtain the timestamp at which the cancun fork was activated
+    fn get_cancun_time(&self) -> Result<Option<u64>, StoreError>;
 
     // Update earliest block number
     fn update_earliest_block_number(&mut self, block_number: BlockNumber)

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -1,12 +1,10 @@
-use std::fmt::Debug;
-
 use bytes::Bytes;
-use ethereum_types::{Address, H256, U256};
-
 use ethereum_rust_core::types::{
     Account, AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, ChainConfig, Index,
     Receipt, Transaction,
 };
+use ethereum_types::{Address, H256, U256};
+use std::fmt::Debug;
 
 use crate::error::StoreError;
 
@@ -23,6 +21,11 @@ pub trait StoreEngine: Debug + Send {
 
     /// Remove account info
     fn remove_account_info(&mut self, address: Address) -> Result<(), StoreError>;
+
+    /// Iterate all accounts in the storage
+    fn account_infos_iter(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = (Address, AccountInfo)>>, StoreError>;
 
     /// Add block header
     fn add_block_header(
@@ -124,7 +127,7 @@ pub trait StoreEngine: Debug + Send {
         &mut self,
         address: Address,
         storage_key: H256,
-        storage_value: H256,
+        storage_value: U256,
     ) -> Result<(), StoreError>;
 
     // Obtain storage value
@@ -132,10 +135,16 @@ pub trait StoreEngine: Debug + Send {
         &self,
         address: Address,
         storage_key: H256,
-    ) -> Result<Option<H256>, StoreError>;
+    ) -> Result<Option<U256>, StoreError>;
 
     // Add storage value
     fn remove_account_storage(&mut self, address: Address) -> Result<(), StoreError>;
+
+    // Get full account storage
+    fn account_storage_iter(
+        &mut self,
+        address: Address,
+    ) -> Result<Box<dyn Iterator<Item = (H256, U256)>>, StoreError>;
 
     /// Stores account in db (including info, code & storage)
     fn add_account(&mut self, address: Address, account: Account) -> Result<(), StoreError> {

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -174,4 +174,38 @@ pub trait StoreEngine: Debug + Send {
 
     /// Obtain the current chain id
     fn get_chain_id(&self) -> Result<Option<U256>, StoreError>;
+
+    // Update earliest block number
+    fn update_earliest_block_number(&mut self, block_number: BlockNumber)
+        -> Result<(), StoreError>;
+
+    // Obtain earliest block number
+    fn get_earliest_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
+
+    // Update finalized block number
+    fn update_finalized_block_number(
+        &mut self,
+        block_number: BlockNumber,
+    ) -> Result<(), StoreError>;
+
+    // Obtain finalized block number
+    fn get_finalized_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
+
+    // Update safe block number
+    fn update_safe_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError>;
+
+    // Obtain safe block number
+    fn get_safe_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
+
+    // Update latest block number
+    fn update_latest_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError>;
+
+    // Obtain latest block number
+    fn get_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
+
+    // Update pending block number
+    fn update_pending_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError>;
+
+    // Obtain pending block number
+    fn get_pending_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
 }

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -1,7 +1,7 @@
 use crate::error::StoreError;
 use bytes::Bytes;
 use ethereum_rust_core::types::{
-    AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, Index, Receipt,
+    AccountInfo, BlockBody, BlockHash, BlockHeader, BlockNumber, ChainConfig, Index, Receipt,
 };
 use ethereum_types::{Address, H256, U256};
 use std::{collections::HashMap, fmt::Debug};
@@ -31,6 +31,7 @@ struct ChainData {
     safe_block_number: Option<BlockNumber>,
     latest_block_number: Option<BlockNumber>,
     pending_block_number: Option<BlockNumber>,
+    cancun_time: Option<u64>,
 }
 
 impl Store {
@@ -174,13 +175,20 @@ impl StoreEngine for Store {
         Ok(())
     }
 
-    fn update_chain_id(&mut self, chain_id: U256) -> Result<(), StoreError> {
-        self.chain_data.chain_id.replace(chain_id);
+    fn set_chain_config(&mut self, chain_config: &ChainConfig) -> Result<(), StoreError> {
+        // Store cancun timestamp
+        self.chain_data.cancun_time = chain_config.cancun_time;
+        // Store chain id
+        self.chain_data.chain_id.replace(chain_config.chain_id);
         Ok(())
     }
 
     fn get_chain_id(&self) -> Result<Option<U256>, StoreError> {
         Ok(self.chain_data.chain_id)
+    }
+
+    fn get_cancun_time(&self) -> Result<Option<u64>, StoreError> {
+        Ok(self.chain_data.cancun_time)
     }
 
     fn update_earliest_block_number(

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -26,6 +26,11 @@ pub struct Store {
 #[derive(Default)]
 struct ChainData {
     chain_id: Option<U256>,
+    earliest_block_number: Option<BlockNumber>,
+    finalized_block_number: Option<BlockNumber>,
+    safe_block_number: Option<BlockNumber>,
+    latest_block_number: Option<BlockNumber>,
+    pending_block_number: Option<BlockNumber>,
 }
 
 impl Store {
@@ -176,6 +181,57 @@ impl StoreEngine for Store {
 
     fn get_chain_id(&self) -> Result<Option<U256>, StoreError> {
         Ok(self.chain_data.chain_id)
+    }
+
+    fn update_earliest_block_number(
+        &mut self,
+        block_number: BlockNumber,
+    ) -> Result<(), StoreError> {
+        self.chain_data.earliest_block_number.replace(block_number);
+        Ok(())
+    }
+
+    fn get_earliest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        Ok(self.chain_data.earliest_block_number)
+    }
+
+    fn update_finalized_block_number(
+        &mut self,
+        block_number: BlockNumber,
+    ) -> Result<(), StoreError> {
+        self.chain_data.finalized_block_number.replace(block_number);
+        Ok(())
+    }
+
+    fn get_finalized_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        Ok(self.chain_data.finalized_block_number)
+    }
+
+    fn update_safe_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.chain_data.safe_block_number.replace(block_number);
+        Ok(())
+    }
+
+    fn get_safe_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        Ok(self.chain_data.safe_block_number)
+    }
+
+    fn update_latest_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.chain_data.latest_block_number.replace(block_number);
+        Ok(())
+    }
+
+    fn get_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        Ok(self.chain_data.latest_block_number)
+    }
+
+    fn update_pending_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.chain_data.pending_block_number.replace(block_number);
+        Ok(())
+    }
+
+    fn get_pending_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        Ok(self.chain_data.pending_block_number)
     }
 }
 

--- a/crates/storage/engines/libmdbx.rs
+++ b/crates/storage/engines/libmdbx.rs
@@ -211,6 +211,92 @@ impl StoreEngine for Store {
                 .map_err(|_| StoreError::DecodeError),
         }
     }
+
+    fn update_earliest_block_number(
+        &mut self,
+        block_number: BlockNumber,
+    ) -> Result<(), StoreError> {
+        self.write::<ChainData>(
+            ChainDataIndex::EarliestBlockNumber,
+            block_number.encode_to_vec(),
+        )
+    }
+
+    fn get_earliest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        match self.read::<ChainData>(ChainDataIndex::EarliestBlockNumber)? {
+            None => Ok(None),
+            Some(ref rlp) => RLPDecode::decode(rlp)
+                .map(Some)
+                .map_err(|_| StoreError::DecodeError),
+        }
+    }
+
+    fn update_finalized_block_number(
+        &mut self,
+        block_number: BlockNumber,
+    ) -> Result<(), StoreError> {
+        self.write::<ChainData>(
+            ChainDataIndex::FinalizedBlockNumber,
+            block_number.encode_to_vec(),
+        )
+    }
+
+    fn get_finalized_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        match self.read::<ChainData>(ChainDataIndex::FinalizedBlockNumber)? {
+            None => Ok(None),
+            Some(ref rlp) => RLPDecode::decode(rlp)
+                .map(Some)
+                .map_err(|_| StoreError::DecodeError),
+        }
+    }
+
+    fn update_safe_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.write::<ChainData>(
+            ChainDataIndex::SafeBlockNumber,
+            block_number.encode_to_vec(),
+        )
+    }
+
+    fn get_safe_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        match self.read::<ChainData>(ChainDataIndex::SafeBlockNumber)? {
+            None => Ok(None),
+            Some(ref rlp) => RLPDecode::decode(rlp)
+                .map(Some)
+                .map_err(|_| StoreError::DecodeError),
+        }
+    }
+
+    fn update_latest_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.write::<ChainData>(
+            ChainDataIndex::LatestBlockNumber,
+            block_number.encode_to_vec(),
+        )
+    }
+
+    fn get_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        match self.read::<ChainData>(ChainDataIndex::LatestBlockNumber)? {
+            None => Ok(None),
+            Some(ref rlp) => RLPDecode::decode(rlp)
+                .map(Some)
+                .map_err(|_| StoreError::DecodeError),
+        }
+    }
+
+    fn update_pending_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.write::<ChainData>(
+            ChainDataIndex::PendingBlockNumber,
+            block_number.encode_to_vec(),
+        )
+    }
+
+    fn get_pending_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        match self.read::<ChainData>(ChainDataIndex::PendingBlockNumber)? {
+            None => Ok(None),
+            Some(ref rlp) => RLPDecode::decode(rlp)
+                .map(Some)
+                .map_err(|_| StoreError::DecodeError),
+        }
+    }
 }
 
 impl Debug for Store {
@@ -317,6 +403,11 @@ impl From<AccountStorageValueBytes> for H256 {
 // (TODO: Remove this comment once full) Will store chain-specific data such as chain id and latest finalized/pending/safe block number
 pub enum ChainDataIndex {
     ChainId = 0,
+    EarliestBlockNumber = 1,
+    FinalizedBlockNumber = 2,
+    SafeBlockNumber = 3,
+    LatestBlockNumber = 4,
+    PendingBlockNumber = 5,
 }
 
 impl Encodable for ChainDataIndex {

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -6,8 +6,8 @@ use self::error::StoreError;
 use bytes::Bytes;
 use engines::api::StoreEngine;
 use ethereum_rust_core::types::{
-    Account, AccountInfo, Block, BlockBody, BlockHash, BlockHeader, BlockNumber, Genesis, Index,
-    Receipt, Transaction,
+    Account, AccountInfo, Block, BlockBody, BlockHash, BlockHeader, BlockNumber, ChainConfig,
+    Genesis, Index, Receipt, Transaction,
 };
 use ethereum_types::{Address, H256, U256};
 use std::fmt::Debug;
@@ -246,8 +246,8 @@ impl Store {
             self.add_account(address, account.into())?;
         }
 
-        // Store chain info
-        self.update_chain_id(genesis.config.chain_id)
+        // Set chain config
+        self.set_chain_config(&genesis.config)
     }
 
     pub fn get_transaction_by_hash(
@@ -298,12 +298,16 @@ impl Store {
             .increment_balance(address, amount)
     }
 
-    pub fn update_chain_id(&self, chain_id: U256) -> Result<(), StoreError> {
-        self.engine.lock().unwrap().update_chain_id(chain_id)
+    pub fn set_chain_config(&self, chain_config: &ChainConfig) -> Result<(), StoreError> {
+        self.engine.lock().unwrap().set_chain_config(chain_config)
     }
 
     pub fn get_chain_id(&self) -> Result<Option<U256>, StoreError> {
         self.engine.lock().unwrap().get_chain_id()
+    }
+
+    pub fn get_cancun_time(&self) -> Result<Option<u64>, StoreError> {
+        self.engine.lock().unwrap().get_cancun_time()
     }
 
     pub fn update_earliest_block_number(
@@ -409,7 +413,8 @@ mod tests {
         test_store_account_storage(store.clone());
         test_remove_account_storage(store.clone());
         test_increment_balance(store.clone());
-        test_store_chain_data(store.clone());
+        test_store_chain_config(store.clone());
+        test_store_block_tags(store.clone());
     }
 
     fn test_store_account(store: Store) {
@@ -661,15 +666,30 @@ mod tests {
         assert_eq!(stored_account_info.balance, 75.into());
     }
 
-    fn test_store_chain_data(store: Store) {
+    fn test_store_chain_config(store: Store) {
         let chain_id = U256::from_dec_str("46").unwrap();
+        let cancun_time = 12;
+        let chain_config = ChainConfig {
+            chain_id,
+            cancun_time: Some(cancun_time),
+            ..Default::default()
+        };
+
+        store.set_chain_config(&chain_config).unwrap();
+
+        let stored_chain_id = store.get_chain_id().unwrap().unwrap();
+        let stored_cancun_time = store.get_cancun_time().unwrap().unwrap();
+
+        assert_eq!(chain_id, stored_chain_id);
+        assert_eq!(cancun_time, stored_cancun_time);
+    }
+    fn test_store_block_tags(store: Store) {
         let earliest_block_number = 0;
         let finalized_block_number = 7;
         let safe_block_number = 6;
         let latest_block_number = 8;
         let pending_block_number = 9;
 
-        store.update_chain_id(chain_id).unwrap();
         store
             .update_earliest_block_number(earliest_block_number)
             .unwrap();
@@ -684,14 +704,12 @@ mod tests {
             .update_pending_block_number(pending_block_number)
             .unwrap();
 
-        let stored_chain_id = store.get_chain_id().unwrap().unwrap();
         let stored_earliest_block_number = store.get_earliest_block_number().unwrap().unwrap();
         let stored_finalized_block_number = store.get_finalized_block_number().unwrap().unwrap();
         let stored_safe_block_number = store.get_safe_block_number().unwrap().unwrap();
         let stored_latest_block_number = store.get_latest_block_number().unwrap().unwrap();
         let stored_pending_block_number = store.get_pending_block_number().unwrap().unwrap();
 
-        assert_eq!(chain_id, stored_chain_id);
         assert_eq!(earliest_block_number, stored_earliest_block_number);
         assert_eq!(finalized_block_number, stored_finalized_block_number);
         assert_eq!(safe_block_number, stored_safe_block_number);

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -305,6 +305,67 @@ impl Store {
     pub fn get_chain_id(&self) -> Result<Option<U256>, StoreError> {
         self.engine.lock().unwrap().get_chain_id()
     }
+
+    pub fn update_earliest_block_number(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<(), StoreError> {
+        self.engine
+            .lock()
+            .unwrap()
+            .update_earliest_block_number(block_number)
+    }
+
+    pub fn get_earliest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        self.engine.lock().unwrap().get_earliest_block_number()
+    }
+
+    pub fn update_finalized_block_number(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<(), StoreError> {
+        self.engine
+            .lock()
+            .unwrap()
+            .update_finalized_block_number(block_number)
+    }
+
+    pub fn get_finalized_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        self.engine.lock().unwrap().get_finalized_block_number()
+    }
+
+    pub fn update_safe_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.engine
+            .lock()
+            .unwrap()
+            .update_safe_block_number(block_number)
+    }
+
+    pub fn get_safe_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        self.engine.lock().unwrap().get_safe_block_number()
+    }
+
+    pub fn update_latest_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.engine
+            .lock()
+            .unwrap()
+            .update_latest_block_number(block_number)
+    }
+
+    pub fn get_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        self.engine.lock().unwrap().get_latest_block_number()
+    }
+
+    pub fn update_pending_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.engine
+            .lock()
+            .unwrap()
+            .update_pending_block_number(block_number)
+    }
+
+    pub fn get_pending_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
+        self.engine.lock().unwrap().get_pending_block_number()
+    }
 }
 
 #[cfg(test)]
@@ -602,11 +663,39 @@ mod tests {
 
     fn test_store_chain_data(store: Store) {
         let chain_id = U256::from_dec_str("46").unwrap();
+        let earliest_block_number = 0;
+        let finalized_block_number = 7;
+        let safe_block_number = 6;
+        let latest_block_number = 8;
+        let pending_block_number = 9;
 
         store.update_chain_id(chain_id).unwrap();
+        store
+            .update_earliest_block_number(earliest_block_number)
+            .unwrap();
+        store
+            .update_finalized_block_number(finalized_block_number)
+            .unwrap();
+        store.update_safe_block_number(safe_block_number).unwrap();
+        store
+            .update_latest_block_number(latest_block_number)
+            .unwrap();
+        store
+            .update_pending_block_number(pending_block_number)
+            .unwrap();
 
         let stored_chain_id = store.get_chain_id().unwrap().unwrap();
+        let stored_earliest_block_number = store.get_earliest_block_number().unwrap().unwrap();
+        let stored_finalized_block_number = store.get_finalized_block_number().unwrap().unwrap();
+        let stored_safe_block_number = store.get_safe_block_number().unwrap().unwrap();
+        let stored_latest_block_number = store.get_latest_block_number().unwrap().unwrap();
+        let stored_pending_block_number = store.get_pending_block_number().unwrap().unwrap();
 
         assert_eq!(chain_id, stored_chain_id);
+        assert_eq!(earliest_block_number, stored_earliest_block_number);
+        assert_eq!(finalized_block_number, stored_finalized_block_number);
+        assert_eq!(safe_block_number, stored_safe_block_number);
+        assert_eq!(latest_block_number, stored_latest_block_number);
+        assert_eq!(pending_block_number, stored_pending_block_number);
     }
 }


### PR DESCRIPTION
**Motivation**

Tests on EF tests on vectors/shanghai/eip4895_withdrawals are failing now that we check for the post_state's correctness.


Withdrawals are processed by incrementing the balance of the involved accounts. We are modifying the DB in the State directly instead of using a State method that writes to the cache.

**Description**


Works on: https://github.com/lambdaclass/ethereum_rust/issues/22

