### PR TITLE
fix: add engine-auth test to CI

### DIFF
--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -26,7 +26,7 @@ jobs:
             run_command: make run-hive SIMULATION=ethereum/rpc-compat TEST_PATTERN="/eth_chainId|eth_getTransactionByBlockHashAndIndex|eth_getTransactionByBlockNumberAndIndex|eth_getCode|eth_getStorageAt|eth_call|eth_getTransactionByHash|eth_getBlockByHash|eth_getBlockByNumber|eth_createAccessList|eth_getBlockTransactionCountByNumber|eth_getBlockTransactionCountByHash|eth_getBlockReceipts|eth_getTransactionReceipt|eth_blobGasPrice|eth_blockNumber|ethGetTransactionCount|debug_getRawHeader|eth_estimateGas"
           - simulation: rpc-engine
             name: "Engine Auth tests"
-            run_command: make run-hive SIMULATION=ethereum/rpc-compat TEST_PATTERN="engine-auth"
+            run_command: make run-hive SIMULATION=ethereum/rpc-compat TEST_PATTERN="/engine-auth"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
**Motivation**

We are not running the `engine-auth` Hive tests in the CI  due to a missing `/`.

**Description**

Adds `engine-auth` to the CI again.

Closes None

