### PR TITLE
fix: conditional check in `engine_NewPayloadV3`

### DIFF
--- a/crates/rpc/engine/mod.rs
+++ b/crates/rpc/engine/mod.rs
@@ -87,7 +87,7 @@ pub fn new_payload_v3(
     }
     // Check that the incoming block extends the current chain
     let last_block_number = storage.get_latest_block_number()?.ok_or(RpcErr::Internal)?;
-    if  block.header.number <= last_block_number {
+    if block.header.number <= last_block_number {
         // Check if we already have this block stored
         if storage
             .get_block_number(block_hash)

--- a/crates/rpc/engine/mod.rs
+++ b/crates/rpc/engine/mod.rs
@@ -87,7 +87,7 @@ pub fn new_payload_v3(
     }
     // Check that the incoming block extends the current chain
     let last_block_number = storage.get_latest_block_number()?.ok_or(RpcErr::Internal)?;
-    if last_block_number <= block.header.number {
+    if  block.header.number <= last_block_number {
         // Check if we already have this block stored
         if storage
             .get_block_number(block_hash)


### PR DESCRIPTION
**Motivation**

The conditional should check the case were the block number is already part of the chain (therefore causing a potential reorg if the block is not the one we have on the state), but instead of checking that the incoming block number is lower or equal to the last block number, it checks that the last block number is lower or equal to the incoming one which doesn't make any sense

**Description**

* Fix conditional check in when checking that the incoming block extends the canonical chain in `engine_NewPaylaodV3`
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but fixes #253 

