### PR TITLE
refactor: move chain config helpers into struct

### DIFF
--- a/crates/core/types/genesis.rs
+++ b/crates/core/types/genesis.rs
@@ -88,6 +88,35 @@ pub struct ChainConfig {
     pub terminal_total_difficulty_passed: bool,
 }
 
+#[derive(Debug, PartialEq, PartialOrd)]
+pub enum ForkId {
+    Paris = 0,
+    Shanghai = 1,
+    Cancun = 2,
+}
+
+impl ChainConfig {
+    pub fn is_shanghai_activated(&self, block_timestamp: u64) -> bool {
+        self.shanghai_time
+            .map_or(false, |time| time <= block_timestamp)
+    }
+
+    pub fn is_cancun_activated(&self, block_timestamp: u64) -> bool {
+        self.cancun_time
+            .map_or(false, |time| time <= block_timestamp)
+    }
+
+    pub fn get_fork(&self, block_timestamp: u64) -> ForkId {
+        if self.is_cancun_activated(block_timestamp) {
+            ForkId::Cancun
+        } else if self.is_shanghai_activated(block_timestamp) {
+            ForkId::Shanghai
+        } else {
+            ForkId::Paris
+        }
+    }
+}
+
 #[allow(unused)]
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct GenesisAccount {

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -125,16 +125,12 @@ fn run_evm(
     spec_id: SpecId,
 ) -> Result<ExecutionResult, EvmError> {
     let tx_result = {
-        let chain_id = state.database().get_chain_id()?;
+        let chain_spec = state.database().get_chain_config()?;
         let mut evm = Evm::builder()
             .with_db(&mut state.0)
             .with_block_env(block_env)
             .with_tx_env(tx_env)
-            .modify_cfg_env(|cfg| {
-                if let Some(chain_id) = chain_id {
-                    cfg.chain_id = chain_id
-                }
-            })
+            .modify_cfg_env(|cfg| cfg.chain_id = chain_spec.chain_id)
             .with_spec_id(spec_id)
             .with_external_context(
                 TracerEip3155::new(Box::new(std::io::stderr())).without_summary(),

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -235,7 +235,7 @@ fn run_without_commit(
         tx_env.gas_price,
         tx_env.max_fee_per_blob_gas,
     );
-    let chain_id = state.database().get_chain_id()?;
+    let chain_config = state.database().get_chain_config()?;
     let mut evm = Evm::builder()
         .with_db(&mut state.0)
         .with_block_env(block_env)
@@ -244,9 +244,7 @@ fn run_without_commit(
         .modify_cfg_env(|env| {
             env.disable_base_fee = true;
             env.disable_block_gas_limit = true;
-            if let Some(chain_id) = chain_id {
-                env.chain_id = chain_id
-            }
+            env.chain_id = chain_config.chain_id;
         })
         .build();
     let tx_result = evm.transact().map_err(EvmError::from)?;

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -541,11 +541,13 @@ fn access_list_inspector(
 /// WARNING: Assumes at least Merge fork is active
 pub fn spec_id(store: &Store, block_timestamp: u64) -> Result<SpecId, StoreError> {
     let chain_config = store.get_chain_config()?;
-    match chain_config.get_fork(block_timestamp) {
-        ForkId::Cancun => return Ok(SpecId::CANCUN),
-        ForkId::Shanghai => return Ok(SpecId::SHANGHAI),
-        ForkId::Paris => return Ok(SpecId::MERGE),
-    }
+    let spec = match chain_config.get_fork(block_timestamp) {
+        ForkId::Cancun => SpecId::CANCUN,
+        ForkId::Shanghai => SpecId::SHANGHAI,
+        ForkId::Paris => SpecId::MERGE,
+    };
+
+    Ok(spec)
 }
 
 /// Calculating gas_price according to EIP-1559 rules

--- a/crates/rpc/admin/mod.rs
+++ b/crates/rpc/admin/mod.rs
@@ -32,9 +32,9 @@ enum Protocol {
 pub fn node_info(storage: Store, local_node: Node) -> Result<Value, RpcErr> {
     let enode_url = local_node.enode_url();
     let mut protocols = HashMap::new();
-    if let Some(chain_config) = storage.get_chain_config()? {
-        protocols.insert("eth".to_string(), Protocol::Eth(chain_config));
-    }
+
+    let chain_config = storage.get_chain_config().map_err(|_| RpcErr::Internal)?;
+    protocols.insert("eth".to_string(), Protocol::Eth(chain_config));
 
     let node_info = NodeInfo {
         enode: enode_url,

--- a/crates/rpc/engine/exchange_transition_config.rs
+++ b/crates/rpc/engine/exchange_transition_config.rs
@@ -48,7 +48,7 @@ impl RpcHandler for ExchangeTransitionConfigV1Req {
         info!("Received new engine request: {self}");
         let payload = &self.payload;
 
-        let chain_config = storage.get_chain_config()?.ok_or(RpcErr::Internal)?;
+        let chain_config = storage.get_chain_config()?;
         let terminal_total_difficulty = chain_config.terminal_total_difficulty;
 
         if terminal_total_difficulty.unwrap_or_default() != payload.terminal_total_difficulty {

--- a/crates/rpc/engine/payload.rs
+++ b/crates/rpc/engine/payload.rs
@@ -1,5 +1,6 @@
 use ethereum_rust_chain::error::ChainError;
 use ethereum_rust_chain::{add_block, latest_valid_hash};
+use ethereum_rust_core::types::ForkId;
 use ethereum_rust_core::H256;
 use ethereum_rust_storage::Store;
 use serde_json::Value;
@@ -45,9 +46,9 @@ pub fn new_payload_v3(
     // Payload Validation
 
     // Check timestamp does not fall within the time frame of the Cancun fork
-    match storage.get_cancun_time()? {
-        Some(cancun_time) if block.header.timestamp > cancun_time => {}
-        _ => return Err(RpcErr::UnsuportedFork),
+    let chain_config = storage.get_chain_config()?;
+    if chain_config.get_fork(block.header.timestamp) < ForkId::Cancun {
+        return Err(RpcErr::UnsuportedFork);
     }
 
     // Check that block_hash is valid

--- a/crates/rpc/eth/client.rs
+++ b/crates/rpc/eth/client.rs
@@ -6,7 +6,7 @@ use crate::utils::RpcErr;
 
 pub fn chain_id(storage: Store) -> Result<Value, RpcErr> {
     info!("Requested chain id");
-    let chain_spec = storage.get_chain_spec().map_err(|_| RpcErr::Internal)?;
+    let chain_spec = storage.get_chain_config().map_err(|_| RpcErr::Internal)?;
     serde_json::to_value(format!("{:#x}", chain_spec.chain_id)).map_err(|_| RpcErr::Internal)
 }
 

--- a/crates/rpc/eth/client.rs
+++ b/crates/rpc/eth/client.rs
@@ -6,14 +6,8 @@ use crate::utils::RpcErr;
 
 pub fn chain_id(storage: Store) -> Result<Value, RpcErr> {
     info!("Requested chain id");
-    match storage.get_chain_id() {
-        Ok(Some(chain_id)) => {
-            serde_json::to_value(format!("{:#x}", chain_id)).map_err(|_| RpcErr::Internal)
-        }
-        // Treat missing value as internal error as we should have a chain id
-        // loaded in the db from loading the genesis file
-        _ => Err(RpcErr::Internal),
-    }
+    let chain_spec = storage.get_chain_spec().map_err(|_| RpcErr::Internal)?;
+    serde_json::to_value(format!("{:#x}", chain_spec.chain_id)).map_err(|_| RpcErr::Internal)
 }
 
 pub fn syncing() -> Result<Value, RpcErr> {

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -292,6 +292,9 @@ mod tests {
         // Setup initial storage
         let storage =
             Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+        storage
+            .set_chain_config(&example_chain_config())
+            .expect("Failed to write to test DB");
         // Values taken from https://github.com/ethereum/execution-apis/blob/main/tests/genesis.json
         // TODO: Replace this initialization with reading and storing genesis block
         storage
@@ -324,6 +327,9 @@ mod tests {
         // Setup initial storage
         let storage =
             Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+        storage
+            .set_chain_config(&example_chain_config())
+            .expect("Failed to write to test DB");
         // Values taken from https://github.com/ethereum/execution-apis/blob/main/tests/genesis.json
         // TODO: Replace this initialization with reading and storing genesis block
         storage

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -186,9 +186,6 @@ pub trait StoreEngine: Debug + Send {
     /// Returns the stored chain configuration
     fn get_chain_config(&self) -> Result<ChainConfig, StoreError>;
 
-    /// Obtain the current chain id
-    fn get_chain_id(&self) -> Result<Option<u64>, StoreError>;
-
     // Update earliest block number
     fn update_earliest_block_number(&mut self, block_number: BlockNumber)
         -> Result<(), StoreError>;

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -184,16 +184,10 @@ pub trait StoreEngine: Debug + Send {
     fn set_chain_config(&mut self, chain_config: &ChainConfig) -> Result<(), StoreError>;
 
     /// Returns the stored chain configuration
-    fn get_chain_config(&self) -> Result<Option<ChainConfig>, StoreError>;
+    fn get_chain_config(&self) -> Result<ChainConfig, StoreError>;
 
     /// Obtain the current chain id
     fn get_chain_id(&self) -> Result<Option<u64>, StoreError>;
-
-    /// Obtain the timestamp at which the cancun fork was activated
-    fn get_cancun_time(&self) -> Result<Option<u64>, StoreError>;
-
-    /// Obtain the timestamp at which the shanghai fork was activated
-    fn get_shanghai_time(&self) -> Result<Option<u64>, StoreError>;
 
     // Update earliest block number
     fn update_earliest_block_number(&mut self, block_number: BlockNumber)

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -199,29 +199,13 @@ impl StoreEngine for Store {
         Ok(())
     }
 
-    fn get_chain_config(&self) -> Result<Option<ChainConfig>, StoreError> {
-        Ok(self.chain_data.chain_config)
+    fn get_chain_config(&self) -> Result<ChainConfig, StoreError> {
+        Ok(self.chain_data.chain_config.unwrap())
     }
 
     fn get_chain_id(&self) -> Result<Option<u64>, StoreError> {
         if let Some(chain_config) = self.chain_data.chain_config {
             Ok(Some(chain_config.chain_id))
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn get_cancun_time(&self) -> Result<Option<u64>, StoreError> {
-        if let Some(chain_config) = self.chain_data.chain_config {
-            Ok(chain_config.cancun_time)
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn get_shanghai_time(&self) -> Result<Option<u64>, StoreError> {
-        if let Some(chain_config) = self.chain_data.chain_config {
-            Ok(chain_config.shanghai_time)
         } else {
             Ok(None)
         }

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -203,14 +203,6 @@ impl StoreEngine for Store {
         Ok(self.chain_data.chain_config.unwrap())
     }
 
-    fn get_chain_id(&self) -> Result<Option<u64>, StoreError> {
-        if let Some(chain_config) = self.chain_data.chain_config {
-            Ok(Some(chain_config.chain_id))
-        } else {
-            Ok(None)
-        }
-    }
-
     fn update_earliest_block_number(
         &mut self,
         block_number: BlockNumber,

--- a/crates/storage/engines/libmdbx.rs
+++ b/crates/storage/engines/libmdbx.rs
@@ -237,11 +237,6 @@ impl StoreEngine for Store {
         }
     }
 
-    fn get_chain_id(&self) -> Result<Option<u64>, StoreError> {
-        let chain_config = self.get_chain_config()?;
-        Ok(Some(chain_config.chain_id))
-    }
-
     fn account_storage_iter(
         &mut self,
         address: Address,

--- a/crates/storage/engines/libmdbx.rs
+++ b/crates/storage/engines/libmdbx.rs
@@ -225,24 +225,21 @@ impl StoreEngine for Store {
         )
     }
 
-    fn get_chain_config(&self) -> std::result::Result<Option<ChainConfig>, StoreError> {
+    fn get_chain_config(&self) -> Result<ChainConfig, StoreError> {
         match self.read::<ChainData>(ChainDataIndex::ChainConfig)? {
-            None => Ok(None),
+            None => Err(StoreError::Custom("Chain config not found".to_string())),
             Some(bytes) => {
                 let json = String::from_utf8(bytes).map_err(|_| StoreError::DecodeError)?;
                 let chain_config: ChainConfig =
                     serde_json::from_str(&json).map_err(|_| StoreError::DecodeError)?;
-                Ok(Some(chain_config))
+                Ok(chain_config)
             }
         }
     }
 
     fn get_chain_id(&self) -> Result<Option<u64>, StoreError> {
-        if let Some(chain_config) = dbg!(self.get_chain_config()?) {
-            Ok(Some(chain_config.chain_id))
-        } else {
-            Ok(None)
-        }
+        let chain_config = self.get_chain_config()?;
+        Ok(Some(chain_config.chain_id))
     }
 
     fn account_storage_iter(
@@ -258,22 +255,6 @@ impl StoreEngine for Store {
             .map_while(|res| res.ok().map(|(key, value)| (key.into(), value.into())));
         // We need to collect here so the resulting iterator doesn't read from the cursor itself
         Ok(Box::new(iter.collect::<Vec<_>>().into_iter()))
-    }
-
-    fn get_cancun_time(&self) -> Result<Option<u64>, StoreError> {
-        if let Some(chain_config) = self.get_chain_config()? {
-            Ok(chain_config.cancun_time)
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn get_shanghai_time(&self) -> Result<Option<u64>, StoreError> {
-        if let Some(chain_config) = self.get_chain_config()? {
-            Ok(chain_config.shanghai_time)
-        } else {
-            Ok(None)
-        }
     }
 
     fn update_earliest_block_number(

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -344,20 +344,12 @@ impl Store {
         self.engine.lock().unwrap().set_chain_config(chain_config)
     }
 
-    pub fn get_chain_config(&self) -> Result<Option<ChainConfig>, StoreError> {
+    pub fn get_chain_config(&self) -> Result<ChainConfig, StoreError> {
         self.engine.lock().unwrap().get_chain_config()
     }
 
     pub fn get_chain_id(&self) -> Result<Option<u64>, StoreError> {
         self.engine.lock().unwrap().get_chain_id()
-    }
-
-    pub fn get_cancun_time(&self) -> Result<Option<u64>, StoreError> {
-        self.engine.lock().unwrap().get_cancun_time()
-    }
-
-    pub fn get_shanghai_time(&self) -> Result<Option<u64>, StoreError> {
-        self.engine.lock().unwrap().get_shanghai_time()
     }
 
     pub fn update_earliest_block_number(
@@ -510,7 +502,6 @@ mod tests {
         run_test(&test_store_account_storage, engine_type);
         run_test(&test_remove_account_storage, engine_type);
         run_test(&test_increment_balance, engine_type);
-        run_test(&test_get_chain_id_cancun_time, engine_type);
         run_test(&test_store_block_tags, engine_type);
         run_test(&test_account_info_iter, engine_type);
         run_test(&test_world_state_root_smoke, engine_type);
@@ -758,23 +749,6 @@ mod tests {
         assert_eq!(stored_account_info.balance, 75.into());
     }
 
-    fn test_get_chain_id_cancun_time(store: Store) {
-        let chain_id = 46_u64;
-        let cancun_time = 12;
-        let chain_config = ChainConfig {
-            chain_id,
-            cancun_time: Some(cancun_time),
-            ..Default::default()
-        };
-
-        store.set_chain_config(&chain_config).unwrap();
-
-        let stored_chain_id = store.get_chain_id().unwrap().unwrap();
-        let stored_cancun_time = store.get_cancun_time().unwrap().unwrap();
-
-        assert_eq!(chain_id, stored_chain_id);
-        assert_eq!(cancun_time, stored_cancun_time);
-    }
     fn test_store_block_tags(store: Store) {
         let earliest_block_number = 0;
         let finalized_block_number = 7;
@@ -890,7 +864,7 @@ mod tests {
     fn test_chain_config_storage(store: Store) {
         let chain_config = example_chain_config();
         store.set_chain_config(&chain_config).unwrap();
-        let retrieved_chain_config = store.get_chain_config().unwrap().unwrap();
+        let retrieved_chain_config = store.get_chain_config().unwrap();
         assert_eq!(chain_config, retrieved_chain_config);
     }
 

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -348,10 +348,6 @@ impl Store {
         self.engine.lock().unwrap().get_chain_config()
     }
 
-    pub fn get_chain_id(&self) -> Result<Option<u64>, StoreError> {
-        self.engine.lock().unwrap().get_chain_id()
-    }
-
     pub fn update_earliest_block_number(
         &self,
         block_number: BlockNumber,


### PR DESCRIPTION
**Motivation**
We want to manage the config object as a single call to the db and lower the surface area of the store engine

