### PR TITLE
fix: remove duplicate block store in `engine_newPayloadV3` + update earliest and latest block number when storing genesis

### DIFF
--- a/crates/rpc/engine/mod.rs
+++ b/crates/rpc/engine/mod.rs
@@ -105,10 +105,6 @@ pub fn new_payload_v3(
     execute_block(&block, &mut evm_state(storage.clone()), SpecId::CANCUN)
         .map_err(|_| RpcErr::Vm)?;
     info!("Block with hash {block_hash} executed succesfully");
-    storage
-        .add_block_number(block_hash, block.header.number)
-        .map_err(|_| RpcErr::Internal)?;
-    storage.add_block(block).map_err(|_| RpcErr::Internal)?;
     info!("Block with hash {block_hash} added to storage");
 
     Ok(PayloadStatus::valid_with_hash(block_hash))

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -251,6 +251,8 @@ impl Store {
         let genesis_block = genesis.get_block();
 
         // Store genesis block
+        self.update_earliest_block_number(genesis_block.header.number)?;
+        self.update_latest_block_number(genesis_block.header.number)?;
         self.add_block(genesis_block)?;
 
         // Store each alloc account


### PR DESCRIPTION
**Motivation**

Fixes two small issues:

1. As the `execute_block` function now also stores the block in the db the call to `add_block` in `engine_newPaylaodV3` is redundant
2. Inability to fetch lates block when no block other than the genesis block has been executed

<!-- Why does this pull request exist? What are its goals? -->

**Description**

* Remove call to `add_block` in `engine_newPaylaodV3`
* Store the genesis block number as earliest and latest block number in the db in `Store::add_initial_state`

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->


