### PR TITLE
feat: add get_BlockTransactionCount rpc endpoints

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - simulation: rpc-compat
-            run_command: just run-hive ethereum/rpc-compat "/eth_chainId|eth_getTransactionByBlockHashAndIndex|eth_getTransactionByBlockNumberAndIndex|eth_getCode|eth_getStorageAt|eth_call|eth_getTransactionByHash|eth_getBlockByHash|eth_getBlockByNumber"
+            run_command: just run-hive ethereum/rpc-compat "/eth_chainId|eth_getTransactionByBlockHashAndIndex|eth_getTransactionByBlockNumberAndIndex|eth_getCode|eth_getStorageAt|eth_call|eth_getTransactionByHash|eth_getBlockByHash|eth_getBlockByNumber|eth_getBlockTransactionCountByNumber|eth_getBlockTransactionCountByHash"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/crates/rpc/eth/block.rs
+++ b/crates/rpc/eth/block.rs
@@ -11,6 +11,8 @@ use ethereum_rust_core::{
 };
 use ethereum_rust_storage::{error::StoreError, Store};
 
+use super::account::BlockIdentifierOrHash;
+
 pub struct GetBlockByNumberRequest {
     pub block: BlockIdentifier,
     pub hydrated: bool,
@@ -21,8 +23,8 @@ pub struct GetBlockByHashRequest {
     pub hydrated: bool,
 }
 
-pub struct GetBlockTransactionCountByNumberRequest {
-    pub block: BlockIdentifier,
+pub struct GetBlockTransactionCountRequest {
+    pub block: BlockIdentifierOrHash,
 }
 
 pub struct GetBlockReceiptsRequest {
@@ -89,13 +91,13 @@ impl GetBlockByHashRequest {
     }
 }
 
-impl GetBlockTransactionCountByNumberRequest {
-    pub fn parse(params: &Option<Vec<Value>>) -> Option<GetBlockTransactionCountByNumberRequest> {
+impl GetBlockTransactionCountRequest {
+    pub fn parse(params: &Option<Vec<Value>>) -> Option<GetBlockTransactionCountRequest> {
         let params = params.as_ref()?;
         if params.len() != 1 {
             return None;
         };
-        Some(GetBlockTransactionCountByNumberRequest {
+        Some(GetBlockTransactionCountRequest {
             block: serde_json::from_value(params[0].clone()).ok()?,
         })
     }
@@ -169,8 +171,8 @@ pub fn get_block_by_hash(request: &GetBlockByHashRequest, storage: Store) -> Res
     serde_json::to_value(&block).map_err(|_| RpcErr::Internal)
 }
 
-pub fn get_block_transaction_count_by_number(
-    request: &GetBlockTransactionCountByNumberRequest,
+pub fn get_block_transaction_count(
+    request: &GetBlockTransactionCountRequest,
     storage: Store,
 ) -> Result<Value, RpcErr> {
     info!(

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -16,7 +16,7 @@ use eth::{
     account::{self, GetBalanceRequest, GetCodeRequest, GetStorageAtRequest},
     block::{
         self, GetBlockByHashRequest, GetBlockByNumberRequest, GetBlockReceiptsRequest,
-        GetBlockTransactionCountByNumberRequest,
+        GetBlockTransactionCountRequest,
     },
     client,
     transaction::{
@@ -167,9 +167,14 @@ pub fn map_eth_requests(req: &RpcRequest, storage: Store) -> Result<Value, RpcEr
             account::get_storage_at(&request, storage)
         }
         "eth_getBlockTransactionCountByNumber" => {
-            let request = GetBlockTransactionCountByNumberRequest::parse(&req.params)
-                .ok_or(RpcErr::BadParams)?;
-            block::get_block_transaction_count_by_number(&request, storage)
+            let request =
+                GetBlockTransactionCountRequest::parse(&req.params).ok_or(RpcErr::BadParams)?;
+            block::get_block_transaction_count(&request, storage)
+        }
+        "eth_getBlockTransactionCountByHash" => {
+            let request =
+                GetBlockTransactionCountRequest::parse(&req.params).ok_or(RpcErr::BadParams)?;
+            block::get_block_transaction_count(&request, storage)
         }
         "eth_getTransactionByBlockNumberAndIndex" => {
             let request = GetTransactionByBlockNumberAndIndexRequest::parse(&req.params)


### PR DESCRIPTION
**Motivation**

To continue with the implementation of the `rpc-compat` set of endpoints.

**Description**

- Implements the `eth_getBlockTransactionCountByHash` endpoint.
- Refactors the `eth_getBlockTransactionCountByNumber` endpoint to handle both in a general solution.

Closes #319 
Closes #320 

