### PR TITLE
feat: pass SpecId to tests and to execute_block

### DIFF
--- a/cmd/ef_tests/test_runner.rs
+++ b/cmd/ef_tests/test_runner.rs
@@ -10,7 +10,7 @@ use ethereum_rust_evm::{evm_state, execute_block, EvmState, SpecId};
 use ethereum_rust_storage::{EngineType, Store};
 
 /// Tests the execute_block function
-pub fn execute_test(test_key: &str, test: &TestUnit) {
+pub fn execute_test(test_key: &str, test: &TestUnit, spec_id: SpecId) {
     // Build pre state
     let mut evm_state = build_evm_state_for_test(test);
     let blocks = test.blocks.clone();
@@ -20,11 +20,8 @@ pub fn execute_test(test_key: &str, test: &TestUnit) {
 
     // Execute all blocks in test
     for block in blocks.iter() {
-        let execution_result = execute_block(
-            &block.block().clone().into(),
-            &mut evm_state,
-            SpecId::CANCUN,
-        );
+        let execution_result =
+            execute_block(&block.block().clone().into(), &mut evm_state, spec_id);
         if block.expect_exception.is_some() {
             assert!(
                 execution_result.is_err(),

--- a/cmd/ef_tests/tests/cancun.rs
+++ b/cmd/ef_tests/tests/cancun.rs
@@ -1,3 +1,4 @@
+use ethereum_rust_evm::SpecId;
 use std::path::Path;
 
 use ef_tests::test_runner::{execute_test, parse_test_file, validate_test};
@@ -6,8 +7,13 @@ fn parse_and_execute(path: &Path) -> datatest_stable::Result<()> {
     let tests = parse_test_file(path);
 
     for (test_key, test) in tests {
+        let spec = match &*test.network {
+            "Shanghai" => SpecId::SHANGHAI,
+            "Cancun" => SpecId::CANCUN,
+            _ => continue,
+        };
         validate_test(&test);
-        execute_test(&test_key, &test);
+        execute_test(&test_key, &test, spec);
     }
     Ok(())
 }
@@ -33,12 +39,12 @@ datatest_stable::harness!(
     parse_and_execute,
     "vectors/cancun/",
     r"eip5656_mcopy/.*/.*\.json",
-    //parse_and_execute,
-    //"vectors/cancun/",
-    //r"eip7516_blobgasfee/.*/.*\.json",
-    //parse_and_execute,
-    //"vectors/cancun/",
-    //r"eip6780_selfdestruct/.*/.*\.json",
+    parse_and_execute,
+    "vectors/cancun/",
+    r"eip7516_blobgasfee/.*/.*\.json",
+    parse_and_execute,
+    "vectors/cancun/",
+    r"eip6780_selfdestruct/.*/.*\.json",
     //parse_and_execute,
     //"vectors/cancun/",
     //r"eip4844_blobs/.*/.*\.json",

--- a/cmd/ef_tests/tests/shanghai.rs
+++ b/cmd/ef_tests/tests/shanghai.rs
@@ -1,3 +1,4 @@
+use ethereum_rust_evm::SpecId;
 use std::path::Path;
 
 use ef_tests::test_runner::{execute_test, parse_test_file, validate_test};
@@ -6,8 +7,13 @@ fn parse_and_execute(path: &Path) -> datatest_stable::Result<()> {
     let tests = parse_test_file(path);
 
     for (test_key, test) in tests {
+        let spec = match &*test.network {
+            "Shanghai" => SpecId::SHANGHAI,
+            "Cancun" => SpecId::CANCUN,
+            _ => continue,
+        };
         validate_test(&test);
-        execute_test(&test_key, &test);
+        execute_test(&test_key, &test, spec);
     }
     Ok(())
 }
@@ -16,12 +22,12 @@ datatest_stable::harness!(
     parse_and_execute,
     "vectors/shanghai/eip3855_push0/",
     r"^.*/*",
-    //parse_and_execute,
-    //"vectors/shanghai/eip3651_warm_coinbase/",
-    //r"^.*/*",
-    // parse_and_execute,
-    // "vectors/shanghai/eip3860_initcode/",
-    // r"^.*/*",
+    parse_and_execute,
+    "vectors/shanghai/eip3651_warm_coinbase/",
+    r"^.*/*",
+    parse_and_execute,
+    "vectors/shanghai/eip3860_initcode/",
+    r"^.*/*",
     // TODO: Get withdrawals/self_destructing_account.json test to pass
     parse_and_execute,
     "vectors/shanghai/eip4895_withdrawals/",

--- a/cmd/ef_tests/types.rs
+++ b/cmd/ef_tests/types.rs
@@ -19,7 +19,7 @@ pub struct TestUnit {
     #[serde(rename = "genesisRLP", with = "ethereum_rust_core::serde_utils::bytes")]
     pub genesis_rlp: Bytes,
     pub lastblockhash: serde_json::Value,
-    pub network: serde_json::Value,
+    pub network: String,
     pub post_state: HashMap<Address, Account>,
     pub pre: HashMap<Address, Account>,
     pub seal_engine: serde_json::Value,


### PR DESCRIPTION
**Motivation**

Many tests were not passing because the execution spec passed to the EVM did not match with the specified fork in the test.

For example, tests with self-destructing contracts and Shanghai spec where not passing with the hard-coded Cancun spec, because the EVM's behaviour for this opcode is different in these two forks.

**Description**

Parses the "network" value from the tests, and passes the fork spec to the EVM.
Tests which specify a network different than Cancun or Shanghai are ignored for now.

With this changes, all tests from the Shanghai test-suite are passing and all tests from the Cancun test-suite except the ones from eip4844_blobs.

fixes: https://github.com/lambdaclass/ethereum_rust/issues/99
closes: https://github.com/lambdaclass/ethereum_rust/issues/228

