### PR TITLE
fix: withdrawal balance increments should also be written in the State's cache

### DIFF
--- a/cmd/ef_tests/test_runner.rs
+++ b/cmd/ef_tests/test_runner.rs
@@ -113,6 +113,7 @@ fn check_poststate_against_db(test_key: &str, post: &HashMap<Address, Account>, 
             "Mismatched account code for code hash {code_hash} test:{test_key}"
         );
         // Check storage
+
         for (key, value) in expected_account.storage {
             let db_storage_value = db
                 .get_storage_at(*addr, key)

--- a/cmd/ef_tests/test_runner.rs
+++ b/cmd/ef_tests/test_runner.rs
@@ -139,7 +139,6 @@ fn check_poststate_against_db(test_key: &str, test: &TestUnit, db: &Store) {
             "Mismatched account code for code hash {code_hash} test:{test_key}"
         );
         // Check storage
-
         for (key, value) in expected_account.storage {
             let db_storage_value = db
                 .get_storage_at(*addr, key)

--- a/cmd/ef_tests/tests/shanghai.rs
+++ b/cmd/ef_tests/tests/shanghai.rs
@@ -22,6 +22,7 @@ datatest_stable::harness!(
     // parse_and_execute,
     // "vectors/shanghai/eip3860_initcode/",
     // r"^.*/*",
+    // TODO: Get withdrawals/self_destructing_account.json test to pass
     parse_and_execute,
     "vectors/shanghai/eip4895_withdrawals/",
     r"^(?!.*withdrawals/self_destructing_account\.json$).*"

--- a/cmd/ef_tests/tests/shanghai.rs
+++ b/cmd/ef_tests/tests/shanghai.rs
@@ -22,7 +22,7 @@ datatest_stable::harness!(
     // parse_and_execute,
     // "vectors/shanghai/eip3860_initcode/",
     // r"^.*/*",
-    //parse_and_execute,
-    //"vectors/shanghai/eip4895_withdrawals/",
-    //r"^.*/*",
+    parse_and_execute,
+    "vectors/shanghai/eip4895_withdrawals/",
+    r"^.*/*",
 );

--- a/cmd/ef_tests/tests/shanghai.rs
+++ b/cmd/ef_tests/tests/shanghai.rs
@@ -24,5 +24,5 @@ datatest_stable::harness!(
     // r"^.*/*",
     parse_and_execute,
     "vectors/shanghai/eip4895_withdrawals/",
-    r"^.*/*",
+    r"^(?!.*withdrawals/self_destructing_account\.json$).*"
 );

--- a/crates/core/types/block.rs
+++ b/crates/core/types/block.rs
@@ -322,7 +322,9 @@ pub struct Withdrawal {
     #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub validator_index: u64,
     pub address: Address,
-    pub amount: U256,
+    //TODO: According to the spec this should be a u64 https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4895.md
+    #[serde(with = "crate::serde_utils::u64::hex_str")]
+    pub amount: u64,
 }
 
 impl RLPEncode for Withdrawal {

--- a/crates/core/types/block.rs
+++ b/crates/core/types/block.rs
@@ -322,7 +322,6 @@ pub struct Withdrawal {
     #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub validator_index: u64,
     pub address: Address,
-    //TODO: According to the spec this should be a u64 https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4895.md
     #[serde(with = "crate::serde_utils::u64::hex_str")]
     pub amount: u64,
 }

--- a/crates/core/types/block.rs
+++ b/crates/core/types/block.rs
@@ -511,7 +511,7 @@ mod test {
             index: 0x00,
             validator_index: 0x00,
             address: H160::from_slice(&hex!("c94f5374fce5edbc8e2a8697c15331677e6ebf0b")),
-            amount: 0x00 as u64,
+            amount: 0x00_u64,
         }];
         let expected_root = H256::from_slice(&hex!(
             "48a703da164234812273ea083e4ec3d09d028300cd325b46a6a75402e5a7ab95"

--- a/crates/core/types/block.rs
+++ b/crates/core/types/block.rs
@@ -511,7 +511,7 @@ mod test {
             index: 0x00,
             validator_index: 0x00,
             address: H160::from_slice(&hex!("c94f5374fce5edbc8e2a8697c15331677e6ebf0b")),
-            amount: 0x00.into(),
+            amount: 0x00 as u64,
         }];
         let expected_root = H256::from_slice(&hex!(
             "48a703da164234812273ea083e4ec3d09d028300cd325b46a6a75402e5a7ab95"

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -248,15 +248,18 @@ pub fn process_withdrawals(
     state: &mut EvmState,
     withdrawals: &[Withdrawal],
 ) -> Result<(), StoreError> {
-    let mut balance_increments = vec![];
-    for withdrawal in withdrawals {
-        if withdrawal.amount > 0 {
-            balance_increments.push((
+    //balance_increments is a vector of tuples (Address, increment as u128)
+    let balance_increments = withdrawals
+        .iter()
+        .filter(|withdrawal| withdrawal.amount > 0)
+        .map(|withdrawal| {
+            (
                 RevmAddress::from_slice(withdrawal.address.as_bytes()),
                 (withdrawal.amount as u128 * GWEI_TO_WEI as u128),
-            ));
-        }
-    }
+            )
+        })
+        .collect::<Vec<_>>();
+
     state.0.increment_balances(balance_increments)?;
     Ok(())
 }

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -56,7 +56,7 @@ pub fn execute_block(block: &Block, state: &mut EvmState, spec_id: SpecId) -> Re
 
     apply_state_transitions(state)?;
     if let Some(withdrawals) = &block.body.withdrawals {
-        process_withdrawals(state.database(), withdrawals)?;
+        process_withdrawals(state, withdrawals)?;
     }
     apply_state_transitions(state)?;
     Ok(())
@@ -244,12 +244,20 @@ pub fn apply_state_transitions(state: &mut EvmState) -> Result<(), StoreError> {
 }
 
 /// Processes a block's withdrawals, updating the account balances in the state
-pub fn process_withdrawals(state: &Store, withdrawals: &[Withdrawal]) -> Result<(), StoreError> {
+pub fn process_withdrawals(
+    state: &mut EvmState,
+    withdrawals: &[Withdrawal],
+) -> Result<(), StoreError> {
+    let mut balance_increments = vec![];
     for withdrawal in withdrawals {
-        if !withdrawal.amount.is_zero() {
-            state.increment_balance(withdrawal.address, withdrawal.amount * GWEI_TO_WEI)?
+        if withdrawal.amount > 0 {
+            balance_increments.push((
+                RevmAddress::from_slice(withdrawal.address.as_bytes()),
+                (withdrawal.amount as u128 * GWEI_TO_WEI as u128),
+            ));
         }
     }
+    state.0.increment_balances(balance_increments)?;
     Ok(())
 }
 


### PR DESCRIPTION
Motivation

Tests on EF tests on vectors/shanghai/eip4895_withdrawals are failing now that we check for the post_state's correctness.

Withdrawals are processed by incrementing the balance of the involved accounts. We are modifying the DB directly instead of using a State method that writes to the cache.

Description

Changes the method used in `process_withdrawals` from:


```rust
ethereum_rust_storage::Store

pub fn increment_balance(&self, address: Address, amount: U256) -> Result<(), StoreError>
```
to:

```rust
revm::db::states::state::State

impl<DB> State<DB>
pub fn increment_balances(&mut self, balances: impl IntoIterator<Item = (Address, u128)>) -> Result<(), DB::Error>
```

Changes the type of withdrawal amount from U256 to u64 as specified in the EIP https://github.com/ethereum/EIPs/blob/233696d2599e8ad5213a3f26ad1cdf2d8b740be9/EIPS/eip-4895.md?plain=1#L48C1-L48C76

Gets all tests from withdrawals to pass except the one using self_destructs which was excluded from the test name regex until that issue is also fixed.

Works on: https://github.com/lambdaclass/ethereum_rust/issues/22

