### PR TITLE
fix: return error when querying historical data

### DIFF
--- a/crates/rpc/eth/account.rs
+++ b/crates/rpc/eth/account.rs
@@ -19,10 +19,10 @@ pub enum BlockIdentifierOrHash {
 
 impl PartialEq<BlockTag> for BlockIdentifierOrHash {
     fn eq(&self, other: &BlockTag) -> bool {
-        matches!(
-            self,
-            BlockIdentifierOrHash::Identifier(BlockIdentifier::Tag(other))
-        )
+        match self {
+            BlockIdentifierOrHash::Identifier(BlockIdentifier::Tag(tag)) => tag == other,
+            _ => false,
+        }
     }
 }
 

--- a/crates/rpc/eth/block.rs
+++ b/crates/rpc/eth/block.rs
@@ -37,7 +37,7 @@ pub enum BlockIdentifier {
     Tag(BlockTag),
 }
 
-#[derive(Deserialize, Default, Clone, Debug)]
+#[derive(Deserialize, Default, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum BlockTag {
     Earliest,

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -278,7 +278,6 @@ impl Store {
         block_number: BlockNumber,
     ) -> Result<(), StoreError> {
         for (index, transaction) in transactions.iter().enumerate() {
-            info!("[Storage] Inserting transaction {:?}", transaction);
             self.add_transaction_location(
                 transaction.compute_hash(),
                 block_number,


### PR DESCRIPTION
**Motivation**
Until we have historical data querying, we should return an error instead of returning the latest data


