### PR TITLE
fix: declare BlockTotalDifficulties table in init_db

### DIFF
--- a/crates/storage/engines/libmdbx.rs
+++ b/crates/storage/engines/libmdbx.rs
@@ -536,6 +536,8 @@ impl Encodable for ChainDataIndex {
 pub fn init_db(path: Option<impl AsRef<Path>>) -> Database {
     let tables = [
         table_info!(BlockNumbers),
+        // TODO (#307): Remove TotalDifficulty.
+        table_info!(BlockTotalDifficulties),
         table_info!(Headers),
         table_info!(Bodies),
         table_info!(AccountInfos),


### PR DESCRIPTION
**Motivation**

Our Kurtosis environment isn't working due to a bug introduced in my last PR.

**Description**

Declares the `BlockTotalDifficulties` table in `libmdbx::init_db()`.

Closes none

