### PR TITLE
fix: execute blocks in chain.rlp

### DIFF
--- a/cmd/ethereum_rust/Cargo.toml
+++ b/cmd/ethereum_rust/Cargo.toml
@@ -10,6 +10,7 @@ ethereum_rust-rpc.workspace = true
 ethereum_rust-core.workspace = true
 ethereum_rust-net.workspace = true
 ethereum_rust-storage.workspace = true
+ethereum_rust-evm.workspace = true
 
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/cmd/ethereum_rust/ethereum_rust.rs
+++ b/cmd/ethereum_rust/ethereum_rust.rs
@@ -1,4 +1,5 @@
 use ethereum_rust_core::types::{Block, Genesis};
+use ethereum_rust_evm::{evm_state, execute_block};
 use ethereum_rust_net::bootnode::BootNode;
 use ethereum_rust_storage::{EngineType, Store};
 use std::{
@@ -85,10 +86,9 @@ async fn main() {
     if let Some(chain_rlp_path) = matches.get_one::<String>("import") {
         let blocks = read_chain_file(chain_rlp_path);
         let size = blocks.len();
+        let mut state = evm_state(store.clone());
         for block in blocks {
-            store
-                .add_block(block)
-                .expect("Failed to add block to blockchain");
+            execute_block(&block, &mut state).expect("Failed to add block to blockchain");
         }
         info!("Added {} blocks to blockchain", size);
     }


### PR DESCRIPTION
**Motivation**

When we import the chain.rlp we add the blocks to the db but we don't execute the blocks so the accounts never get updated. This PR aims to fix this by executing each block in the chain.

**Description**

* Replace `add_block` with `execute_block` when consuming blocks imported from the chain rlp file

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but makes hive test `eth_getBalance/get-balance` pass

