### PR TITLE
fix: update latest block number when adding a block

### DIFF
--- a/cmd/ef_tests/test_runner.rs
+++ b/cmd/ef_tests/test_runner.rs
@@ -124,7 +124,6 @@ pub fn build_evm_state_for_test(test: &TestUnit) -> EvmState {
     store
         .add_block_number(test.genesis_block_header.hash, block_number)
         .unwrap();
-    let _ = store.update_latest_block_number(block_number);
     for (address, account) in &test.pre {
         let account: CoreAccount = account.clone().into();
         store

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -122,9 +122,6 @@ pub fn execute_block(block: &Block, state: &mut EvmState) -> Result<(), EvmError
     if state.database().world_state_root() == block.header.state_root {
         // Store Block in database
         state.database().add_block(block.clone())?;
-        state
-            .database()
-            .update_latest_block_number(block_header.number)?;
     } else {
         return Err(EvmError::Custom(
             "State root mismatch after executing block".into(),

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -240,7 +240,7 @@ impl Store {
         self.add_block_body(number, block.body)?;
         self.add_block_header(number, header)?;
         self.add_block_number(hash, number)?;
-        Ok(())
+        self.update_latest_block_number(number)
     }
 
     pub fn add_initial_state(&mut self, genesis: Genesis) -> Result<(), StoreError> {
@@ -252,7 +252,6 @@ impl Store {
 
         // Store genesis block
         self.update_earliest_block_number(genesis_block.header.number)?;
-        self.update_latest_block_number(genesis_block.header.number)?;
         self.add_block(genesis_block)?;
 
         // Store each alloc account


### PR DESCRIPTION
**Motivation**

When we add a block to this store this block will always become the latest block.
Previously we handled this by updating the latest block number after we added a new block but this was not consistent as we had to remember to update the last block number after each call to add block, leading to bugs.
This PR aims to solve this issue by including the update of the latest block number in the store's add block functionality.

**Description**

* Call `update_latest_block_number` in `Store::add_block`
* Remove calls to `update_latest_block_number` elsewhere
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes Closes #266 

