### PR TITLE
fix: set chain_id in evm config before running transactions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76 as builder
+FROM rust:1.76 AS builder
 
 RUN apt-get update && apt-get install -y \
   build-essential \

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -82,10 +82,12 @@ fn run_evm(
     spec_id: SpecId,
 ) -> Result<ExecutionResult, EvmError> {
     let tx_result = {
+        let chain_id = state.database().get_chain_id()?.unwrap_or_default().low_u64();
         let mut evm = Evm::builder()
             .with_db(&mut state.0)
             .with_block_env(block_env)
             .with_tx_env(tx_env)
+            .modify_cfg_env(|cfg| cfg.chain_id = chain_id)
             .with_spec_id(spec_id)
             .reset_handler()
             .with_external_context(

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -82,7 +82,11 @@ fn run_evm(
     spec_id: SpecId,
 ) -> Result<ExecutionResult, EvmError> {
     let tx_result = {
-        let chain_id = state.database().get_chain_id()?.unwrap_or_default().low_u64();
+        let chain_id = state
+            .database()
+            .get_chain_id()?
+            .ok_or_else(|| EvmError::Custom(String::from("Missing chain id")))?
+            .low_u64();
         let mut evm = Evm::builder()
             .with_db(&mut state.0)
             .with_block_env(block_env)

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -82,16 +82,16 @@ fn run_evm(
     spec_id: SpecId,
 ) -> Result<ExecutionResult, EvmError> {
     let tx_result = {
-        let chain_id = state
-            .database()
-            .get_chain_id()?
-            .ok_or_else(|| EvmError::Custom(String::from("Missing chain id")))?
-            .low_u64();
+        let chain_id = state.database().get_chain_id()?.map(|ci| ci.low_u64());
         let mut evm = Evm::builder()
             .with_db(&mut state.0)
             .with_block_env(block_env)
             .with_tx_env(tx_env)
-            .modify_cfg_env(|cfg| cfg.chain_id = chain_id)
+            .modify_cfg_env(|cfg| {
+                if let Some(chain_id) = chain_id {
+                    cfg.chain_id = chain_id
+                }
+            })
             .with_spec_id(spec_id)
             .reset_handler()
             .with_external_context(


### PR DESCRIPTION
**Motivation**

Some transactions fail when running with kurtosis with the evm error "invalid chain id". This is because the evm uses 1 as default chain id when it is not set and then checks that the transaction's chain_id matches the one in its config when validating the transaction.

**Description**

* Fetches chain_id from the state and sets it in the evm config before running transactions
* Misc: Fixes warning on Dockerfile
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but is needed for #51 

