### PR TITLE
feat: `debug_getRawBlock` endpoint

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - simulation: rpc-compat
-            run_command: just run-hive ethereum/rpc-compat "/eth_chainId|eth_getTransactionByBlockHashAndIndex|eth_getTransactionByBlockNumberAndIndex|eth_getCode|eth_getStorageAt|eth_call|eth_getTransactionByHash|eth_getBlockByHash|eth_getBlockByNumber|eth_createAccessList|eth_getBlockTransactionCountByNumber|eth_getBlockTransactionCountByHash|eth_getBlockReceipts|eth_getTransactionReceipt|eth_blobGasPrice|eth_blockNumber|ethGetTransactionCount"
+            run_command: just run-hive ethereum/rpc-compat "/eth_chainId|eth_getTransactionByBlockHashAndIndex|eth_getTransactionByBlockNumberAndIndex|eth_getCode|eth_getStorageAt|eth_call|eth_getTransactionByHash|eth_getBlockByHash|eth_getBlockByNumber|eth_createAccessList|eth_getBlockTransactionCountByNumber|eth_getBlockTransactionCountByHash|eth_getBlockReceipts|eth_getTransactionReceipt|eth_blobGasPrice|eth_blockNumber|ethGetTransactionCount|debug_getRawBlock"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/crates/core/serde_utils.rs
+++ b/crates/core/serde_utils.rs
@@ -80,6 +80,11 @@ pub mod u64 {
             D: Deserializer<'de>,
         {
             let value = String::deserialize(d)?;
+
+            if !value.starts_with("0x") {
+                return Err(D::Error::custom("Failed to deserialize u64 value"));
+            };
+
             let res = u64::from_str_radix(value.trim_start_matches("0x"), 16)
                 .map_err(|_| D::Error::custom("Failed to deserialize u64 value"));
             res

--- a/crates/rpc/debug_rpc/mod.rs
+++ b/crates/rpc/debug_rpc/mod.rs
@@ -1,7 +1,11 @@
 use serde_json::Value;
 use tracing::info;
 
-use crate::{eth::block::BlockIdentifier, utils::RpcErr, RpcHandler};
+use crate::{
+    eth::block::BlockIdentifier,
+    utils::{RpcErr, RpcRequest},
+    RpcHandler,
+};
 use ethereum_rust_core::{rlp::encode::RLPEncode, types::Block};
 use ethereum_rust_storage::Store;
 
@@ -18,6 +22,11 @@ impl RpcHandler for GetRawBlock {
         Some(GetRawBlock {
             block: serde_json::from_value(params[0].clone()).ok()?,
         })
+    }
+
+    fn call(req: &RpcRequest, storage: Store) -> Result<Value, RpcErr> {
+        let request = Self::parse(&req.params).ok_or(RpcErr::InvalidParams)?;
+        request.handle(storage)
     }
 
     fn handle(&self, storage: Store) -> Result<Value, RpcErr> {

--- a/crates/rpc/debug_rpc/mod.rs
+++ b/crates/rpc/debug_rpc/mod.rs
@@ -1,0 +1,43 @@
+use serde_json::Value;
+use tracing::info;
+
+use crate::{eth::account::BlockIdentifierOrHash, utils::RpcErr, RpcHandler};
+use ethereum_rust_core::{rlp::encode::RLPEncode, types::Block};
+use ethereum_rust_storage::Store;
+
+pub struct GetRawBlock {
+    pub block: BlockIdentifierOrHash,
+}
+
+impl RpcHandler for GetRawBlock {
+    fn parse(params: &Option<Vec<Value>>) -> Option<GetRawBlock> {
+        let params = params.as_ref()?;
+        if params.len() != 1 {
+            return None;
+        }
+        Some(GetRawBlock {
+            block: serde_json::from_value(params[0].clone()).ok()?,
+        })
+    }
+
+    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+        info!("Requested raw block: {}", self.block);
+        let block_number = match self.block.resolve_block_number(&storage)? {
+            Some(block_number) => block_number,
+            _ => return Ok(Value::Null),
+        };
+        let header = storage.get_block_header(block_number)?;
+        let body = storage.get_block_body(block_number)?;
+        let (header, body) = match (header, body) {
+            (Some(header), Some(body)) => (header, body),
+            _ => return Ok(Value::Null),
+        };
+        let block = Block {
+            header: header.clone(),
+            body: body.clone(),
+        }
+        .encode_to_vec();
+
+        serde_json::to_value(format!("0x{}", &hex::encode(block))).map_err(|_| RpcErr::Internal)
+    }
+}

--- a/crates/rpc/debug_rpc/mod.rs
+++ b/crates/rpc/debug_rpc/mod.rs
@@ -1,12 +1,12 @@
 use serde_json::Value;
 use tracing::info;
 
-use crate::{eth::account::BlockIdentifierOrHash, utils::RpcErr, RpcHandler};
+use crate::{eth::block::BlockIdentifier, utils::RpcErr, RpcHandler};
 use ethereum_rust_core::{rlp::encode::RLPEncode, types::Block};
 use ethereum_rust_storage::Store;
 
 pub struct GetRawBlock {
-    pub block: BlockIdentifierOrHash,
+    pub block: BlockIdentifier,
 }
 
 impl RpcHandler for GetRawBlock {

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -16,7 +16,7 @@ use eth::{
     account::{GetBalanceRequest, GetCodeRequest, GetStorageAtRequest, GetTransactionCountRequest},
     block::{
         self, GetBlockByHashRequest, GetBlockByNumberRequest, GetBlockReceiptsRequest,
-        GetBlockTransactionCountRequest,
+        GetBlockTransactionCountRequest, GetRawBlock,
     },
     client,
     transaction::{
@@ -140,6 +140,7 @@ pub fn map_http_requests(
     match req.namespace() {
         Ok(RpcNamespace::Eth) => map_eth_requests(req, storage),
         Ok(RpcNamespace::Admin) => map_admin_requests(req, storage, local_p2p_node),
+        Ok(RpcNamespace::Debug) => map_debug_requests(req, storage),
         _ => Err(RpcErr::MethodNotFound),
     }
 }
@@ -149,6 +150,7 @@ pub fn map_authrpc_requests(req: &RpcRequest, storage: Store) -> Result<Value, R
     match req.namespace() {
         Ok(RpcNamespace::Engine) => map_engine_requests(req, storage),
         Ok(RpcNamespace::Eth) => map_eth_requests(req, storage),
+        Ok(RpcNamespace::Debug) => map_debug_requests(req, storage),
         _ => Err(RpcErr::MethodNotFound),
     }
 }
@@ -217,6 +219,13 @@ pub fn map_admin_requests(
 ) -> Result<Value, RpcErr> {
     match req.method.as_str() {
         "admin_nodeInfo" => admin::node_info(storage, local_p2p_node),
+        _ => Err(RpcErr::MethodNotFound),
+    }
+}
+
+pub fn map_debug_requests(req: &RpcRequest, storage: Store) -> Result<Value, RpcErr> {
+    match req.method.as_str() {
+        "debug_getRawBlock" => GetRawBlock::call(req, storage),
         _ => Err(RpcErr::MethodNotFound),
     }
 }

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -1,5 +1,6 @@
 use crate::authentication::authenticate;
 use bytes::Bytes;
+use debug_rpc::GetRawBlock;
 use std::{future::IntoFuture, net::SocketAddr};
 
 use axum::{routing::post, Json, Router};
@@ -16,7 +17,7 @@ use eth::{
     account::{GetBalanceRequest, GetCodeRequest, GetStorageAtRequest, GetTransactionCountRequest},
     block::{
         self, GetBlockByHashRequest, GetBlockByNumberRequest, GetBlockReceiptsRequest,
-        GetBlockTransactionCountRequest, GetRawBlock,
+        GetBlockTransactionCountRequest,
     },
     client,
     transaction::{
@@ -33,6 +34,7 @@ use utils::{
 };
 mod admin;
 mod authentication;
+mod debug_rpc;
 mod engine;
 mod eth;
 mod types;

--- a/crates/rpc/utils.rs
+++ b/crates/rpc/utils.rs
@@ -25,7 +25,7 @@ impl From<RpcErr> for RpcErrorMetadata {
                 message: "Method not found".to_string(),
             },
             RpcErr::BadParams => RpcErrorMetadata {
-                code: -32000,
+                code: -32602,
                 data: None,
                 message: "Invalid params".to_string(),
             },

--- a/crates/rpc/utils.rs
+++ b/crates/rpc/utils.rs
@@ -79,6 +79,7 @@ pub enum RpcNamespace {
     Engine,
     Eth,
     Admin,
+    Debug,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -97,6 +98,7 @@ impl RpcRequest {
                 "engine" => Ok(RpcNamespace::Engine),
                 "eth" => Ok(RpcNamespace::Eth),
                 "admin" => Ok(RpcNamespace::Admin),
+                "debug" => Ok(RpcNamespace::Debug),
                 _ => Err(RpcErr::MethodNotFound),
             }
         } else {

--- a/crates/rpc/utils.rs
+++ b/crates/rpc/utils.rs
@@ -8,7 +8,8 @@ use crate::authentication::AuthenticationError;
 #[derive(Debug)]
 pub enum RpcErr {
     MethodNotFound,
-    BadParams,
+    InvalidRequest,
+    InvalidParams,
     UnsuportedFork,
     Internal,
     Vm,
@@ -24,7 +25,12 @@ impl From<RpcErr> for RpcErrorMetadata {
                 data: None,
                 message: "Method not found".to_string(),
             },
-            RpcErr::BadParams => RpcErrorMetadata {
+            RpcErr::InvalidRequest => RpcErrorMetadata {
+                code: -32000,
+                data: None,
+                message: "Invalid request".to_string(),
+            },
+            RpcErr::InvalidParams => RpcErrorMetadata {
                 code: -32602,
                 data: None,
                 message: "Invalid params".to_string(),

--- a/test_data/genesis-kurtosis.json
+++ b/test_data/genesis-kurtosis.json
@@ -826,7 +826,7 @@
     },
     "0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02": {
       "balance": "0",
-      "nonce": "1",
+      "nonce": "0x1",
       "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"
     },
     "0x8943545177806ED17B9F23F0a21ee5948eCaa776": {


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
This PR adds the `debug_getRawBlock` RPC endpoint for retrieving raw block data and includes Hive tests to verify its functionality.

**Description**
- Add `debug_getRawBlock` RPC implementation.
- Include Hive tests for the new endpoint.
- Fix u64 deserialization from hex and `BadParams` error code: this [test](https://github.com/ethereum/execution-apis/blob/main/tests/debug_getRawBlock/get-invalid-number.io) was testing that when providing a number without a hex prefix (`0x`), then we should return bad params err. That required fixing the u64 hex decoding (by adding a prefix check) and returning the correct code number in the bad params error. We were previously returning `-32600`, which is for invalid requests. `-32602` (the one the test expected) is for actually invalid parameters. See more [here](https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#errors). However, this change made other tests fail since they expected the `-32000` code. So I left the current implementation as it was and instead changed only the `debug_getRawBlock`. Tbh, I am not quite sure what the difference is between them or if they can be used interchangeably.

Closes #327


