### PR TITLE
fix: remove totalDifficulty

### DIFF
--- a/crates/rpc/eth/block.rs
+++ b/crates/rpc/eth/block.rs
@@ -13,9 +13,8 @@ use crate::{
     utils::RpcErr,
     RpcHandler,
 };
-use ethereum_rust_core::{
-    types::{calculate_base_fee_per_blob_gas, BlockBody, BlockHash, BlockHeader, BlockNumber},
-    U256,
+use ethereum_rust_core::types::{
+    calculate_base_fee_per_blob_gas, BlockBody, BlockHash, BlockHeader, BlockNumber,
 };
 use ethereum_rust_storage::{error::StoreError, Store};
 
@@ -98,15 +97,7 @@ impl RpcHandler for GetBlockByNumberRequest {
             _ => return Ok(Value::Null),
         };
         let hash = header.compute_block_hash();
-        // TODO (#307): Remove TotalDifficulty.
-        let total_difficulty = storage.get_block_total_difficulty(hash)?;
-        let block = RpcBlock::build(
-            header,
-            body,
-            hash,
-            self.hydrated,
-            total_difficulty.unwrap_or(U256::zero()),
-        );
+        let block = RpcBlock::build(header, body, hash, self.hydrated);
 
         serde_json::to_value(&block).map_err(|_| RpcErr::Internal)
     }
@@ -137,15 +128,7 @@ impl RpcHandler for GetBlockByHashRequest {
             _ => return Ok(Value::Null),
         };
         let hash = header.compute_block_hash();
-        // TODO (#307): Remove TotalDifficulty.
-        let total_difficulty = storage.get_block_total_difficulty(hash)?;
-        let block = RpcBlock::build(
-            header,
-            body,
-            hash,
-            self.hydrated,
-            total_difficulty.unwrap_or(U256::zero()),
-        );
+        let block = RpcBlock::build(header, body, hash, self.hydrated);
         serde_json::to_value(&block).map_err(|_| RpcErr::Internal)
     }
 }

--- a/crates/rpc/types/block.rs
+++ b/crates/rpc/types/block.rs
@@ -3,7 +3,7 @@ use ethereum_rust_core::{
     rlp::encode::RLPEncode,
     serde_utils,
     types::{Block, BlockBody, BlockHash, BlockHeader, BlockNumber, Withdrawal},
-    H256, U256,
+    H256,
 };
 
 use serde::Serialize;
@@ -14,8 +14,6 @@ pub struct RpcBlock {
     hash: H256,
     #[serde(with = "serde_utils::u64::hex_str")]
     size: u64,
-    // TODO (#307): Remove TotalDifficulty.
-    total_difficulty: U256,
     #[serde(flatten)]
     header: BlockHeader,
     #[serde(flatten)]
@@ -50,7 +48,6 @@ impl RpcBlock {
         body: BlockBody,
         hash: H256,
         full_transactions: bool,
-        total_difficulty: U256,
     ) -> RpcBlock {
         let size = Block {
             header: header.clone(),
@@ -70,7 +67,6 @@ impl RpcBlock {
 
         RpcBlock {
             hash,
-            total_difficulty,
             size: size as u64,
             header,
             body: body_wrapper,
@@ -194,8 +190,8 @@ mod test {
         };
         let hash = block_header.compute_block_hash();
 
-        let block = RpcBlock::build(block_header, block_body, hash, true, U256::zero());
-        let expected_block = r#"{"hash":"0x63d6a2504601fc2db0ccf02a28055eb0cdb40c444ecbceec0f613980421a035e","size":"0x2d6","totalDifficulty":"0x0","parentHash":"0x1ac1bf1eef97dc6b03daba5af3b89881b7ae4bc1600dc434f450a9ec34d44999","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","miner":"0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba","stateRoot":"0x9de6f95cb4ff4ef22a73705d6ba38c4b927c7bca9887ef5d24a734bb863218d9","transactionsRoot":"0x578602b2b7e3a3291c3eefca3a08bc13c0d194f9845a39b6f3bcf843d9fed79d","receiptsRoot":"0x035d56bac3f47246c5eed0e6642ca40dc262f9144b582f058bc23ded72aa72fa","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","difficulty":"0x0","number":"0x1","gasLimit":"0x16345785d8a0000","gasUsed":"0xa8de","timestamp":"0x3e8","extraData":"0x","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","baseFeePerGas":"0x7","withdrawalsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","blobGasUsed":"0x0","excessBlobGas":"0x0","parentBeaconBlockRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","transactions":[{"type":"0x2","nonce":"0x0","to":"0x6177843db3138ae69679a54b95cf345ed759450d","gas":"0xf618","value":"0xaa87bee538000","input":"0x307831353638","maxPriorityFeePerGas":"0x11","maxFeePerGas":"0x4e","gasPrice":"0x4e","accessList":[{"address":"0x6177843db3138ae69679a54b95cf345ed759450d","storageKeys":[]}],"chainId":"0x301824","yParity":"0x0","v":"0x0","r":"0x151ccc02146b9b11adf516e6787b59acae3e76544fdcd75e77e67c6b598ce65d","s":"0x64c5dd5aae2fbb535830ebbdad0234975cd7ece3562013b63ea18cc0df6c97d4","blockNumber":"0x1","blockHash":"0x63d6a2504601fc2db0ccf02a28055eb0cdb40c444ecbceec0f613980421a035e","from":"0x35af8ea983a3ba94c655e19b82b932a30d6b9558","hash":"0x0b8c8f37731d9493916b06d666c3fd5dee2c3bbda06dfe866160d717e00dda91","transactionIndex":"0x0"}],"uncles":[],"withdrawals":[]}"#;
+        let block = RpcBlock::build(block_header, block_body, hash, true);
+        let expected_block = r#"{"hash":"0x63d6a2504601fc2db0ccf02a28055eb0cdb40c444ecbceec0f613980421a035e","size":"0x2d6","parentHash":"0x1ac1bf1eef97dc6b03daba5af3b89881b7ae4bc1600dc434f450a9ec34d44999","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","miner":"0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba","stateRoot":"0x9de6f95cb4ff4ef22a73705d6ba38c4b927c7bca9887ef5d24a734bb863218d9","transactionsRoot":"0x578602b2b7e3a3291c3eefca3a08bc13c0d194f9845a39b6f3bcf843d9fed79d","receiptsRoot":"0x035d56bac3f47246c5eed0e6642ca40dc262f9144b582f058bc23ded72aa72fa","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","difficulty":"0x0","number":"0x1","gasLimit":"0x16345785d8a0000","gasUsed":"0xa8de","timestamp":"0x3e8","extraData":"0x","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","baseFeePerGas":"0x7","withdrawalsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","blobGasUsed":"0x0","excessBlobGas":"0x0","parentBeaconBlockRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","transactions":[{"type":"0x2","nonce":"0x0","to":"0x6177843db3138ae69679a54b95cf345ed759450d","gas":"0xf618","value":"0xaa87bee538000","input":"0x307831353638","maxPriorityFeePerGas":"0x11","maxFeePerGas":"0x4e","gasPrice":"0x4e","accessList":[{"address":"0x6177843db3138ae69679a54b95cf345ed759450d","storageKeys":[]}],"chainId":"0x301824","yParity":"0x0","v":"0x0","r":"0x151ccc02146b9b11adf516e6787b59acae3e76544fdcd75e77e67c6b598ce65d","s":"0x64c5dd5aae2fbb535830ebbdad0234975cd7ece3562013b63ea18cc0df6c97d4","blockNumber":"0x1","blockHash":"0x63d6a2504601fc2db0ccf02a28055eb0cdb40c444ecbceec0f613980421a035e","from":"0x35af8ea983a3ba94c655e19b82b932a30d6b9558","hash":"0x0b8c8f37731d9493916b06d666c3fd5dee2c3bbda06dfe866160d717e00dda91","transactionIndex":"0x0"}],"uncles":[],"withdrawals":[]}"#;
         assert_eq!(serde_json::to_string(&block).unwrap(), expected_block)
     }
 }

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -60,19 +60,6 @@ pub trait StoreEngine: Debug + Send {
     /// Obtain block number
     fn get_block_number(&self, block_hash: BlockHash) -> Result<Option<BlockNumber>, StoreError>;
 
-    // TODO (#307): Remove TotalDifficulty.
-    /// Add block total difficulty
-    fn add_block_total_difficulty(
-        &mut self,
-        block_hash: BlockHash,
-        block_total_difficulty: U256,
-    ) -> Result<(), StoreError>;
-
-    // TODO (#307): Remove TotalDifficulty.
-    /// Obtain block total difficulty
-    fn get_block_total_difficulty(&self, block_hash: BlockHash)
-        -> Result<Option<U256>, StoreError>;
-
     /// Store transaction location (block number and index of the transaction within the block)
     fn add_transaction_location(
         &mut self,
@@ -235,17 +222,6 @@ pub trait StoreEngine: Debug + Send {
 
     // Obtain latest block number
     fn get_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
-
-    // TODO (#307): Remove TotalDifficulty.
-    // Update latest total difficulty
-    fn update_latest_total_difficulty(
-        &mut self,
-        latest_total_difficulty: U256,
-    ) -> Result<(), StoreError>;
-
-    // TODO (#307): Remove TotalDifficulty.
-    // Obtain latest total difficulty
-    fn get_latest_total_difficulty(&self) -> Result<Option<U256>, StoreError>;
 
     // Update pending block number
     fn update_pending_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError>;

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -13,8 +13,6 @@ pub struct Store {
     chain_data: ChainData,
     account_infos: HashMap<Address, AccountInfo>,
     block_numbers: HashMap<BlockHash, BlockNumber>,
-    // TODO (#307): Remove TotalDifficulty.
-    block_total_difficulties: HashMap<BlockHash, U256>,
     bodies: HashMap<BlockNumber, BlockBody>,
     headers: HashMap<BlockNumber, BlockHeader>,
     // Maps code hashes to code
@@ -32,8 +30,6 @@ struct ChainData {
     finalized_block_number: Option<BlockNumber>,
     safe_block_number: Option<BlockNumber>,
     latest_block_number: Option<BlockNumber>,
-    // TODO (#307): Remove TotalDifficulty.
-    latest_total_difficulty: Option<U256>,
     pending_block_number: Option<BlockNumber>,
 }
 
@@ -105,23 +101,6 @@ impl StoreEngine for Store {
 
     fn get_block_number(&self, block_hash: BlockHash) -> Result<Option<BlockNumber>, StoreError> {
         Ok(self.block_numbers.get(&block_hash).copied())
-    }
-
-    fn add_block_total_difficulty(
-        &mut self,
-        block_hash: BlockHash,
-        block_total_difficulty: U256,
-    ) -> Result<(), StoreError> {
-        self.block_total_difficulties
-            .insert(block_hash, block_total_difficulty);
-        Ok(())
-    }
-
-    fn get_block_total_difficulty(
-        &self,
-        block_hash: BlockHash,
-    ) -> Result<Option<U256>, StoreError> {
-        Ok(self.block_total_difficulties.get(&block_hash).copied())
     }
 
     fn add_transaction_location(
@@ -285,22 +264,9 @@ impl StoreEngine for Store {
         self.chain_data.latest_block_number.replace(block_number);
         Ok(())
     }
-    fn update_latest_total_difficulty(
-        &mut self,
-        latest_total_difficulty: U256,
-    ) -> Result<(), StoreError> {
-        self.chain_data
-            .latest_total_difficulty
-            .replace(latest_total_difficulty);
-        Ok(())
-    }
 
     fn get_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
         Ok(self.chain_data.latest_block_number)
-    }
-
-    fn get_latest_total_difficulty(&self) -> Result<Option<U256>, StoreError> {
-        Ok(self.chain_data.latest_total_difficulty)
     }
 
     fn update_pending_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {

--- a/crates/storage/engines/libmdbx.rs
+++ b/crates/storage/engines/libmdbx.rs
@@ -2,7 +2,7 @@ use super::api::StoreEngine;
 use crate::error::StoreError;
 use crate::rlp::{
     AccountCodeHashRLP, AccountCodeRLP, AccountInfoRLP, AddressRLP, BlockBodyRLP, BlockHashRLP,
-    BlockHeaderRLP, BlockTotalDifficultyRLP, ReceiptRLP, TransactionHashRLP,
+    BlockHeaderRLP, ReceiptRLP, TransactionHashRLP,
 };
 use anyhow::Result;
 use bytes::Bytes;
@@ -141,22 +141,6 @@ impl StoreEngine for Store {
         block_hash: BlockHash,
     ) -> std::result::Result<Option<BlockNumber>, StoreError> {
         self.read::<BlockNumbers>(block_hash.into())
-    }
-    fn add_block_total_difficulty(
-        &mut self,
-        block_hash: BlockHash,
-        block_total_difficulty: U256,
-    ) -> std::result::Result<(), StoreError> {
-        self.write::<BlockTotalDifficulties>(block_hash.into(), block_total_difficulty.into())
-    }
-
-    fn get_block_total_difficulty(
-        &self,
-        block_hash: BlockHash,
-    ) -> std::result::Result<Option<U256>, StoreError> {
-        Ok(self
-            .read::<BlockTotalDifficulties>(block_hash.into())?
-            .map(|b| b.to()))
     }
 
     fn add_account_code(&mut self, code_hash: H256, code: Bytes) -> Result<(), StoreError> {
@@ -362,25 +346,6 @@ impl StoreEngine for Store {
         }
     }
 
-    fn update_latest_total_difficulty(
-        &mut self,
-        latest_total_difficulty: U256,
-    ) -> std::result::Result<(), StoreError> {
-        self.write::<ChainData>(
-            ChainDataIndex::LatestTotalDifficulty,
-            latest_total_difficulty.encode_to_vec(),
-        )
-    }
-
-    fn get_latest_total_difficulty(&self) -> Result<Option<U256>, StoreError> {
-        match self.read::<ChainData>(ChainDataIndex::LatestTotalDifficulty)? {
-            None => Ok(None),
-            Some(ref rlp) => RLPDecode::decode(rlp)
-                .map(Some)
-                .map_err(|_| StoreError::DecodeError),
-        }
-    }
-
     fn update_pending_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
         self.write::<ChainData>(
             ChainDataIndex::PendingBlockNumber,
@@ -409,12 +374,6 @@ impl Debug for Store {
 table!(
     /// Block hash to number table.
     ( BlockNumbers ) BlockHashRLP => BlockNumber
-);
-
-// TODO (#307): Remove TotalDifficulty.
-table!(
-    /// Block hash to total difficulties table.
-    ( BlockTotalDifficulties ) BlockHashRLP => BlockTotalDifficultyRLP
 );
 
 table!(
@@ -521,8 +480,6 @@ pub enum ChainDataIndex {
     SafeBlockNumber = 3,
     LatestBlockNumber = 4,
     PendingBlockNumber = 5,
-    // TODO (#307): Remove TotalDifficulty.
-    LatestTotalDifficulty = 6,
 }
 
 impl Encodable for ChainDataIndex {
@@ -538,8 +495,6 @@ impl Encodable for ChainDataIndex {
 pub fn init_db(path: Option<impl AsRef<Path>>) -> Database {
     let tables = [
         table_info!(BlockNumbers),
-        // TODO (#307): Remove TotalDifficulty.
-        table_info!(BlockTotalDifficulties),
         table_info!(Headers),
         table_info!(Bodies),
         table_info!(AccountInfos),

--- a/crates/storage/rlp.rs
+++ b/crates/storage/rlp.rs
@@ -6,7 +6,6 @@ use ethereum_rust_core::{
     types::{AccountInfo, BlockBody, BlockHash, BlockHeader, Receipt},
     Address, H256,
 };
-use ethereum_types::U256;
 #[cfg(feature = "libmdbx")]
 use libmdbx::orm::{Decodable, Encodable};
 
@@ -20,8 +19,6 @@ pub type AccountCodeRLP = Rlp<Bytes>;
 pub type BlockHashRLP = Rlp<BlockHash>;
 pub type BlockHeaderRLP = Rlp<BlockHeader>;
 pub type BlockBodyRLP = Rlp<BlockBody>;
-// TODO (#307): Remove TotalDifficulty.
-pub type BlockTotalDifficultyRLP = Rlp<U256>;
 
 // Receipt types
 pub type ReceiptRLP = Rlp<Receipt>;

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -154,29 +154,6 @@ impl Store {
             .get_block_number(block_hash)
     }
 
-    pub fn add_block_total_difficulty(
-        &self,
-        block_hash: BlockHash,
-        block_difficulty: U256,
-    ) -> Result<(), StoreError> {
-        self.engine
-            .clone()
-            .lock()
-            .unwrap()
-            .add_block_total_difficulty(block_hash, block_difficulty)
-    }
-
-    pub fn get_block_total_difficulty(
-        &self,
-        block_hash: BlockHash,
-    ) -> Result<Option<U256>, StoreError> {
-        self.engine
-            .clone()
-            .lock()
-            .unwrap()
-            .get_block_total_difficulty(block_hash)
-    }
-
     pub fn add_transaction_location(
         &self,
         transaction_hash: H256,
@@ -259,17 +236,12 @@ impl Store {
         // TODO Maybe add both in a single tx?
         let header = block.header;
         let number = header.number;
-        let latest_total_difficulty = self.get_latest_total_difficulty()?;
-        let block_total_difficulty =
-            latest_total_difficulty.unwrap_or(U256::zero()) + header.difficulty;
         let hash = header.compute_block_hash();
         self.add_transaction_locations(&block.body.transactions, number)?;
         self.add_block_body(number, block.body)?;
         self.add_block_header(number, header)?;
         self.add_block_number(hash, number)?;
-        self.update_latest_block_number(number)?;
-        self.add_block_total_difficulty(hash, block_total_difficulty)?;
-        self.update_latest_total_difficulty(block_total_difficulty)
+        self.update_latest_block_number(number)
     }
 
     fn add_transaction_locations(
@@ -433,19 +405,9 @@ impl Store {
             .unwrap()
             .update_latest_block_number(block_number)
     }
-    pub fn update_latest_total_difficulty(&self, block_difficulty: U256) -> Result<(), StoreError> {
-        self.engine
-            .lock()
-            .unwrap()
-            .update_latest_total_difficulty(block_difficulty)
-    }
 
     pub fn get_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
         self.engine.lock().unwrap().get_latest_block_number()
-    }
-
-    pub fn get_latest_total_difficulty(&self) -> Result<Option<U256>, StoreError> {
-        self.engine.lock().unwrap().get_latest_total_difficulty()
     }
 
     pub fn update_pending_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {


### PR DESCRIPTION
**Motivation**

After the merge, `totalDifficulty` no longer plays any role in the core protocol's operation. We were maintaining it solely to pass Hive tests.

**Description**

Removes `totalDifficulty` from our codebase.

Closes #307 

