### PR TITLE
fix: create ordered trie when computing roots for transactions, receipts & withdrawals

### DIFF
--- a/crates/core/types/block.rs
+++ b/crates/core/types/block.rs
@@ -205,67 +205,37 @@ impl BlockBody {
     }
 
     pub fn compute_transactions_root(&self) -> H256 {
-        let transactions_iter: Vec<_> = self
-            .transactions
-            .iter()
-            .enumerate()
-            .map(|(i, tx)| {
-                // Key: RLP(tx_index)
-                let mut k = Vec::new();
-                i.encode(&mut k);
-
-                // Value: tx_type || RLP(tx)  if tx_type != 0
-                //                   RLP(tx)  else
-                let mut v = Vec::new();
-                tx.encode(&mut v);
-
-                (k, v)
-            })
-            .collect();
-        let root = PatriciaMerkleTree::<_, _, Keccak256>::compute_hash_from_sorted_iter(
-            &transactions_iter,
-        );
+        let mut trie = PatriciaMerkleTree::<Vec<u8>, Vec<u8>, Keccak256>::new();
+        for (idx, tx) in self.transactions.iter().enumerate() {
+            // Key: RLP(tx_index)
+            // Value: tx_type || RLP(tx)  if tx_type != 0
+            //                   RLP(tx)  else
+            trie.insert(idx.encode_to_vec(), tx.encode_to_vec());
+        }
+        let &root = trie.compute_hash();
         H256(root.into())
     }
 }
 
 pub fn compute_receipts_root(receipts: &[Receipt]) -> H256 {
-    let receipts_iter: Vec<_> = receipts
-        .iter()
-        .enumerate()
-        .map(|(i, receipt)| {
-            // Key: RLP(index)
-            let mut k = Vec::new();
-            i.encode(&mut k);
-
-            // Value: tx_type || RLP(receipt)  if tx_type != 0
-            //                   RLP(receipt)  else
-            let mut v = Vec::new();
-            receipt.encode(&mut v);
-
-            (k, v)
-        })
-        .collect();
-    let root = PatriciaMerkleTree::<_, _, Keccak256>::compute_hash_from_sorted_iter(&receipts_iter);
+    let mut trie = PatriciaMerkleTree::<Vec<u8>, Vec<u8>, Keccak256>::new();
+    for (idx, receipt) in receipts.iter().enumerate() {
+        // Key: RLP(index)
+        // Value: tx_type || RLP(receipt)  if tx_type != 0
+        //                   RLP(receipt)  else
+        trie.insert(idx.encode_to_vec(), receipt.encode_to_vec());
+    }
+    let &root = trie.compute_hash();
     H256(root.into())
 }
 
 // See [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895)
 pub fn compute_withdrawals_root(withdrawals: &[Withdrawal]) -> H256 {
-    let withdrawals_iter: Vec<_> = withdrawals
-        .iter()
-        .enumerate()
-        .map(|(idx, withdrawal)| {
-            let mut key = Vec::new();
-            idx.encode(&mut key);
-            let mut val = Vec::new();
-            withdrawal.encode(&mut val);
-
-            (key, val)
-        })
-        .collect();
-    let root =
-        PatriciaMerkleTree::<_, _, Keccak256>::compute_hash_from_sorted_iter(&withdrawals_iter);
+    let mut trie = PatriciaMerkleTree::<Vec<u8>, Vec<u8>, Keccak256>::new();
+    for (idx, withdrawal) in withdrawals.iter().enumerate() {
+        trie.insert(idx.encode_to_vec(), withdrawal.encode_to_vec());
+    }
+    let &root = trie.compute_hash();
     H256(root.into())
 }
 


### PR DESCRIPTION
**Motivation**

These roots are currently being calculated using `from_sorted_iter` but without being sorted beforehand. This PR replaces this behavior with inserting directly into the trie to ensure that it is ordered, then computing the root (The same fix that has been previously applied to storage root)

**Description**

Fixes `compute_transactions_root`, `compute_receipts_root` & `compute_withdrawals_root`
<!-- A clear and concise general description of the changes this PR introduces -->

**Notes**

After this change, the payloads created by kurtosis local net now pass the block hash validations in `engine_NewPayloadV3`
<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but is needed for #51 

