### PR TITLE
fix: use dashes for date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ HIVE_REVISION := 9bff4bbf4439336bd037a444560516dd49ff1c40
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our
 # target revision).
-HIVE_SHALLOW_SINCE := 2024_09_02
+HIVE_SHALLOW_SINCE := 2024-09-02
 hive:
 	git clone --single-branch --branch master --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive
 


### PR DESCRIPTION
**Motivation**

The Makefile migration had a typo where a date has underscores rather than dashes.
That broke the unshallow checkout on successive runs of `make setup-hive`, which
in turn would have broken the update mechanism for the fork.

**Description**

Simply use dashes.
