### PR TITLE
refactor: use `RpcHandler` for all RPC calls

### DIFF
--- a/crates/rpc/engine/fork_choice.rs
+++ b/crates/rpc/engine/fork_choice.rs
@@ -3,7 +3,7 @@ use serde_json::{json, Value};
 
 use crate::{
     types::fork_choice::{ForkChoiceState, PayloadAttributesV3},
-    RpcErr,
+    RpcErr, RpcHandler,
 };
 
 #[derive(Debug)]
@@ -13,8 +13,8 @@ pub struct ForkChoiceUpdatedV3 {
     pub payload_attributes: Option<PayloadAttributesV3>,
 }
 
-impl ForkChoiceUpdatedV3 {
-    pub fn parse(params: &Option<Vec<Value>>) -> Result<ForkChoiceUpdatedV3, RpcErr> {
+impl RpcHandler for ForkChoiceUpdatedV3 {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
         let params = params.as_ref().ok_or(RpcErr::BadParams)?;
         if params.len() != 2 {
             return Err(RpcErr::BadParams);
@@ -24,32 +24,29 @@ impl ForkChoiceUpdatedV3 {
             payload_attributes: serde_json::from_value(params[1].clone())?,
         })
     }
-}
 
-pub fn forkchoice_updated_v3(
-    request: ForkChoiceUpdatedV3,
-    storage: Store,
-) -> Result<Value, RpcErr> {
-    // Just a minimal implementation to pass rpc-compat Hive tests.
-    // TODO (#50): Implement `engine_forkchoiceUpdatedV3`
-    let safe = storage.get_block_number(request.fork_choice_state.safe_block_hash);
-    let finalized = storage.get_block_number(request.fork_choice_state.finalized_block_hash);
+    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+        // Just a minimal implementation to pass rpc-compat Hive tests.
+        // TODO (#50): Implement `engine_forkchoiceUpdatedV3`
+        let safe = storage.get_block_number(self.fork_choice_state.safe_block_hash);
+        let finalized = storage.get_block_number(self.fork_choice_state.finalized_block_hash);
 
-    // Check if we already have the blocks stored.
-    let (safe_block_number, finalized_block_number) = match (safe, finalized) {
-        (Ok(Some(safe)), Ok(Some(finalized))) => (safe, finalized),
-        _ => return Err(RpcErr::Internal),
-    };
+        // Check if we already have the blocks stored.
+        let (safe_block_number, finalized_block_number) = match (safe, finalized) {
+            (Ok(Some(safe)), Ok(Some(finalized))) => (safe, finalized),
+            _ => return Err(RpcErr::Internal),
+        };
 
-    storage.update_finalized_block_number(finalized_block_number)?;
-    storage.update_safe_block_number(safe_block_number)?;
-    serde_json::to_value(json!({
-        "payloadId": null,
-        "payloadStatus": {
-            "latestValidHash": null,
-            "status": "SYNCING",
-            "validationError": null
-        }
-    }))
-    .map_err(|_| RpcErr::Internal)
+        storage.update_finalized_block_number(finalized_block_number)?;
+        storage.update_safe_block_number(safe_block_number)?;
+        serde_json::to_value(json!({
+            "payloadId": null,
+            "payloadStatus": {
+                "latestValidHash": null,
+                "status": "SYNCING",
+                "validationError": null
+            }
+        }))
+        .map_err(|_| RpcErr::Internal)
+    }
 }

--- a/crates/rpc/engine/mod.rs
+++ b/crates/rpc/engine/mod.rs
@@ -2,11 +2,22 @@ pub mod exchange_transition_config;
 pub mod fork_choice;
 pub mod payload;
 
-use crate::RpcErr;
+use crate::{RpcErr, RpcHandler, Store};
 use serde_json::{json, Value};
 
 pub type ExchangeCapabilitiesRequest = Vec<String>;
 
-pub fn exchange_capabilities(capabilities: &ExchangeCapabilitiesRequest) -> Result<Value, RpcErr> {
-    Ok(json!(capabilities))
+impl RpcHandler for ExchangeCapabilitiesRequest {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        params
+            .as_ref()
+            .ok_or(RpcErr::BadParams)?
+            .first()
+            .ok_or(RpcErr::BadParams)
+            .and_then(|v| serde_json::from_value(v.clone()).map_err(|_| RpcErr::BadParams))
+    }
+
+    fn handle(&self, _storage: Store) -> Result<Value, RpcErr> {
+        Ok(json!(*self))
+    }
 }

--- a/crates/rpc/engine/payload.rs
+++ b/crates/rpc/engine/payload.rs
@@ -8,7 +8,7 @@ use tracing::{info, warn};
 
 use crate::{
     types::payload::{ExecutionPayloadV3, PayloadStatus},
-    RpcErr,
+    RpcErr, RpcHandler,
 };
 
 pub struct NewPayloadV3Request {
@@ -17,8 +17,8 @@ pub struct NewPayloadV3Request {
     pub parent_beacon_block_root: H256,
 }
 
-impl NewPayloadV3Request {
-    pub fn parse(params: &Option<Vec<Value>>) -> Result<NewPayloadV3Request, RpcErr> {
+impl RpcHandler for NewPayloadV3Request {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
         let params = params.as_ref().ok_or(RpcErr::BadParams)?;
         if params.len() != 3 {
             return Err(RpcErr::BadParams);
@@ -29,81 +29,93 @@ impl NewPayloadV3Request {
             parent_beacon_block_root: serde_json::from_value(params[2].clone())?,
         })
     }
-}
 
-pub fn new_payload_v3(
-    request: NewPayloadV3Request,
-    storage: Store,
-) -> Result<PayloadStatus, RpcErr> {
-    let block_hash = request.payload.block_hash;
-    info!("Received new payload with block hash: {block_hash}");
+    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+        let block_hash = self.payload.block_hash;
+        info!("Received new payload with block hash: {block_hash}");
 
-    let block = match request.payload.into_block(request.parent_beacon_block_root) {
-        Ok(block) => block,
-        Err(error) => return Ok(PayloadStatus::invalid_with_err(&error.to_string())),
-    };
-
-    // Payload Validation
-
-    // Check timestamp does not fall within the time frame of the Cancun fork
-    let chain_config = storage.get_chain_config()?;
-    if chain_config.get_fork(block.header.timestamp) < ForkId::Cancun {
-        return Err(RpcErr::UnsuportedFork);
-    }
-
-    // Check that block_hash is valid
-    let actual_block_hash = block.header.compute_block_hash();
-    if block_hash != actual_block_hash {
-        return Ok(PayloadStatus::invalid_with_err("Invalid block hash"));
-    }
-    info!("Block hash {block_hash} is valid");
-    // Concatenate blob versioned hashes lists (tx.blob_versioned_hashes) of each blob transaction included in the payload, respecting the order of inclusion
-    // and check that the resulting array matches expected_blob_versioned_hashes
-    let blob_versioned_hashes: Vec<H256> = block
-        .body
-        .transactions
-        .iter()
-        .flat_map(|tx| tx.blob_versioned_hashes())
-        .collect();
-    if request.expected_blob_versioned_hashes != blob_versioned_hashes {
-        return Ok(PayloadStatus::invalid_with_err(
-            "Invalid blob_versioned_hashes",
-        ));
-    }
-    // Check that the incoming block extends the current chain
-    let last_block_number = storage.get_latest_block_number()?.ok_or(RpcErr::Internal)?;
-    if block.header.number <= last_block_number {
-        // Check if we already have this block stored
-        if storage
-            .get_block_number(block_hash)
-            .map_err(|_| RpcErr::Internal)?
-            .is_some_and(|num| num == block.header.number)
+        let block = match self
+            .payload
+            .clone()
+            .into_block(self.parent_beacon_block_root)
         {
-            return Ok(PayloadStatus::valid_with_hash(block_hash));
+            Ok(block) => block,
+            Err(error) => {
+                let result = PayloadStatus::invalid_with_err(&error.to_string());
+                return serde_json::to_value(result).map_err(|_| RpcErr::Internal);
+            }
+        };
+
+        // Payload Validation
+
+        // Check timestamp does not fall within the time frame of the Cancun fork
+        let chain_config = storage.get_chain_config()?;
+        if chain_config.get_fork(block.header.timestamp) < ForkId::Cancun {
+            return Err(RpcErr::UnsuportedFork);
         }
-        warn!("Should start reorg but it is not supported yet");
-        return Err(RpcErr::Internal);
-    } else if block.header.number != last_block_number + 1 {
-        return Ok(PayloadStatus::syncing());
-    }
 
-    let latest_valid_hash = latest_valid_hash(&storage).map_err(|_| RpcErr::Internal)?;
-
-    // Execute and store the block
-    info!("Executing payload with block hash: {block_hash}");
-    match add_block(&block, &storage) {
-        Err(ChainError::NonCanonicalBlock) => Ok(PayloadStatus::syncing()),
-        Err(ChainError::ParentNotFound) => Ok(PayloadStatus::invalid_with_err(
-            "Could not reference parent block with parent_hash",
-        )),
-        Err(ChainError::InvalidBlock(_)) => Ok(PayloadStatus::invalid_with_hash(latest_valid_hash)),
-        Err(ChainError::EvmError(error)) => Ok(PayloadStatus::invalid_with_err(&error.to_string())),
-        Err(ChainError::StoreError(_)) => Err(RpcErr::Internal),
-        Ok(()) => {
-            info!("Block with hash {block_hash} executed succesfully");
-            info!("Block with hash {block_hash} added to storage");
-
-            Ok(PayloadStatus::valid_with_hash(block_hash))
+        // Check that block_hash is valid
+        let actual_block_hash = block.header.compute_block_hash();
+        if block_hash != actual_block_hash {
+            let result = PayloadStatus::invalid_with_err("Invalid block hash");
+            return serde_json::to_value(result).map_err(|_| RpcErr::Internal);
         }
+        info!("Block hash {block_hash} is valid");
+        // Concatenate blob versioned hashes lists (tx.blob_versioned_hashes) of each blob transaction included in the payload, respecting the order of inclusion
+        // and check that the resulting array matches expected_blob_versioned_hashes
+        let blob_versioned_hashes: Vec<H256> = block
+            .body
+            .transactions
+            .iter()
+            .flat_map(|tx| tx.blob_versioned_hashes())
+            .collect();
+        if self.expected_blob_versioned_hashes != blob_versioned_hashes {
+            let result = PayloadStatus::invalid_with_err("Invalid blob_versioned_hashes");
+            return serde_json::to_value(result).map_err(|_| RpcErr::Internal);
+        }
+        // Check that the incoming block extends the current chain
+        let last_block_number = storage.get_latest_block_number()?.ok_or(RpcErr::Internal)?;
+        if block.header.number <= last_block_number {
+            // Check if we already have this block stored
+            if storage
+                .get_block_number(block_hash)
+                .map_err(|_| RpcErr::Internal)?
+                .is_some_and(|num| num == block.header.number)
+            {
+                let result = PayloadStatus::valid_with_hash(block_hash);
+                return serde_json::to_value(result).map_err(|_| RpcErr::Internal);
+            }
+            warn!("Should start reorg but it is not supported yet");
+            return Err(RpcErr::Internal);
+        } else if block.header.number != last_block_number + 1 {
+            let result = PayloadStatus::syncing();
+            return serde_json::to_value(result).map_err(|_| RpcErr::Internal);
+        }
+
+        let latest_valid_hash = latest_valid_hash(&storage).map_err(|_| RpcErr::Internal)?;
+
+        // Execute and store the block
+        info!("Executing payload with block hash: {block_hash}");
+        let result = match add_block(&block, &storage) {
+            Err(ChainError::NonCanonicalBlock) => Ok(PayloadStatus::syncing()),
+            Err(ChainError::ParentNotFound) => Ok(PayloadStatus::invalid_with_err(
+                "Could not reference parent block with parent_hash",
+            )),
+            Err(ChainError::InvalidBlock(_)) => {
+                Ok(PayloadStatus::invalid_with_hash(latest_valid_hash))
+            }
+            Err(ChainError::EvmError(error)) => {
+                Ok(PayloadStatus::invalid_with_err(&error.to_string()))
+            }
+            Err(ChainError::StoreError(_)) => Err(RpcErr::Internal),
+            Ok(()) => {
+                info!("Block with hash {block_hash} executed succesfully");
+                info!("Block with hash {block_hash} added to storage");
+
+                Ok(PayloadStatus::valid_with_hash(block_hash))
+            }
+        }?;
+
+        serde_json::to_value(result).map_err(|_| RpcErr::Internal)
     }
 }

--- a/crates/rpc/eth/block.rs
+++ b/crates/rpc/eth/block.rs
@@ -51,6 +51,9 @@ pub struct GetRawReceipts {
     pub block: BlockIdentifier,
 }
 
+pub struct BlockNumberRequest;
+pub struct GetBlobBaseFee;
+
 impl RpcHandler for GetBlockByNumberRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetBlockByNumberRequest, RpcErr> {
         let params = params.as_ref().ok_or(RpcErr::BadParams)?;
@@ -262,6 +265,47 @@ impl RpcHandler for GetRawReceipts {
     }
 }
 
+impl RpcHandler for BlockNumberRequest {
+    fn parse(_params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        Ok(Self {})
+    }
+
+    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+        info!("Requested latest block number");
+        match storage.get_latest_block_number() {
+            Ok(Some(block_number)) => {
+                serde_json::to_value(format!("{:#x}", block_number)).map_err(|_| RpcErr::Internal)
+            }
+            _ => Err(RpcErr::Internal),
+        }
+    }
+}
+
+impl RpcHandler for GetBlobBaseFee {
+    fn parse(_params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        Ok(Self {})
+    }
+
+    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+        info!("Requested blob gas price");
+        match storage.get_latest_block_number() {
+            Ok(Some(block_number)) => {
+                let header = match storage.get_block_header(block_number)? {
+                    Some(header) => header,
+                    _ => return Err(RpcErr::Internal),
+                };
+                let parent_header = match find_parent_header(&header, &storage) {
+                    Ok(header) => header,
+                    _ => return Err(RpcErr::Internal),
+                };
+                let blob_base_fee = calculate_base_fee_per_blob_gas(&parent_header);
+                serde_json::to_value(format!("{:#x}", blob_base_fee)).map_err(|_| RpcErr::Internal)
+            }
+            _ => Err(RpcErr::Internal),
+        }
+    }
+}
+
 pub fn get_all_block_rpc_receipts(
     block_number: BlockNumber,
     header: BlockHeader,
@@ -325,33 +369,4 @@ pub fn get_all_block_receipts(
         receipts.push(receipt);
     }
     Ok(receipts)
-}
-
-pub fn block_number(storage: Store) -> Result<Value, RpcErr> {
-    info!("Requested latest block number");
-    match storage.get_latest_block_number() {
-        Ok(Some(block_number)) => {
-            serde_json::to_value(format!("{:#x}", block_number)).map_err(|_| RpcErr::Internal)
-        }
-        _ => Err(RpcErr::Internal),
-    }
-}
-
-pub fn get_blob_base_fee(storage: &Store) -> Result<Value, RpcErr> {
-    info!("Requested blob gas price");
-    match storage.get_latest_block_number() {
-        Ok(Some(block_number)) => {
-            let header = match storage.get_block_header(block_number)? {
-                Some(header) => header,
-                _ => return Err(RpcErr::Internal),
-            };
-            let parent_header = match find_parent_header(&header, storage) {
-                Ok(header) => header,
-                _ => return Err(RpcErr::Internal),
-            };
-            let blob_base_fee = calculate_base_fee_per_blob_gas(&parent_header);
-            serde_json::to_value(format!("{:#x}", blob_base_fee)).map_err(|_| RpcErr::Internal)
-        }
-        _ => Err(RpcErr::Internal),
-    }
 }

--- a/crates/rpc/eth/client.rs
+++ b/crates/rpc/eth/client.rs
@@ -1,15 +1,30 @@
-use ethereum_rust_storage::Store;
-use serde_json::Value;
 use tracing::info;
 
-use crate::utils::RpcErr;
+use ethereum_rust_storage::Store;
+use serde_json::Value;
 
-pub fn chain_id(storage: Store) -> Result<Value, RpcErr> {
-    info!("Requested chain id");
-    let chain_spec = storage.get_chain_config().map_err(|_| RpcErr::Internal)?;
-    serde_json::to_value(format!("{:#x}", chain_spec.chain_id)).map_err(|_| RpcErr::Internal)
+use crate::{utils::RpcErr, RpcHandler};
+
+pub struct ChainId;
+impl RpcHandler for ChainId {
+    fn parse(_params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        Ok(Self {})
+    }
+
+    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+        info!("Requested chain id");
+        let chain_spec = storage.get_chain_config().map_err(|_| RpcErr::Internal)?;
+        serde_json::to_value(format!("{:#x}", chain_spec.chain_id)).map_err(|_| RpcErr::Internal)
+    }
 }
 
-pub fn syncing() -> Result<Value, RpcErr> {
-    Ok(Value::Bool(false))
+pub struct Syncing;
+impl RpcHandler for Syncing {
+    fn parse(_params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        Ok(Self {})
+    }
+
+    fn handle(&self, _storage: Store) -> Result<Value, RpcErr> {
+        Ok(Value::Bool(false))
+    }
 }

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -8,18 +8,17 @@ use axum_extra::{
     TypedHeader,
 };
 use engine::{
-    exchange_transition_config::ExchangeTransitionConfigV1Req,
-    fork_choice::{self, ForkChoiceUpdatedV3},
-    payload::{self, NewPayloadV3Request},
-    ExchangeCapabilitiesRequest,
+    exchange_transition_config::ExchangeTransitionConfigV1Req, fork_choice::ForkChoiceUpdatedV3,
+    payload::NewPayloadV3Request, ExchangeCapabilitiesRequest,
 };
 use eth::{
     account::{GetBalanceRequest, GetCodeRequest, GetStorageAtRequest, GetTransactionCountRequest},
     block::{
-        self, GetBlockByHashRequest, GetBlockByNumberRequest, GetBlockReceiptsRequest,
-        GetBlockTransactionCountRequest, GetRawBlockRequest, GetRawHeaderRequest, GetRawReceipts,
+        BlockNumberRequest, GetBlobBaseFee, GetBlockByHashRequest, GetBlockByNumberRequest,
+        GetBlockReceiptsRequest, GetBlockTransactionCountRequest, GetRawBlockRequest,
+        GetRawHeaderRequest, GetRawReceipts,
     },
-    client,
+    client::{ChainId, Syncing},
     fee_market::FeeHistoryRequest,
     transaction::{
         CallRequest, CreateAccessListRequest, EstimateGasRequest, GetRawTransaction,
@@ -159,8 +158,8 @@ pub fn map_authrpc_requests(req: &RpcRequest, storage: Store) -> Result<Value, R
 
 pub fn map_eth_requests(req: &RpcRequest, storage: Store) -> Result<Value, RpcErr> {
     match req.method.as_str() {
-        "eth_chainId" => client::chain_id(storage),
-        "eth_syncing" => client::syncing(),
+        "eth_chainId" => ChainId::call(req, storage),
+        "eth_syncing" => Syncing::call(req, storage),
         "eth_getBlockByNumber" => GetBlockByNumberRequest::call(req, storage),
         "eth_getBlockByHash" => GetBlockByHashRequest::call(req, storage),
         "eth_getBalance" => GetBalanceRequest::call(req, storage),
@@ -180,9 +179,9 @@ pub fn map_eth_requests(req: &RpcRequest, storage: Store) -> Result<Value, RpcEr
         "eth_getTransactionByHash" => GetTransactionByHashRequest::call(req, storage),
         "eth_getTransactionReceipt" => GetTransactionReceiptRequest::call(req, storage),
         "eth_createAccessList" => CreateAccessListRequest::call(req, storage),
-        "eth_blockNumber" => block::block_number(storage),
+        "eth_blockNumber" => BlockNumberRequest::call(req, storage),
         "eth_call" => CallRequest::call(req, storage),
-        "eth_blobBaseFee" => block::get_blob_base_fee(&storage),
+        "eth_blobBaseFee" => GetBlobBaseFee::call(req, storage),
         "eth_getTransactionCount" => GetTransactionCountRequest::call(req, storage),
         "eth_feeHistory" => FeeHistoryRequest::call(req, storage),
         "eth_estimateGas" => EstimateGasRequest::call(req, storage),
@@ -202,26 +201,9 @@ pub fn map_debug_requests(req: &RpcRequest, storage: Store) -> Result<Value, Rpc
 
 pub fn map_engine_requests(req: &RpcRequest, storage: Store) -> Result<Value, RpcErr> {
     match req.method.as_str() {
-        "engine_exchangeCapabilities" => {
-            let capabilities: ExchangeCapabilitiesRequest = req
-                .params
-                .as_ref()
-                .ok_or(RpcErr::BadParams)?
-                .first()
-                .ok_or(RpcErr::BadParams)
-                .and_then(|v| serde_json::from_value(v.clone()).map_err(|_| RpcErr::BadParams))?;
-            engine::exchange_capabilities(&capabilities)
-        }
-
-        "engine_forkchoiceUpdatedV3" => {
-            let request = ForkChoiceUpdatedV3::parse(&req.params)?;
-            fork_choice::forkchoice_updated_v3(request, storage)
-        }
-        "engine_newPayloadV3" => {
-            let request = NewPayloadV3Request::parse(&req.params)?;
-            serde_json::to_value(payload::new_payload_v3(request, storage)?)
-                .map_err(|_| RpcErr::Internal)
-        }
+        "engine_exchangeCapabilities" => ExchangeCapabilitiesRequest::call(req, storage),
+        "engine_forkchoiceUpdatedV3" => ForkChoiceUpdatedV3::call(req, storage),
+        "engine_newPayloadV3" => NewPayloadV3Request::call(req, storage),
         "engine_exchangeTransitionConfigurationV1" => {
             ExchangeTransitionConfigV1Req::call(req, storage)
         }

--- a/crates/rpc/types/payload.rs
+++ b/crates/rpc/types/payload.rs
@@ -11,7 +11,7 @@ use ethereum_rust_core::{
     Address, Bloom, H256,
 };
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecutionPayloadV3 {
     parent_hash: H256,
@@ -41,7 +41,7 @@ pub struct ExecutionPayloadV3 {
     excess_blob_gas: u64,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct EncodedTransaction(pub Bytes);
 
 impl<'de> Deserialize<'de> for EncodedTransaction {


### PR DESCRIPTION
**Motivation**

Improve code organization.

**Description**

This migrates all the remaining endpoints except for the admin requests,
which require a `Node` argument the trait doesn't provide.

Resolves #376
Closes #376
