### PR TITLE
feat: `engine_exchangeTransitionConfigurationV1` method

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -22,10 +22,10 @@ jobs:
       matrix:
         include:
           - simulation: rpc-compat
-            name: "Hive: rpc-compat tests"
+            name: "Rpc Compat tests"
             run_command: just run-hive ethereum/rpc-compat "/eth_chainId|eth_getTransactionByBlockHashAndIndex|eth_getTransactionByBlockNumberAndIndex|eth_getCode|eth_getStorageAt|eth_call|eth_getTransactionByHash|eth_getBlockByHash|eth_getBlockByNumber|eth_createAccessList|eth_getBlockTransactionCountByNumber|eth_getBlockTransactionCountByHash|eth_getBlockReceipts|eth_getTransactionReceipt|eth_blobGasPrice|eth_blockNumber|ethGetTransactionCount"
           - simulation: rpc-engine
-            name: "Hive: rpc-engine tests"
+            name: "Engine Auth tests"
             run_command: just run-hive ethereum/engine "/engine-auth"
     steps:
       - name: Checkout sources

--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -16,14 +16,16 @@ env:
 
 jobs:
   run-hive:
-    name: ${{ matrix.simulation }}
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           - simulation: rpc-compat
+            name: "Hive: rpc-compat tests"
             run_command: just run-hive ethereum/rpc-compat "/eth_chainId|eth_getTransactionByBlockHashAndIndex|eth_getTransactionByBlockNumberAndIndex|eth_getCode|eth_getStorageAt|eth_call|eth_getTransactionByHash|eth_getBlockByHash|eth_getBlockByNumber|eth_createAccessList|eth_getBlockTransactionCountByNumber|eth_getBlockTransactionCountByHash|eth_getBlockReceipts|eth_getTransactionReceipt|eth_blobGasPrice|eth_blockNumber|ethGetTransactionCount"
           - simulation: rpc-engine
+            name: "Hive: rpc-engine tests"
             run_command: just run-hive ethereum/engine "/engine-auth"
     steps:
       - name: Checkout sources

--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -23,6 +23,8 @@ jobs:
         include:
           - simulation: rpc-compat
             run_command: just run-hive ethereum/rpc-compat "/eth_chainId|eth_getTransactionByBlockHashAndIndex|eth_getTransactionByBlockNumberAndIndex|eth_getCode|eth_getStorageAt|eth_call|eth_getTransactionByHash|eth_getBlockByHash|eth_getBlockByNumber|eth_createAccessList|eth_getBlockTransactionCountByNumber|eth_getBlockTransactionCountByHash|eth_getBlockReceipts|eth_getTransactionReceipt|eth_blobGasPrice|eth_blockNumber|ethGetTransactionCount"
+          - simulation: rpc-engine
+            run_command: just run-hive ethereum/engine "/engine-auth"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/crates/core/serde_utils.rs
+++ b/crates/core/serde_utils.rs
@@ -165,6 +165,31 @@ pub mod u64 {
     }
 }
 
+pub mod u128 {
+    use super::*;
+
+    pub mod hex_str {
+        use super::*;
+
+        pub fn deserialize<'de, D>(d: D) -> Result<u128, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let value = String::deserialize(d)?;
+            let res = u128::from_str_radix(value.trim_start_matches("0x"), 32)
+                .map_err(|_| D::Error::custom("Failed to deserialize u128 value"));
+            res
+        }
+
+        pub fn serialize<S>(value: &u128, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_str(&format!("{:#x}", value))
+        }
+    }
+}
+
 /// Serializes to and deserializes from 0x prefixed hex string
 pub mod bytes {
     use ::bytes::Bytes;

--- a/crates/rpc/engine/exchange_transition_config.rs
+++ b/crates/rpc/engine/exchange_transition_config.rs
@@ -1,0 +1,83 @@
+use ethereum_rust_core::{serde_utils, H256};
+use ethereum_rust_storage::Store;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::{info, warn};
+
+use crate::utils::RpcErr;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExchangeTransitionConfigPayload {
+    #[serde(with = "serde_utils::u128::hex_str")]
+    terminal_total_difficulty: u128,
+    terminal_block_hash: H256,
+    #[serde(with = "serde_utils::u64::hex_str")]
+    terminal_block_number: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExchangeTransitionConfigV1Req {
+    payload: ExchangeTransitionConfigPayload,
+}
+
+impl std::fmt::Display for ExchangeTransitionConfigV1Req {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ExchangeTransitionConfigV1Req {{ terminal_total_difficulty: {}, terminal_block_hash: {:?}, terminal_block_number: {} }}",
+            self.payload.terminal_total_difficulty,
+            self.payload.terminal_block_hash,
+            self.payload.terminal_block_number
+        )
+    }
+}
+
+impl ExchangeTransitionConfigV1Req {
+    pub fn parse(params: &Option<Vec<Value>>) -> Option<ExchangeTransitionConfigV1Req> {
+        let params = params.as_ref()?;
+        if params.len() != 1 {
+            return None;
+        };
+        let params: ExchangeTransitionConfigPayload =
+            serde_json::from_value(params[0].clone()).unwrap();
+        Some(ExchangeTransitionConfigV1Req {
+            payload: ExchangeTransitionConfigPayload {
+                terminal_total_difficulty: params.terminal_total_difficulty,
+                terminal_block_hash: params.terminal_block_hash,
+                terminal_block_number: params.terminal_block_number,
+            },
+        })
+    }
+}
+
+/// Deprecated endpoint used before the merge, though still needed for certain hive tests
+/// ExchangeTransitionConfigurationV1 checks the given configuration against the configuration of the node.
+pub fn exchange_transition_config_v1(
+    req: ExchangeTransitionConfigV1Req,
+    storage: Store,
+) -> Result<Value, RpcErr> {
+    info!("Received new engine request: {req}");
+    let payload = req.payload;
+
+    let chain_config = storage.get_chain_config()?.ok_or(RpcErr::Internal)?;
+    let terminal_total_difficulty = chain_config.terminal_total_difficulty;
+
+    if terminal_total_difficulty.unwrap_or_default() != payload.terminal_total_difficulty {
+        warn!(
+            "Invalid terminal total difficulty configured: execution {:?} consensus {}",
+            terminal_total_difficulty, payload.terminal_total_difficulty
+        );
+    };
+
+    let block = storage.get_block_header(payload.terminal_block_number)?;
+    let terminal_block_hash = block.map_or(H256::zero(), |block| block.compute_block_hash());
+
+    serde_json::to_value(ExchangeTransitionConfigPayload {
+        terminal_block_hash,
+        terminal_block_number: payload.terminal_block_number,
+        terminal_total_difficulty: terminal_total_difficulty.unwrap_or_default(),
+    })
+    .map_err(|_| RpcErr::Internal)
+}

--- a/crates/rpc/engine/exchange_transition_config.rs
+++ b/crates/rpc/engine/exchange_transition_config.rs
@@ -40,15 +40,9 @@ impl RpcHandler for ExchangeTransitionConfigV1Req {
         if params.len() != 1 {
             return None;
         };
-        let params: ExchangeTransitionConfigPayload =
+        let payload: ExchangeTransitionConfigPayload =
             serde_json::from_value(params[0].clone()).unwrap();
-        Some(ExchangeTransitionConfigV1Req {
-            payload: ExchangeTransitionConfigPayload {
-                terminal_total_difficulty: params.terminal_total_difficulty,
-                terminal_block_hash: params.terminal_block_hash,
-                terminal_block_number: params.terminal_block_number,
-            },
-        })
+        Some(ExchangeTransitionConfigV1Req { payload })
     }
 
     fn handle(&self, storage: Store) -> Result<Value, RpcErr> {

--- a/crates/rpc/engine/mod.rs
+++ b/crates/rpc/engine/mod.rs
@@ -1,3 +1,4 @@
+pub mod exchange_transition_config;
 pub mod fork_choice;
 pub mod payload;
 

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -8,7 +8,7 @@ use axum_extra::{
     TypedHeader,
 };
 use engine::{
-    exchange_transition_config::{self, ExchangeTransitionConfigV1Req},
+    exchange_transition_config::ExchangeTransitionConfigV1Req,
     fork_choice::{self, ForkChoiceUpdatedV3},
     payload::{self, NewPayloadV3Request},
     ExchangeCapabilitiesRequest,
@@ -208,9 +208,7 @@ pub fn map_engine_requests(req: &RpcRequest, storage: Store) -> Result<Value, Rp
                 .map_err(|_| RpcErr::Internal)
         }
         "engine_exchangeTransitionConfigurationV1" => {
-            let request =
-                ExchangeTransitionConfigV1Req::parse(&req.params).ok_or(RpcErr::BadParams)?;
-            exchange_transition_config::exchange_transition_config_v1(request, storage)
+            ExchangeTransitionConfigV1Req::call(req, storage)
         }
         _ => Err(RpcErr::MethodNotFound),
     }

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -8,6 +8,7 @@ use axum_extra::{
     TypedHeader,
 };
 use engine::{
+    exchange_transition_config::{self, ExchangeTransitionConfigV1Req},
     fork_choice::{self, ForkChoiceUpdatedV3},
     payload::{self, NewPayloadV3Request},
     ExchangeCapabilitiesRequest,
@@ -205,6 +206,11 @@ pub fn map_engine_requests(req: &RpcRequest, storage: Store) -> Result<Value, Rp
             let request = NewPayloadV3Request::parse(&req.params).ok_or(RpcErr::BadParams)?;
             serde_json::to_value(payload::new_payload_v3(request, storage)?)
                 .map_err(|_| RpcErr::Internal)
+        }
+        "engine_exchangeTransitionConfigurationV1" => {
+            let request =
+                ExchangeTransitionConfigV1Req::parse(&req.params).ok_or(RpcErr::BadParams)?;
+            exchange_transition_config::exchange_transition_config_v1(request, storage)
         }
         _ => Err(RpcErr::MethodNotFound),
     }

--- a/crates/rpc/utils.rs
+++ b/crates/rpc/utils.rs
@@ -10,7 +10,6 @@ pub enum RpcErr {
     MethodNotFound,
     BadParams,
     UnsuportedFork,
-    Deprecation(String),
     Internal,
     Vm,
     Revert { data: String },
@@ -29,11 +28,6 @@ impl From<RpcErr> for RpcErrorMetadata {
                 code: -32000,
                 data: None,
                 message: "Invalid params".to_string(),
-            },
-            RpcErr::Deprecation(message) => RpcErrorMetadata {
-                code: -32000,
-                data: None,
-                message: format!("Deprecation notice: {}", message).to_string(),
             },
             RpcErr::UnsuportedFork => RpcErrorMetadata {
                 code: -38005,

--- a/crates/rpc/utils.rs
+++ b/crates/rpc/utils.rs
@@ -10,6 +10,7 @@ pub enum RpcErr {
     MethodNotFound,
     BadParams,
     UnsuportedFork,
+    Deprecation(String),
     Internal,
     Vm,
     Revert { data: String },
@@ -28,6 +29,11 @@ impl From<RpcErr> for RpcErrorMetadata {
                 code: -32000,
                 data: None,
                 message: "Invalid params".to_string(),
+            },
+            RpcErr::Deprecation(message) => RpcErrorMetadata {
+                code: -32000,
+                data: None,
+                message: format!("Deprecation notice: {}", message).to_string(),
             },
             RpcErr::UnsuportedFork => RpcErrorMetadata {
                 code: -38005,


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
This PR implements the [deprecated](https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#deprecate-engine_exchangetransitionconfigurationv1) RPC endpoint `engine_exchangeTransitionConfigurationV1`. Despite its deprecation, this method is still used by certain test suites, such as those under `hive/auth`. Supporting these tests is the actual motivation behind this implementation.

**Description**

The implementation was done [following the spec](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_exchangetransitionconfigurationv1).

Closes #343

