### PR TITLE
fix: error code for `Invalid params` rpc  error

### DIFF
--- a/crates/rpc/utils.rs
+++ b/crates/rpc/utils.rs
@@ -19,7 +19,7 @@ impl From<RpcErr> for RpcErrorMetadata {
                 message: "Method not found".to_string(),
             },
             RpcErr::BadParams => RpcErrorMetadata {
-                code: -32602,
+                code: -32000,
                 message: "Invalid params".to_string(),
             },
             RpcErr::UnsuportedFork => RpcErrorMetadata {


### PR DESCRIPTION
**Motivation**

We are getting errors when running hive tests due to differences in the error codes, ie:
```
INFO[08-15|11:46:28] API: test started                        suite=0 test=2 name="eth_getStorageAt/get-storage-invalid-key-too-large (ethereumrust)"
[c30b50f9] >>  {"jsonrpc":"2.0","id":1,"method":"eth_getStorageAt","params":["0xaa00000000000000000000000000000000000000","0x00000000000000000000000000000000000000000000000000000000000000000","latest"]}
[c30b50f9] <<  {"id":1,"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"}}
[c30b50f9] note: error messages removed from comparison
[c30b50f9] response differs from expected (-- client, ++ test):
[c30b50f9]  {
[c30b50f9]    "error": {
[c30b50f9] -    "code": -32602
[c30b50f9] +    "code": -32000
[c30b50f9]    },
[c30b50f9]    "id": 1,
[c30b50f9]    "jsonrpc": "2.0"
[c30b50f9]  }
```

**Description**
* Change the error code for `RpcErr::BadParams` to match the one expected by the hive testing suite

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but fixes hive tests that result in invalid params

