### PR TITLE
fix: make base_fee_per_gas optional when decoding chain.rlp

### DIFF
--- a/cmd/ef_tests/types.rs
+++ b/cmd/ef_tests/types.rs
@@ -202,7 +202,7 @@ impl From<Header> for BlockHeader {
             extra_data: val.extra_data,
             prev_randao: val.mix_hash,
             nonce: val.nonce.to_low_u64_be(),
-            base_fee_per_gas: val.base_fee_per_gas.unwrap().as_u64(),
+            base_fee_per_gas: val.base_fee_per_gas.map(|v| v.as_u64()),
             withdrawals_root: val.withdrawals_root,
             blob_gas_used: val.blob_gas_used.map(|x| x.as_u64()),
             excess_blob_gas: val.excess_blob_gas.map(|x| x.as_u64()),

--- a/crates/core/types/block.rs
+++ b/crates/core/types/block.rs
@@ -1,6 +1,6 @@
 use super::{
     BASE_FEE_MAX_CHANGE_DENOMINATOR, BLOB_BASE_FEE_UPDATE_FRACTION, ELASTICITY_MULTIPLIER,
-    GAS_LIMIT_ADJUSTMENT_FACTOR, GAS_LIMIT_MINIMUM, MIN_BASE_FEE_PER_BLOB_GAS,
+    GAS_LIMIT_ADJUSTMENT_FACTOR, GAS_LIMIT_MINIMUM, INITIAL_BASE_FEE, MIN_BASE_FEE_PER_BLOB_GAS,
 };
 use crate::{
     rlp::{
@@ -94,8 +94,8 @@ pub struct BlockHeader {
     pub prev_randao: H256,
     #[serde(with = "crate::serde_utils::u64::hex_str_padding")]
     pub nonce: u64,
-    #[serde(with = "crate::serde_utils::u64::hex_str")]
-    pub base_fee_per_gas: u64,
+    #[serde(with = "crate::serde_utils::u64::hex_str_opt")]
+    pub base_fee_per_gas: Option<u64>,
     pub withdrawals_root: Option<H256>,
     #[serde(with = "crate::serde_utils::u64::hex_str_opt")]
     pub blob_gas_used: Option<u64>,
@@ -122,7 +122,7 @@ impl RLPEncode for BlockHeader {
             .encode_field(&self.extra_data)
             .encode_field(&self.prev_randao)
             .encode_field(&self.nonce.to_be_bytes())
-            .encode_field(&self.base_fee_per_gas)
+            .encode_optional_field(&self.base_fee_per_gas)
             .encode_optional_field(&self.withdrawals_root)
             .encode_optional_field(&self.blob_gas_used)
             .encode_optional_field(&self.excess_blob_gas)
@@ -150,7 +150,7 @@ impl RLPDecode for BlockHeader {
         let (prev_randao, decoder) = decoder.decode_field("prev_randao")?;
         let (nonce, decoder) = decoder.decode_field("nonce")?;
         let nonce = u64::from_be_bytes(nonce);
-        let (base_fee_per_gas, decoder) = decoder.decode_field("base_fee_per_gas")?;
+        let (base_fee_per_gas, decoder) = decoder.decode_optional_field();
         let (withdrawals_root, decoder) = decoder.decode_optional_field();
         let (blob_gas_used, decoder) = decoder.decode_optional_field();
         let (excess_blob_gas, decoder) = decoder.decode_optional_field();
@@ -397,14 +397,14 @@ pub fn validate_block_header(header: &BlockHeader, parent_header: &BlockHeader) 
         header.gas_limit,
         parent_header.gas_limit,
         parent_header.gas_used,
-        parent_header.base_fee_per_gas,
+        parent_header.base_fee_per_gas.unwrap_or(INITIAL_BASE_FEE),
     ) {
         base_fee
     } else {
         return false;
     };
 
-    expected_base_fee_per_gas == header.base_fee_per_gas
+    expected_base_fee_per_gas == header.base_fee_per_gas.unwrap_or(INITIAL_BASE_FEE)
         && header.timestamp > parent_header.timestamp
         && header.number == parent_header.number + 1
         && header.extra_data.len() <= 32
@@ -508,7 +508,7 @@ mod test {
             extra_data: Bytes::new(),
             prev_randao: H256::zero(),
             nonce: 0x0000000000000000,
-            base_fee_per_gas: 0x07,
+            base_fee_per_gas: Some(0x07),
             withdrawals_root: Some(
                 H256::from_str(
                     "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
@@ -550,7 +550,7 @@ mod test {
             extra_data: Bytes::new(),
             prev_randao: H256::zero(),
             nonce: 0x0000000000000000,
-            base_fee_per_gas: 0x07,
+            base_fee_per_gas: Some(0x07),
             withdrawals_root: Some(
                 H256::from_str(
                     "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",

--- a/crates/core/types/genesis.rs
+++ b/crates/core/types/genesis.rs
@@ -164,7 +164,7 @@ impl Genesis {
             extra_data: self.extra_data.clone(),
             prev_randao: self.mix_hash,
             nonce: self.nonce,
-            base_fee_per_gas: self.base_fee_per_gas.unwrap_or(INITIAL_BASE_FEE),
+            base_fee_per_gas: self.base_fee_per_gas.or(Some(INITIAL_BASE_FEE)),
             withdrawals_root: Some(compute_withdrawals_root(&[])),
             blob_gas_used,
             excess_blob_gas,
@@ -212,6 +212,8 @@ impl Genesis {
 mod tests {
     use std::str::FromStr;
     use std::{fs::File, io::BufReader};
+
+    use crate::types::INITIAL_BASE_FEE;
 
     use super::*;
 
@@ -328,7 +330,10 @@ mod tests {
         assert_eq!(header.extra_data, Bytes::default());
         assert_eq!(header.prev_randao, H256::from([0; 32]));
         assert_eq!(header.nonce, 4660);
-        assert_eq!(header.base_fee_per_gas, INITIAL_BASE_FEE);
+        assert_eq!(
+            header.base_fee_per_gas.unwrap_or(INITIAL_BASE_FEE),
+            INITIAL_BASE_FEE
+        );
         assert_eq!(header.withdrawals_root, Some(compute_withdrawals_root(&[])));
         assert_eq!(header.blob_gas_used, Some(0));
         assert_eq!(header.excess_blob_gas, Some(0));

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -9,7 +9,7 @@ use db::StoreWrapper;
 use ethereum_rust_core::{
     types::{
         AccountInfo, Block, BlockHeader, ForkId, GenericTransaction, Receipt, Transaction, TxKind,
-        Withdrawal, GWEI_TO_WEI,
+        Withdrawal, GWEI_TO_WEI, INITIAL_BASE_FEE,
     },
     Address, BigEndianHash, H256, U256,
 };
@@ -97,7 +97,7 @@ pub fn simulate_tx_from_generic(
     spec_id: SpecId,
 ) -> Result<ExecutionResult, EvmError> {
     let block_env = block_env(header);
-    let tx_env = tx_env_from_generic(tx, header.base_fee_per_gas);
+    let tx_env = tx_env_from_generic(tx, header.base_fee_per_gas.unwrap_or(INITIAL_BASE_FEE));
     run_without_commit(tx_env, block_env, state, spec_id)
 }
 
@@ -148,7 +148,7 @@ pub fn create_access_list(
     state: &mut EvmState,
     spec_id: SpecId,
 ) -> Result<(ExecutionResult, AccessList), EvmError> {
-    let mut tx_env = tx_env_from_generic(tx, header.base_fee_per_gas);
+    let mut tx_env = tx_env_from_generic(tx, header.base_fee_per_gas.unwrap_or(INITIAL_BASE_FEE));
     let block_env = block_env(header);
     // Run tx with access list inspector
 
@@ -395,7 +395,7 @@ fn block_env(header: &BlockHeader) -> BlockEnv {
         coinbase: RevmAddress(header.coinbase.0.into()),
         timestamp: RevmU256::from(header.timestamp),
         gas_limit: RevmU256::from(header.gas_limit),
-        basefee: RevmU256::from(header.base_fee_per_gas),
+        basefee: RevmU256::from(header.base_fee_per_gas.unwrap_or(INITIAL_BASE_FEE)),
         difficulty: RevmU256::from_limbs(header.difficulty.0),
         prevrandao: Some(header.prev_randao.as_fixed_bytes().into()),
         blob_excess_gas_and_price: Some(BlobExcessGasAndPrice::new(

--- a/crates/rpc/types/block.rs
+++ b/crates/rpc/types/block.rs
@@ -141,7 +141,7 @@ mod test {
             extra_data: Bytes::new(),
             prev_randao: H256::zero(),
             nonce: 0x0000000000000000,
-            base_fee_per_gas: 0x07,
+            base_fee_per_gas: Some(0x07),
             withdrawals_root: Some(
                 H256::from_str(
                     "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",

--- a/crates/rpc/types/payload.rs
+++ b/crates/rpc/types/payload.rs
@@ -95,7 +95,7 @@ impl ExecutionPayloadV3 {
                 extra_data: self.extra_data,
                 prev_randao: self.prev_randao,
                 nonce: 0,
-                base_fee_per_gas: self.base_fee_per_gas,
+                base_fee_per_gas: Some(self.base_fee_per_gas),
                 withdrawals_root: Some(compute_withdrawals_root(
                     &body.withdrawals.clone().unwrap_or_default(),
                 )),

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -600,7 +600,7 @@ mod tests {
             extra_data: Bytes::new(),
             prev_randao: H256::zero(),
             nonce: 0x0000000000000000,
-            base_fee_per_gas: 0x07,
+            base_fee_per_gas: Some(0x07),
             withdrawals_root: Some(
                 H256::from_str(
                     "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",


### PR DESCRIPTION
**Motivation**

When running Hive devp2p tests, the node unexpectedly finishes before executing any test with the following message:

```
Error decoding field 'base_fee_per_gas' of type u64: InvalidLength
```
**Description**

Makes the field `base_fee_per_gas` optional, and use `INITIAL_BASE_FEE` when missing.

Closes None

