### PR TITLE
feat: cache built dependencies on Dockerfile using cargo chef

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,34 @@
-FROM rust:1.80 AS builder
+FROM rust:1.80 AS chef
 
 RUN apt-get update && apt-get install -y \
-  build-essential \
-  libclang-dev \
-  libc6 \
-  libssl-dev \
-  ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
+	build-essential \
+	libclang-dev \
+	libc6 \
+	libssl-dev \
+	ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+RUN cargo install cargo-chef
 
-WORKDIR /usr/src/ethereum_rust
+WORKDIR /ethereum_rust
+
+FROM chef AS planner
+COPY . .
+# Determine the crates that need to be built from dependencies
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+
+COPY --from=planner /ethereum_rust/recipe.json recipe.json
+# Build dependencies only, these remained cached
+RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY . .
-
 RUN cargo build --release
 
 FROM ubuntu:24.04
-
 WORKDIR /usr/local/bin
 
-COPY --from=builder /usr/src/ethereum_rust/target/release/ethereum_rust .
-
+COPY --from=builder ethereum_rust/target/release/ethereum_rust .
 EXPOSE 8545
-
 ENTRYPOINT [ "./ethereum_rust" ]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
-
 COPY --from=planner /ethereum_rust/recipe.json recipe.json
 # Build dependencies only, these remained cached
 RUN cargo chef cook --release --recipe-path recipe.json


### PR DESCRIPTION
**Motivation**

Building the container image for the client now takes up to a minute and a half each time.

This makes testing the client in Kurtosis or with Hive really tedious.

Most of the build time is wasted building the dependencies, [cargo chef](https://hub.docker.com/r/lukemathwalker/cargo-chef) is a tool for speeding up cargo docker files by building the dependencies and the final binary in two different steps, allowing for the dependencies to be cached by the docker engine.

**Description**
In a Dockerfile, everything before a COPY statement is cached if there where no changes to the files being copied. This can be leveraged to reduce building times.

Modifies the Dockerfile to use cargo chef in a multi-stage build, caching the dependencies and significantly speeding up the image's build time.

_Build time before this PR: 92 seconds_
![image](https://github.com/user-attachments/assets/ef60204c-7253-4447-9361-79d3be714e64)

_Build time running for the first time after this PR: 102 seconds_
![image](https://github.com/user-attachments/assets/305bc81f-dc46-4807-9861-9c21e7f4c55b)

_Build time for consequent builds after chaching dependencies: 15 seconds_
![image](https://github.com/user-attachments/assets/79a40d4f-41e0-44c0-bfb2-f9bbc1d91cb5)


Closes none
