### PR TITLE
feat: implement eth_getTransactionCount endpoint

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - simulation: rpc-compat
-            run_command: just run-hive ethereum/rpc-compat "/eth_chainId|eth_getTransactionByBlockHashAndIndex|eth_getTransactionByBlockNumberAndIndex|eth_getCode|eth_getStorageAt|eth_call|eth_getTransactionByHash|eth_getBlockByHash|eth_getBlockByNumber|eth_createAccessList|eth_getBlockTransactionCountByNumber|eth_getBlockTransactionCountByHash|eth_getBlockReceipts|eth_getTransactionReceipt"
+            run_command: just run-hive ethereum/rpc-compat "/eth_chainId|eth_getTransactionByBlockHashAndIndex|eth_getTransactionByBlockNumberAndIndex|eth_getCode|eth_getStorageAt|eth_call|eth_getTransactionByHash|eth_getBlockByHash|eth_getBlockByNumber|eth_createAccessList|eth_getBlockTransactionCountByNumber|eth_getBlockTransactionCountByHash|eth_getBlockReceipts|eth_getTransactionReceipt|ethGetTransactionCount"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/crates/rpc/eth/account.rs
+++ b/crates/rpc/eth/account.rs
@@ -58,6 +58,7 @@ pub struct GetCodeRequest {
     pub address: Address,
     pub block: BlockIdentifierOrHash,
 }
+
 pub struct GetStorageAtRequest {
     pub address: Address,
     pub storage_slot: H256,
@@ -180,7 +181,8 @@ impl RpcHandler for GetTransactionCountRequest {
         );
 
         // TODO: implement historical querying
-        if self.block != BlockTag::Latest {
+        let is_latest = self.block.is_latest(&storage)?;
+        if !is_latest {
             return Err(RpcErr::Internal);
         }
 

--- a/crates/rpc/eth/block.rs
+++ b/crates/rpc/eth/block.rs
@@ -47,7 +47,7 @@ pub enum BlockIdentifier {
     Tag(BlockTag),
 }
 
-#[derive(Deserialize, Default, Clone, Debug)]
+#[derive(Deserialize, Default, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum BlockTag {
     Earliest,

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -13,7 +13,7 @@ use engine::{
     ExchangeCapabilitiesRequest,
 };
 use eth::{
-    account::{GetBalanceRequest, GetCodeRequest, GetStorageAtRequest},
+    account::{GetBalanceRequest, GetCodeRequest, GetStorageAtRequest, GetTransactionCountRequest},
     block::{
         self, GetBlockByHashRequest, GetBlockByNumberRequest, GetBlockReceiptsRequest,
         GetBlockTransactionCountRequest,
@@ -178,6 +178,7 @@ pub fn map_eth_requests(req: &RpcRequest, storage: Store) -> Result<Value, RpcEr
         "eth_createAccessList" => CreateAccessListRequest::call(req, storage),
         "eth_blockNumber" => block::block_number(storage),
         "eth_call" => CallRequest::call(req, storage),
+        "eth_getTransactionCount" => GetTransactionCountRequest::call(req, storage),
         _ => Err(RpcErr::MethodNotFound),
     }
 }

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -117,6 +117,14 @@ pub trait StoreEngine: Debug + Send {
         self.get_account_code(code_hash)
     }
 
+    /// Obtain account nonce via account address
+    fn get_nonce_by_account_address(&self, address: Address) -> Result<Option<u64>, StoreError> {
+        let nonce = self
+            .get_account_info(address)?
+            .map(|acc_info| acc_info.nonce);
+        Ok(nonce)
+    }
+
     fn get_transaction_by_hash(
         &self,
         transaction_hash: H256,

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -225,6 +225,16 @@ impl Store {
             .unwrap()
             .get_code_by_account_address(address)
     }
+    pub fn get_nonce_by_account_address(
+        &self,
+        address: Address,
+    ) -> Result<Option<u64>, StoreError> {
+        self.engine
+            .clone()
+            .lock()
+            .unwrap()
+            .get_nonce_by_account_address(address)
+    }
 
     pub fn add_account(&self, address: Address, account: Account) -> Result<(), StoreError> {
         self.engine.lock().unwrap().add_account(address, account)


### PR DESCRIPTION
Implements `eth_getTransactionCount` endpoint:
- Returns the `nonce` of an address at a specific `Block`.

**Observations**

This PR only responds to request where the specified block is the `latest`. Otherwise, an error is returned.
This is because we are not handling historical data yet.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #335 