### PR TITLE
fix: `eth_getBalance`, `eth_getCode` & `eth_getStorageAt`: return default value if account is not found

### DIFF
--- a/crates/rpc/eth/account.rs
+++ b/crates/rpc/eth/account.rs
@@ -68,13 +68,10 @@ pub fn get_balance(request: &GetBalanceRequest, storage: Store) -> Result<Value,
         "Requested balance of account {} at block {}",
         request.address, request.block
     );
-    let account = match storage.get_account_info(request.address)? {
-        Some(account) => account,
-        // Account not found
-        _ => return Ok(Value::Null),
-    };
+    let account = storage.get_account_info(request.address)?;
+    let balance = account.map(|acc| acc.balance).unwrap_or_default();
 
-    serde_json::to_value(format!("{:#x}", account.balance)).map_err(|_| RpcErr::Internal)
+    serde_json::to_value(format!("{:#x}", balance)).map_err(|_| RpcErr::Internal)
 }
 
 pub fn get_code(request: &GetCodeRequest, storage: Store) -> Result<Value, RpcErr> {

--- a/crates/rpc/eth/account.rs
+++ b/crates/rpc/eth/account.rs
@@ -79,11 +79,9 @@ pub fn get_code(request: &GetCodeRequest, storage: Store) -> Result<Value, RpcEr
         "Requested code of account {} at block {}",
         request.address, request.block
     );
-    let code = match storage.get_code_by_account_address(request.address)? {
-        Some(code) => code,
-        // Account not found
-        _ => return Ok(Value::Null),
-    };
+    let code = storage
+        .get_code_by_account_address(request.address)?
+        .unwrap_or_default();
 
     serde_json::to_value(format!("0x{:x}", code)).map_err(|_| RpcErr::Internal)
 }
@@ -93,11 +91,9 @@ pub fn get_storage_at(request: &GetStorageAtRequest, storage: Store) -> Result<V
         "Requested storage sot {} of account {} at block {}",
         request.storage_slot, request.address, request.block
     );
-    let storage_value = match storage.get_storage_at(request.address, request.storage_slot)? {
-        Some(storage_value) => storage_value,
-        // Account not found
-        _ => return Ok(Value::Null),
-    };
+    let storage_value = storage
+        .get_storage_at(request.address, request.storage_slot)?
+        .unwrap_or_default();
 
     serde_json::to_value(format!("{:#x}", storage_value)).map_err(|_| RpcErr::Internal)
 }


### PR DESCRIPTION
**Motivation**

Rpc endpoint `eth_getBalance` should return 0 if the account is not present in the storage.
Rpc endpoint `eth_getCode` should return empty bytes  if the account is not present in the storage.
Rpc endpoint `eth_getStorageAt` should return 0 if the account or storage slot is not present in the storage.
<!-- Why does this pull request exist? What are its goals? -->

**Description**

* `eth_getBalance`: return zero if the account is not part of the state
* `eth_getCode`: return empty bytes if the account is not part of the state
* `eth_getStorageAt`: return zero if the account  or storage slot is not part of the state
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but makes hive test `eth_getBalance/get-balance-unknown-account` & `eth_getCode/get-code-unknown-account` pass. (`eth_getStorageAt/get-storage-unknown-account` would also pass if it weren't for formatting differences)

