### PR TITLE
refactor: map common errors to RpcErr

### DIFF
--- a/crates/rpc/engine/mod.rs
+++ b/crates/rpc/engine/mod.rs
@@ -61,7 +61,7 @@ pub fn new_payload_v3(
     // Payload Validation
 
     // Check timestamp does not fall within the time frame of the Cancun fork
-    match storage.get_cancun_time().map_err(|_| RpcErr::Internal)? {
+    match storage.get_cancun_time()? {
         Some(cancun_time) if block.header.timestamp > cancun_time => {}
         _ => return Err(RpcErr::UnsuportedFork),
     }
@@ -87,10 +87,7 @@ pub fn new_payload_v3(
     }
 
     // Fetch parent block header and validate current header
-    if let Some(parent_header) = storage
-        .get_block_header(block.header.number.saturating_sub(1))
-        .map_err(|_| RpcErr::Internal)?
-    {
+    if let Some(parent_header) = storage.get_block_header(block.header.number.saturating_sub(1))? {
         if !validate_block_header(&block.header, &parent_header) {
             return Ok(PayloadStatus::invalid_with_hash(
                 parent_header.compute_block_hash(),
@@ -102,7 +99,7 @@ pub fn new_payload_v3(
 
     // Execute and store the block
     info!("Executing payload with block hash: {block_hash}");
-    execute_block(&block, &mut evm_state(storage.clone())).map_err(|_| RpcErr::Vm)?;
+    execute_block(&block, &mut evm_state(storage.clone()))?;
     info!("Block with hash {block_hash} executed succesfully");
     info!("Block with hash {block_hash} added to storage");
 

--- a/crates/rpc/eth/account.rs
+++ b/crates/rpc/eth/account.rs
@@ -68,12 +68,10 @@ pub fn get_balance(request: &GetBalanceRequest, storage: Store) -> Result<Value,
         "Requested balance of account {} at block {}",
         request.address, request.block
     );
-    let account = match storage.get_account_info(request.address) {
-        Ok(Some(account)) => account,
+    let account = match storage.get_account_info(request.address)? {
+        Some(account) => account,
         // Account not found
-        Ok(_) => return Ok(Value::Null),
-        // DB error
-        _ => return Err(RpcErr::Internal),
+        _ => return Ok(Value::Null),
     };
 
     serde_json::to_value(format!("{:#x}", account.balance)).map_err(|_| RpcErr::Internal)
@@ -84,12 +82,10 @@ pub fn get_code(request: &GetCodeRequest, storage: Store) -> Result<Value, RpcEr
         "Requested code of account {} at block {}",
         request.address, request.block
     );
-    let code = match storage.get_code_by_account_address(request.address) {
-        Ok(Some(code)) => code,
+    let code = match storage.get_code_by_account_address(request.address)? {
+        Some(code) => code,
         // Account not found
-        Ok(_) => return Ok(Value::Null),
-        // DB error
-        _ => return Err(RpcErr::Internal),
+        _ => return Ok(Value::Null),
     };
 
     serde_json::to_value(format!("0x{:x}", code)).map_err(|_| RpcErr::Internal)
@@ -100,12 +96,10 @@ pub fn get_storage_at(request: &GetStorageAtRequest, storage: Store) -> Result<V
         "Requested storage sot {} of account {} at block {}",
         request.storage_slot, request.address, request.block
     );
-    let storage_value = match storage.get_storage_at(request.address, request.storage_slot) {
-        Ok(Some(storage_value)) => storage_value,
+    let storage_value = match storage.get_storage_at(request.address, request.storage_slot)? {
+        Some(storage_value) => storage_value,
         // Account not found
-        Ok(_) => return Ok(Value::Null),
-        // DB error
-        _ => return Err(RpcErr::Internal),
+        _ => return Ok(Value::Null),
     };
 
     serde_json::to_value(format!("{:#x}", storage_value)).map_err(|_| RpcErr::Internal)

--- a/crates/rpc/eth/block.rs
+++ b/crates/rpc/eth/block.rs
@@ -226,18 +226,16 @@ pub fn get_block_by_number(
     storage: Store,
 ) -> Result<Value, RpcErr> {
     info!("Requested block with number: {}", request.block);
-    let block_number = match resolve_block_number(&request.block, &storage) {
-        Ok(Some(block_number)) => block_number,
+    let block_number = match resolve_block_number(&request.block, &storage)? {
+        Some(block_number) => block_number,
         _ => return Ok(Value::Null),
     };
-    let header = storage.get_block_header(block_number);
-    let body = storage.get_block_body(block_number);
+    let header = storage.get_block_header(block_number)?;
+    let body = storage.get_block_body(block_number)?;
     let (header, body) = match (header, body) {
-        (Ok(Some(header)), Ok(Some(body))) => (header, body),
+        (Some(header), Some(body)) => (header, body),
         // Block not found
-        (Ok(_), Ok(_)) => return Ok(Value::Null),
-        // DB error
-        _ => return Err(RpcErr::Internal),
+        _ => return Ok(Value::Null),
     };
     let block = BlockSerializable::from_block(header, body, request.hydrated);
 
@@ -246,19 +244,16 @@ pub fn get_block_by_number(
 
 pub fn get_block_by_hash(request: &GetBlockByHashRequest, storage: Store) -> Result<Value, RpcErr> {
     info!("Requested block with hash: {}", request.block);
-    let block_number = match storage.get_block_number(request.block) {
-        Ok(Some(number)) => number,
-        Ok(_) => return Ok(Value::Null),
-        _ => return Err(RpcErr::Internal),
+    let block_number = match storage.get_block_number(request.block)? {
+        Some(number) => number,
+        _ => return Ok(Value::Null),
     };
-    let header = storage.get_block_header(block_number);
-    let body = storage.get_block_body(block_number);
+    let header = storage.get_block_header(block_number)?;
+    let body = storage.get_block_body(block_number)?;
     let (header, body) = match (header, body) {
-        (Ok(Some(header)), Ok(Some(body))) => (header, body),
+        (Some(header), Some(body)) => (header, body),
         // Block not found
-        (Ok(_), Ok(_)) => return Ok(Value::Null),
-        // DB error
-        _ => return Err(RpcErr::Internal),
+        _ => return Ok(Value::Null),
     };
     let block = BlockSerializable::from_block(header, body, request.hydrated);
 
@@ -273,14 +268,13 @@ pub fn get_block_transaction_count_by_number(
         "Requested transaction count for block with number: {}",
         request.block
     );
-    let block_number = match resolve_block_number(&request.block, &storage) {
-        Ok(Some(block_number)) => block_number,
+    let block_number = match resolve_block_number(&request.block, &storage)? {
+        Some(block_number) => block_number,
         _ => return Ok(Value::Null),
     };
-    let block_body = match storage.get_block_body(block_number) {
-        Ok(Some(block_body)) => block_body,
-        Ok(_) => return Ok(Value::Null),
-        _ => return Err(RpcErr::Internal),
+    let block_body = match storage.get_block_body(block_number)? {
+        Some(block_body) => block_body,
+        _ => return Ok(Value::Null),
     };
     let transaction_count = block_body.transactions.len();
 
@@ -295,14 +289,13 @@ pub fn get_transaction_by_block_number_and_index(
         "Requested transaction at index: {} of block with number: {}",
         request.transaction_index, request.block,
     );
-    let block_number = match resolve_block_number(&request.block, &storage) {
-        Ok(Some(block_number)) => block_number,
+    let block_number = match resolve_block_number(&request.block, &storage)? {
+        Some(block_number) => block_number,
         _ => return Ok(Value::Null),
     };
-    let block_body = match storage.get_block_body(block_number) {
-        Ok(Some(block_body)) => block_body,
-        Ok(_) => return Ok(Value::Null),
-        _ => return Err(RpcErr::Internal),
+    let block_body = match storage.get_block_body(block_number)? {
+        Some(block_body) => block_body,
+        _ => return Ok(Value::Null),
     };
     let tx = match block_body.transactions.get(request.transaction_index) {
         Some(tx) => tx,
@@ -320,15 +313,13 @@ pub fn get_transaction_by_block_hash_and_index(
         "Requested transaction at index: {} of block with hash: {}",
         request.transaction_index, request.block,
     );
-    let block_number = match storage.get_block_number(request.block) {
-        Ok(Some(number)) => number,
-        Ok(_) => return Ok(Value::Null),
-        _ => return Err(RpcErr::Internal),
+    let block_number = match storage.get_block_number(request.block)? {
+        Some(number) => number,
+        _ => return Ok(Value::Null),
     };
-    let block_body = match storage.get_block_body(block_number) {
-        Ok(Some(block_body)) => block_body,
-        Ok(_) => return Ok(Value::Null),
-        _ => return Err(RpcErr::Internal),
+    let block_body = match storage.get_block_body(block_number)? {
+        Some(block_body) => block_body,
+        _ => return Ok(Value::Null),
     };
     let tx = match block_body.transactions.get(request.transaction_index) {
         Some(tx) => tx,
@@ -346,18 +337,16 @@ pub fn get_block_receipts(
         "Requested receipts for block with number: {}",
         request.block
     );
-    let block_number = match resolve_block_number(&request.block, &storage) {
-        Ok(Some(block_number)) => block_number,
+    let block_number = match resolve_block_number(&request.block, &storage)? {
+        Some(block_number) => block_number,
         _ => return Ok(Value::Null),
     };
-    let header = storage.get_block_header(block_number);
-    let body = storage.get_block_body(block_number);
+    let header = storage.get_block_header(block_number)?;
+    let body = storage.get_block_body(block_number)?;
     let (header, body) = match (header, body) {
-        (Ok(Some(header)), Ok(Some(body))) => (header, body),
+        (Some(header), Some(body)) => (header, body),
         // Block not found
-        (Ok(_), Ok(_)) => return Ok(Value::Null),
-        // DB error
-        _ => return Err(RpcErr::Internal),
+        _ => return Ok(Value::Null),
     };
     // Fetch receipt info from block
     let block_info = header.receipt_info();
@@ -365,10 +354,9 @@ pub fn get_block_receipts(
     let mut receipts = Vec::new();
     for (index, tx) in body.transactions.iter().enumerate() {
         let index = index as u64;
-        let receipt = match storage.get_receipt(block_number, index) {
-            Ok(Some(receipt)) => receipt,
-            Ok(_) => return Ok(Value::Null),
-            _ => return Err(RpcErr::Internal),
+        let receipt = match storage.get_receipt(block_number, index)? {
+            Some(receipt) => receipt,
+            _ => return Ok(Value::Null),
         };
         let block_info = block_info.clone();
         let tx_info = tx.receipt_info(index);
@@ -391,10 +379,9 @@ pub fn get_transaction_by_hash(
         request.transaction_hash,
     );
     let transaction: ethereum_rust_core::types::Transaction =
-        match storage.get_transaction_by_hash(request.transaction_hash) {
-            Ok(Some(transaction)) => transaction,
-            Ok(_) => return Ok(Value::Null),
-            _ => return Err(RpcErr::Internal),
+        match storage.get_transaction_by_hash(request.transaction_hash)? {
+            Some(transaction) => transaction,
+            _ => return Ok(Value::Null),
         };
 
     serde_json::to_value(transaction).map_err(|_| RpcErr::Internal)
@@ -408,25 +395,21 @@ pub fn get_transaction_receipt(
         "Requested receipt for transaction {}",
         request.transaction_hash,
     );
-    let (block_number, index) = match storage.get_transaction_location(request.transaction_hash) {
-        Ok(Some(location)) => location,
-        Ok(_) => return Ok(Value::Null),
-        _ => return Err(RpcErr::Internal),
+    let (block_number, index) = match storage.get_transaction_location(request.transaction_hash)? {
+        Some(location) => location,
+        _ => return Ok(Value::Null),
     };
-    let block_header = match storage.get_block_header(block_number) {
-        Ok(Some(block_header)) => block_header,
-        Ok(_) => return Ok(Value::Null),
-        _ => return Err(RpcErr::Internal),
+    let block_header = match storage.get_block_header(block_number)? {
+        Some(block_header) => block_header,
+        _ => return Ok(Value::Null),
     };
-    let block_body = match storage.get_block_body(block_number) {
-        Ok(Some(block_body)) => block_body,
-        Ok(_) => return Ok(Value::Null),
-        _ => return Err(RpcErr::Internal),
+    let block_body = match storage.get_block_body(block_number)? {
+        Some(block_body) => block_body,
+        _ => return Ok(Value::Null),
     };
-    let receipt = match storage.get_receipt(block_number, index) {
-        Ok(Some(receipt)) => receipt,
-        Ok(_) => return Ok(Value::Null),
-        _ => return Err(RpcErr::Internal),
+    let receipt = match storage.get_receipt(block_number, index)? {
+        Some(receipt) => receipt,
+        _ => return Ok(Value::Null),
     };
     let tx = match index
         .try_into()
@@ -452,16 +435,14 @@ pub fn create_access_list(
 ) -> Result<Value, RpcErr> {
     let block = request.block.clone().unwrap_or_default();
     info!("Requested access list creation for tx on block: {}", block);
-    let block_number = match block {
-        BlockIdentifier::Tag(_) => unimplemented!("Obtain block number from tag"),
-        BlockIdentifier::Number(block_number) => block_number,
+    let block_number = match resolve_block_number(&block, &storage)? {
+        Some(block_number) => block_number,
+        _ => return Ok(Value::Null),
     };
-    let header = match storage.get_block_header(block_number) {
-        Ok(Some(header)) => header,
+    let header = match storage.get_block_header(block_number)? {
+        Some(header) => header,
         // Block not found
-        Ok(_) => return Ok(Value::Null),
-        // DB error
-        _ => return Err(RpcErr::Internal),
+        _ => return Ok(Value::Null),
     };
     // Run transaction and obtain access list
     let (gas_used, access_list, error) = match ethereum_rust_evm::create_access_list(
@@ -469,9 +450,7 @@ pub fn create_access_list(
         &header,
         &mut evm_state(storage),
         SpecId::CANCUN,
-    )
-    .map_err(|_| RpcErr::Vm)?
-    {
+    )? {
         (
             ExecutionResult::Success {
                 reason: _,

--- a/crates/rpc/utils.rs
+++ b/crates/rpc/utils.rs
@@ -1,3 +1,5 @@
+use ethereum_rust_evm::EvmError;
+use ethereum_rust_storage::error::StoreError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -62,4 +64,17 @@ pub struct RpcErrorResponse {
     pub id: i32,
     pub jsonrpc: String,
     pub error: RpcErrorMetadata,
+}
+
+/// Failure to read from DB will always constitute an internal error
+impl From<StoreError> for RpcErr {
+    fn from(_value: StoreError) -> Self {
+        RpcErr::Internal
+    }
+}
+
+impl From<EvmError> for RpcErr {
+    fn from(_value: EvmError) -> Self {
+        RpcErr::Vm
+    }
 }


### PR DESCRIPTION
**Motivation**

Make the roc codebase less verbose by mapping common error types to their corresponding RpcErr variant

**Description**

* Implement `From<StoreError> for RpcErr`
* Implement `From<EvmError> for RpcErr`
* Remove corresponding error mapping

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but will make adding more roc endpoints a bit more easy

