### PR TITLE
refactor: allow different tables Libdbmx TrieDB implementation using generics

### DIFF
--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -159,7 +159,7 @@ impl<DB: TrieDB> Trie<DB> {
 mod test {
     use std::sync::Arc;
 
-    use crate::trie::test_utils::new_temp_trie;
+    use crate::trie::test_utils::{new_db, TestNodes};
 
     use super::*;
     // Rename imports to avoid potential name clashes
@@ -177,7 +177,8 @@ mod test {
 
     #[test]
     fn compute_hash() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert(b"first".to_vec(), b"value".to_vec()).unwrap();
         trie.insert(b"second".to_vec(), b"value".to_vec()).unwrap();
 
@@ -189,7 +190,8 @@ mod test {
 
     #[test]
     fn compute_hash_long() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert(b"first".to_vec(), b"value".to_vec()).unwrap();
         trie.insert(b"second".to_vec(), b"value".to_vec()).unwrap();
         trie.insert(b"third".to_vec(), b"value".to_vec()).unwrap();
@@ -203,7 +205,8 @@ mod test {
 
     #[test]
     fn get_insert_words() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let first_path = b"first".to_vec();
         let first_value = b"value_a".to_vec();
         let second_path = b"second".to_vec();
@@ -223,7 +226,8 @@ mod test {
 
     #[test]
     fn get_insert_zero() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert(vec![0x0], b"value".to_vec()).unwrap();
         let first = trie.get(&[0x0][..].to_vec()).unwrap();
         assert_eq!(first, Some(b"value".to_vec()));
@@ -231,7 +235,8 @@ mod test {
 
     #[test]
     fn get_insert_a() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert(vec![16], vec![0]).unwrap();
         trie.insert(vec![16, 0], vec![0]).unwrap();
 
@@ -244,7 +249,8 @@ mod test {
 
     #[test]
     fn get_insert_b() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert(vec![0, 0], vec![0, 0]).unwrap();
         trie.insert(vec![1, 0], vec![1, 0]).unwrap();
 
@@ -257,7 +263,8 @@ mod test {
 
     #[test]
     fn get_insert_c() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let vecs = vec![
             vec![26, 192, 44, 251],
             vec![195, 132, 220, 124, 112, 201, 70, 128, 235],
@@ -276,7 +283,8 @@ mod test {
 
     #[test]
     fn get_insert_d() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let vecs = vec![
             vec![52, 53, 143, 52, 206, 112],
             vec![14, 183, 34, 39, 113],
@@ -299,7 +307,8 @@ mod test {
 
     #[test]
     fn get_insert_e() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert(vec![0x00], vec![0x00]).unwrap();
         trie.insert(vec![0xC8], vec![0xC8]).unwrap();
         trie.insert(vec![0xC8, 0x00], vec![0xC8, 0x00]).unwrap();
@@ -311,7 +320,8 @@ mod test {
 
     #[test]
     fn get_insert_f() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert(vec![0x00], vec![0x00]).unwrap();
         trie.insert(vec![0x01], vec![0x01]).unwrap();
         trie.insert(vec![0x10], vec![0x10]).unwrap();
@@ -329,7 +339,8 @@ mod test {
 
     #[test]
     fn get_insert_remove_a() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert(b"do".to_vec(), b"verb".to_vec()).unwrap();
         trie.insert(b"horse".to_vec(), b"stallion".to_vec())
             .unwrap();
@@ -341,7 +352,8 @@ mod test {
 
     #[test]
     fn get_insert_remove_b() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert(vec![185], vec![185]).unwrap();
         trie.insert(vec![185, 0], vec![185, 0]).unwrap();
         trie.insert(vec![185, 1], vec![185, 1]).unwrap();
@@ -353,7 +365,8 @@ mod test {
 
     #[test]
     fn compute_hash_a() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert(b"do".to_vec(), b"verb".to_vec()).unwrap();
         trie.insert(b"horse".to_vec(), b"stallion".to_vec())
             .unwrap();
@@ -368,7 +381,8 @@ mod test {
 
     #[test]
     fn compute_hash_b() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         assert_eq!(
             trie.hash().unwrap().0.as_slice(),
             hex!("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421").as_slice(),
@@ -377,7 +391,8 @@ mod test {
 
     #[test]
     fn compute_hash_c() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let data = [
             (
                 hex!("0000000000000000000000000000000000000000000000000000000000000045").to_vec(),
@@ -429,7 +444,8 @@ mod test {
 
     #[test]
     fn compute_hash_d() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
 
         let data = [
             (
@@ -461,7 +477,8 @@ mod test {
 
     #[test]
     fn compute_hash_e() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert(b"abc".to_vec(), b"123".to_vec()).unwrap();
         trie.insert(b"abcd".to_vec(), b"abcd".to_vec()).unwrap();
         trie.insert(b"abc".to_vec(), b"abc".to_vec()).unwrap();
@@ -474,7 +491,8 @@ mod test {
 
     #[test]
     fn get_old_state() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert([0; 32].to_vec(), [0; 32].to_vec()).unwrap();
         trie.insert([1; 32].to_vec(), [1; 32].to_vec()).unwrap();
 
@@ -498,7 +516,8 @@ mod test {
 
     #[test]
     fn get_old_state_with_removals() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert([0; 32].to_vec(), [0; 32].to_vec()).unwrap();
         trie.insert([1; 32].to_vec(), [1; 32].to_vec()).unwrap();
         trie.insert([2; 32].to_vec(), [2; 32].to_vec()).unwrap();
@@ -530,7 +549,8 @@ mod test {
 
     #[test]
     fn revert() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert([0; 32].to_vec(), [0; 32].to_vec()).unwrap();
         trie.insert([1; 32].to_vec(), [1; 32].to_vec()).unwrap();
 
@@ -550,7 +570,8 @@ mod test {
 
     #[test]
     fn revert_with_removals() {
-        let mut trie = new_temp_trie();
+        let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         trie.insert([0; 32].to_vec(), [0; 32].to_vec()).unwrap();
         trie.insert([1; 32].to_vec(), [1; 32].to_vec()).unwrap();
         trie.insert([2; 32].to_vec(), [2; 32].to_vec()).unwrap();
@@ -575,11 +596,11 @@ mod test {
     fn resume_trie() {
         const TRIE_DIR: &str = "trie-db-resume-trie-test";
         let trie_dir = TempDir::new(TRIE_DIR).expect("Failed to create temp dir");
-        let trie_dir = trie_dir.path().to_str().unwrap();
+        let trie_dir = trie_dir.path();
 
         // Create new trie from clean DB
-        let db = Libmdbx::create(trie_dir).unwrap();
-        let mut trie = Trie::new(db);
+        let db = test_utils::new_db_with_path::<TestNodes>(trie_dir.into());
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
 
         trie.insert([0; 32].to_vec(), [1; 32].to_vec()).unwrap();
         trie.insert([1; 32].to_vec(), [2; 32].to_vec()).unwrap();
@@ -588,11 +609,11 @@ mod test {
         // Save current root
         let root = trie.hash().unwrap();
 
-        drop(trie); // Release DB
+        drop(db); // Release DB
 
-        let mut db2 = Libmdbx::open(trie_dir).unwrap();
+        let mut db2 = test_utils::open_db::<TestNodes>(trie_dir.to_str().unwrap());
         // Create a new trie based on the previous trie's DB
-        let trie = Trie::open(db2, root);
+        let trie = Trie::open(Libmdbx::<TestNodes>::new(&db2), root);
 
         assert_eq!(trie.get(&[0; 32].to_vec()).unwrap(), Some([1; 32].to_vec()));
         assert_eq!(trie.get(&[1; 32].to_vec()).unwrap(), Some([2; 32].to_vec()));
@@ -603,7 +624,8 @@ mod test {
     proptest! {
         #[test]
         fn proptest_get_insert(data in btree_set(vec(any::<u8>(), 1..100), 1..100)) {
-            let mut trie = new_temp_trie();
+            let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
 
             for val in data.iter(){
                 trie.insert(val.clone(), val.clone()).unwrap();
@@ -618,7 +640,8 @@ mod test {
 
         #[test]
         fn proptest_get_insert_with_removals(mut data in vec((vec(any::<u8>(), 5..100), any::<bool>()), 1..100)) {
-            let mut trie = new_temp_trie();
+            let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
             // Remove duplicate values with different expected status
             data.sort_by_key(|(val, _)| val.clone());
             data.dedup_by_key(|(val, _)| val.clone());
@@ -648,7 +671,8 @@ mod test {
         // The previous test needs to sort the input values in order to get rid of duplicate entries, leading to ordered insertions
         // This check has a fixed way of determining wether a value should be removed but doesn't require ordered insertions
         fn proptest_get_insert_with_removals_unsorted(data in btree_set(vec(any::<u8>(), 5..100), 1..100)) {
-            let mut trie = new_temp_trie();
+            let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
             // Remove all values that have an odd first value
             let remove = |value: &Vec<u8>| -> bool {
                 value.first().is_some_and(|v| v % 2 != 0)
@@ -678,7 +702,8 @@ mod test {
 
         #[test]
         fn proptest_compare_hash(data in btree_set(vec(any::<u8>(), 1..100), 1..100)) {
-            let mut trie = new_temp_trie();
+            let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
             let mut cita_trie = cita_trie();
 
             for val in data.iter(){
@@ -693,7 +718,8 @@ mod test {
 
         #[test]
         fn proptest_compare_hash_with_removals(mut data in vec((vec(any::<u8>(), 5..100), any::<bool>()), 1..100)) {
-            let mut trie = new_temp_trie();
+            let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
             let mut cita_trie = cita_trie();
             // Remove duplicate values with different expected status
             data.sort_by_key(|(val, _)| val.clone());
@@ -720,7 +746,8 @@ mod test {
         // The previous test needs to sort the input values in order to get rid of duplicate entries, leading to ordered insertions
         // This check has a fixed way of determining wether a value should be removed but doesn't require ordered insertions
         fn proptest_compare_hash_with_removals_unsorted(data in btree_set(vec(any::<u8>(), 5..100), 1..100)) {
-            let mut trie = new_temp_trie();
+            let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
             let mut cita_trie = cita_trie();
             // Remove all values that have an odd first value
             let remove = |value: &Vec<u8>| -> bool {
@@ -746,7 +773,8 @@ mod test {
 
         #[test]
         fn proptest_compare_hash_between_inserts(data in btree_set(vec(any::<u8>(), 1..100), 1..100)) {
-            let mut trie = new_temp_trie();
+            let db = test_utils::new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
             let mut cita_trie = cita_trie();
 
             for val in data.iter(){

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -165,7 +165,7 @@ mod test {
     // Rename imports to avoid potential name clashes
     use super::test_utils;
     use cita_trie::{MemoryDB as CitaMemoryDB, PatriciaTrie as CitaTrie, Trie as CitaTrieTrait};
-    use db::libmdbx::Libmdbx;
+    use db::libmdbx::LibmdbxTrieDB;
     use hasher::HasherKeccak;
     use hex_literal::hex;
     use proptest::{
@@ -178,7 +178,7 @@ mod test {
     #[test]
     fn compute_hash() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert(b"first".to_vec(), b"value".to_vec()).unwrap();
         trie.insert(b"second".to_vec(), b"value".to_vec()).unwrap();
 
@@ -191,7 +191,7 @@ mod test {
     #[test]
     fn compute_hash_long() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert(b"first".to_vec(), b"value".to_vec()).unwrap();
         trie.insert(b"second".to_vec(), b"value".to_vec()).unwrap();
         trie.insert(b"third".to_vec(), b"value".to_vec()).unwrap();
@@ -206,7 +206,7 @@ mod test {
     #[test]
     fn get_insert_words() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let first_path = b"first".to_vec();
         let first_value = b"value_a".to_vec();
         let second_path = b"second".to_vec();
@@ -227,7 +227,7 @@ mod test {
     #[test]
     fn get_insert_zero() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert(vec![0x0], b"value".to_vec()).unwrap();
         let first = trie.get(&[0x0][..].to_vec()).unwrap();
         assert_eq!(first, Some(b"value".to_vec()));
@@ -236,7 +236,7 @@ mod test {
     #[test]
     fn get_insert_a() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert(vec![16], vec![0]).unwrap();
         trie.insert(vec![16, 0], vec![0]).unwrap();
 
@@ -250,7 +250,7 @@ mod test {
     #[test]
     fn get_insert_b() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert(vec![0, 0], vec![0, 0]).unwrap();
         trie.insert(vec![1, 0], vec![1, 0]).unwrap();
 
@@ -264,7 +264,7 @@ mod test {
     #[test]
     fn get_insert_c() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let vecs = vec![
             vec![26, 192, 44, 251],
             vec![195, 132, 220, 124, 112, 201, 70, 128, 235],
@@ -284,7 +284,7 @@ mod test {
     #[test]
     fn get_insert_d() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let vecs = vec![
             vec![52, 53, 143, 52, 206, 112],
             vec![14, 183, 34, 39, 113],
@@ -308,7 +308,7 @@ mod test {
     #[test]
     fn get_insert_e() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert(vec![0x00], vec![0x00]).unwrap();
         trie.insert(vec![0xC8], vec![0xC8]).unwrap();
         trie.insert(vec![0xC8, 0x00], vec![0xC8, 0x00]).unwrap();
@@ -321,7 +321,7 @@ mod test {
     #[test]
     fn get_insert_f() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert(vec![0x00], vec![0x00]).unwrap();
         trie.insert(vec![0x01], vec![0x01]).unwrap();
         trie.insert(vec![0x10], vec![0x10]).unwrap();
@@ -340,7 +340,7 @@ mod test {
     #[test]
     fn get_insert_remove_a() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert(b"do".to_vec(), b"verb".to_vec()).unwrap();
         trie.insert(b"horse".to_vec(), b"stallion".to_vec())
             .unwrap();
@@ -353,7 +353,7 @@ mod test {
     #[test]
     fn get_insert_remove_b() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert(vec![185], vec![185]).unwrap();
         trie.insert(vec![185, 0], vec![185, 0]).unwrap();
         trie.insert(vec![185, 1], vec![185, 1]).unwrap();
@@ -366,7 +366,7 @@ mod test {
     #[test]
     fn compute_hash_a() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert(b"do".to_vec(), b"verb".to_vec()).unwrap();
         trie.insert(b"horse".to_vec(), b"stallion".to_vec())
             .unwrap();
@@ -382,7 +382,7 @@ mod test {
     #[test]
     fn compute_hash_b() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         assert_eq!(
             trie.hash().unwrap().0.as_slice(),
             hex!("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421").as_slice(),
@@ -392,7 +392,7 @@ mod test {
     #[test]
     fn compute_hash_c() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let data = [
             (
                 hex!("0000000000000000000000000000000000000000000000000000000000000045").to_vec(),
@@ -445,7 +445,7 @@ mod test {
     #[test]
     fn compute_hash_d() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
 
         let data = [
             (
@@ -478,7 +478,7 @@ mod test {
     #[test]
     fn compute_hash_e() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert(b"abc".to_vec(), b"123".to_vec()).unwrap();
         trie.insert(b"abcd".to_vec(), b"abcd".to_vec()).unwrap();
         trie.insert(b"abc".to_vec(), b"abc".to_vec()).unwrap();
@@ -492,7 +492,7 @@ mod test {
     #[test]
     fn get_old_state() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert([0; 32].to_vec(), [0; 32].to_vec()).unwrap();
         trie.insert([1; 32].to_vec(), [1; 32].to_vec()).unwrap();
 
@@ -517,7 +517,7 @@ mod test {
     #[test]
     fn get_old_state_with_removals() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert([0; 32].to_vec(), [0; 32].to_vec()).unwrap();
         trie.insert([1; 32].to_vec(), [1; 32].to_vec()).unwrap();
         trie.insert([2; 32].to_vec(), [2; 32].to_vec()).unwrap();
@@ -550,7 +550,7 @@ mod test {
     #[test]
     fn revert() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert([0; 32].to_vec(), [0; 32].to_vec()).unwrap();
         trie.insert([1; 32].to_vec(), [1; 32].to_vec()).unwrap();
 
@@ -571,7 +571,7 @@ mod test {
     #[test]
     fn revert_with_removals() {
         let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         trie.insert([0; 32].to_vec(), [0; 32].to_vec()).unwrap();
         trie.insert([1; 32].to_vec(), [1; 32].to_vec()).unwrap();
         trie.insert([2; 32].to_vec(), [2; 32].to_vec()).unwrap();
@@ -600,7 +600,7 @@ mod test {
 
         // Create new trie from clean DB
         let db = test_utils::new_db_with_path::<TestNodes>(trie_dir.into());
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
 
         trie.insert([0; 32].to_vec(), [1; 32].to_vec()).unwrap();
         trie.insert([1; 32].to_vec(), [2; 32].to_vec()).unwrap();
@@ -613,7 +613,7 @@ mod test {
 
         let mut db2 = test_utils::open_db::<TestNodes>(trie_dir.to_str().unwrap());
         // Create a new trie based on the previous trie's DB
-        let trie = Trie::open(Libmdbx::<TestNodes>::new(&db2), root);
+        let trie = Trie::open(LibmdbxTrieDB::<TestNodes>::new(&db2), root);
 
         assert_eq!(trie.get(&[0; 32].to_vec()).unwrap(), Some([1; 32].to_vec()));
         assert_eq!(trie.get(&[1; 32].to_vec()).unwrap(), Some([2; 32].to_vec()));
@@ -625,7 +625,7 @@ mod test {
         #[test]
         fn proptest_get_insert(data in btree_set(vec(any::<u8>(), 1..100), 1..100)) {
             let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
 
             for val in data.iter(){
                 trie.insert(val.clone(), val.clone()).unwrap();
@@ -641,7 +641,7 @@ mod test {
         #[test]
         fn proptest_get_insert_with_removals(mut data in vec((vec(any::<u8>(), 5..100), any::<bool>()), 1..100)) {
             let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
             // Remove duplicate values with different expected status
             data.sort_by_key(|(val, _)| val.clone());
             data.dedup_by_key(|(val, _)| val.clone());
@@ -672,7 +672,7 @@ mod test {
         // This check has a fixed way of determining wether a value should be removed but doesn't require ordered insertions
         fn proptest_get_insert_with_removals_unsorted(data in btree_set(vec(any::<u8>(), 5..100), 1..100)) {
             let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
             // Remove all values that have an odd first value
             let remove = |value: &Vec<u8>| -> bool {
                 value.first().is_some_and(|v| v % 2 != 0)
@@ -703,7 +703,7 @@ mod test {
         #[test]
         fn proptest_compare_hash(data in btree_set(vec(any::<u8>(), 1..100), 1..100)) {
             let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
             let mut cita_trie = cita_trie();
 
             for val in data.iter(){
@@ -719,7 +719,7 @@ mod test {
         #[test]
         fn proptest_compare_hash_with_removals(mut data in vec((vec(any::<u8>(), 5..100), any::<bool>()), 1..100)) {
             let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
             let mut cita_trie = cita_trie();
             // Remove duplicate values with different expected status
             data.sort_by_key(|(val, _)| val.clone());
@@ -747,7 +747,7 @@ mod test {
         // This check has a fixed way of determining wether a value should be removed but doesn't require ordered insertions
         fn proptest_compare_hash_with_removals_unsorted(data in btree_set(vec(any::<u8>(), 5..100), 1..100)) {
             let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
             let mut cita_trie = cita_trie();
             // Remove all values that have an odd first value
             let remove = |value: &Vec<u8>| -> bool {
@@ -774,7 +774,7 @@ mod test {
         #[test]
         fn proptest_compare_hash_between_inserts(data in btree_set(vec(any::<u8>(), 1..100), 1..100)) {
             let db = test_utils::new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
             let mut cita_trie = cita_trie();
 
             for val in data.iter(){

--- a/crates/storage/trie/db.rs
+++ b/crates/storage/trie/db.rs
@@ -1,12 +1,7 @@
 pub mod libmdbx;
 
-/// RLP-encoded trie node
-pub type NodeRLP = Vec<u8>;
-/// RLP-encoded node hash
-pub type NodeHashRLP = [u8; 32];
-
 use crate::error::StoreError;
 pub trait TrieDB {
-    fn get(&self, key: NodeHashRLP) -> Result<Option<NodeRLP>, StoreError>;
-    fn put(&self, key: NodeHashRLP, value: NodeRLP) -> Result<(), StoreError>;
+    fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, StoreError>;
+    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), StoreError>;
 }

--- a/crates/storage/trie/db.rs
+++ b/crates/storage/trie/db.rs
@@ -1,7 +1,12 @@
 pub mod libmdbx;
 
+/// RLP-encoded trie node
+pub type NodeRLP = Vec<u8>;
+/// RLP-encoded node hash
+pub type NodeHashRLP = [u8; 32];
+
 use crate::error::StoreError;
 pub trait TrieDB {
-    fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, StoreError>;
-    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), StoreError>;
+    fn get(&self, key: NodeHashRLP) -> Result<Option<NodeRLP>, StoreError>;
+    fn put(&self, key: NodeHashRLP, value: NodeRLP) -> Result<(), StoreError>;
 }

--- a/crates/storage/trie/db/libmdbx.rs
+++ b/crates/storage/trie/db/libmdbx.rs
@@ -1,70 +1,82 @@
+use std::marker::PhantomData;
+
 use crate::error::StoreError;
 use libmdbx::{
-    orm::{table, Database},
+    orm::{table, Database, Table},
     table_info,
 };
 
+use crate::trie::db::{NodeHashRLP, NodeRLP};
+
 /// Libmdbx implementation for the TrieDB trait, with get and put operations.
-pub struct Libmdbx(Database);
+pub struct Libmdbx<'a, T: Table> {
+    db: &'a Database,
+    phantom: PhantomData<T>,
+}
 
 use super::TrieDB;
 
 table!(
     /// NodeHash to Node table
-    ( Nodes ) Vec<u8> => Vec<u8>
+    ( Nodes )  NodeHashRLP => NodeRLP
 );
 
-impl Libmdbx {
-    /// Opens a DB created by a previous execution or creates a new one if it doesn't exist
-
-    pub fn init(trie_dir: &str) -> Result<Self, StoreError> {
-        Self::open(trie_dir).or_else(|_| Self::create(trie_dir))
+impl<'a, T: Table> TrieDB for Libmdbx<'a, T> {
+    fn get(&self, key: NodeHashRLP) -> Result<Option<NodeRLP>, StoreError> {
+        let txn = self.db.begin_read().map_err(StoreError::LibmdbxError)?;
+        txn.get::<T>(key).map_err(StoreError::LibmdbxError)
     }
 
-    /// Creates a new clean DB
-    pub fn create(trie_dir: &str) -> Result<Self, StoreError> {
-        let tables = [table_info!(Nodes)].into_iter().collect();
-        let path = Some(trie_dir.into());
-        Ok(Self(
-            Database::create(path, &tables).map_err(StoreError::LibmdbxError)?,
-        ))
-    }
-
-    /// Opens a DB created by a previous execution
-    pub fn open(trie_dir: &str) -> Result<Self, StoreError> {
-        // Open DB
-        let tables = [table_info!(Nodes)].into_iter().collect();
-        let db = Database::open(trie_dir, &tables).map_err(StoreError::LibmdbxError)?;
-        Ok(Self(db))
-    }
-
-    #[cfg(test)]
-    /// Creates a temporary DB, for testing purposes only
-    pub fn init_temp() -> Self {
-        use tempdir::TempDir;
-        let tables = [table_info!(Nodes)].into_iter().collect();
-        Self(Database::create(None, &tables).expect("Failed to create temp DB"))
-    }
-}
-
-impl TrieDB for Libmdbx {
-    fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, StoreError> {
-        let txn = self.0.begin_read().map_err(StoreError::LibmdbxError)?;
-        txn.get::<Nodes>(key).map_err(StoreError::LibmdbxError)
-    }
-
-    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), StoreError> {
-        let txn = self.0.begin_readwrite().map_err(StoreError::LibmdbxError)?;
-        txn.upsert::<Nodes>(key, value)
+    fn put(&self, key: NodeHashRLP, value: NodeRLP) -> Result<(), StoreError> {
+        let txn = self
+            .db
+            .begin_readwrite()
+            .map_err(StoreError::LibmdbxError)?;
+        txn.upsert::<T>(key, value)
             .map_err(StoreError::LibmdbxError)?;
         txn.commit().map_err(StoreError::LibmdbxError)
     }
 }
 
+#[cfg(test)]
+fn new_db() -> Database {
+    let tables = [table_info!(Nodes)].into_iter().collect();
+    Database::create(None, &tables).expect("Failed to create temp DB")
+}
+
 #[test]
 fn simple_addition() {
-    let db = Libmdbx::init_temp();
+    let inner_db = new_db();
+    let db = Libmdbx::<Nodes> { db: inner_db };
     assert_eq!(db.get("hello".into()).unwrap(), None);
     db.put("hello".into(), "value".into());
     assert_eq!(db.get("hello".into()).unwrap(), Some("value".into()));
+}
+
+#[test]
+fn different_tables() {
+    table!(
+        /// vec to vec
+        ( TableA ) Vec<u8> => Vec<u8>
+    );
+    table!(
+        /// vec to vec
+        ( TableB ) Vec<u8> => Vec<u8>
+    );
+    let inner_db = new_db();
+    let tables = [table_info!(TableA), table_info!(TableB)]
+        .into_iter()
+        .collect();
+
+    let db = Database::create(None, &tables).unwrap();
+    let trie_dba = Libmdbx::<TableA> {
+        db: &db,
+        phantom: PhantomData,
+    };
+    let trie_dbb = Libmdbx::<TableB> {
+        db: &db,
+        phantom: PhantomData,
+    };
+    trie_dba.put("hello".into(), "value".into());
+    assert_eq!(trie_dbb.get("hello".into()).unwrap(), Some("value".into()));
 }

--- a/crates/storage/trie/db/libmdbx.rs
+++ b/crates/storage/trie/db/libmdbx.rs
@@ -17,7 +17,7 @@ use super::TrieDB;
 impl<'a, T: Table> Libmdbx<'a, T> {
     pub fn new(db: &'a Database) -> Self {
         Self {
-            db: db,
+            db,
             phantom: PhantomData,
         }
     }

--- a/crates/storage/trie/db/libmdbx.rs
+++ b/crates/storage/trie/db/libmdbx.rs
@@ -7,14 +7,14 @@ use libmdbx::{
 };
 
 /// Libmdbx implementation for the TrieDB trait, with get and put operations.
-pub struct Libmdbx<'a, T: Table> {
+pub struct LibmdbxTrieDB<'a, T: Table> {
     db: &'a Database,
     phantom: PhantomData<T>,
 }
 
 use super::TrieDB;
 
-impl<'a, T: Table> Libmdbx<'a, T> {
+impl<'a, T: Table> LibmdbxTrieDB<'a, T> {
     pub fn new(db: &'a Database) -> Self {
         Self {
             db,
@@ -23,7 +23,7 @@ impl<'a, T: Table> Libmdbx<'a, T> {
     }
 }
 
-impl<'a, T: Table> TrieDB for Libmdbx<'a, T>
+impl<'a, T: Table> TrieDB for LibmdbxTrieDB<'a, T>
 where
     T: Table<Key = Vec<u8>, Value = Vec<u8>>,
 {
@@ -45,7 +45,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::Libmdbx;
+    use super::LibmdbxTrieDB;
     use crate::trie::test_utils::new_db;
     use libmdbx::{
         orm::{table, Database, Table},
@@ -61,7 +61,7 @@ mod test {
     #[test]
     fn simple_addition() {
         let inner_db = new_db::<Nodes>();
-        let db = Libmdbx::<Nodes>::new(&inner_db);
+        let db = LibmdbxTrieDB::<Nodes>::new(&inner_db);
         assert_eq!(db.get("hello".into()).unwrap(), None);
         db.put("hello".into(), "value".into());
         assert_eq!(db.get("hello".into()).unwrap(), Some("value".into()));
@@ -82,8 +82,8 @@ mod test {
             .collect();
 
         let inner_db = Database::create(None, &tables).unwrap();
-        let db_a = Libmdbx::<TableA>::new(&inner_db);
-        let db_b = Libmdbx::<TableB>::new(&inner_db);
+        let db_a = LibmdbxTrieDB::<TableA>::new(&inner_db);
+        let db_b = LibmdbxTrieDB::<TableB>::new(&inner_db);
         db_a.put("hello".into(), "value".into());
         assert_eq!(db_b.get("hello".into()).unwrap(), None);
     }

--- a/crates/storage/trie/db/libmdbx.rs
+++ b/crates/storage/trie/db/libmdbx.rs
@@ -6,8 +6,6 @@ use libmdbx::{
     table_info,
 };
 
-use crate::trie::db::{NodeHashRLP, NodeRLP};
-
 /// Libmdbx implementation for the TrieDB trait, with get and put operations.
 pub struct Libmdbx<'a, T: Table> {
     db: &'a Database,
@@ -16,18 +14,25 @@ pub struct Libmdbx<'a, T: Table> {
 
 use super::TrieDB;
 
-table!(
-    /// NodeHash to Node table
-    ( Nodes )  NodeHashRLP => NodeRLP
-);
+impl<'a, T: Table> Libmdbx<'a, T> {
+    pub fn new(db: &'a Database) -> Self {
+        Self {
+            db: db,
+            phantom: PhantomData,
+        }
+    }
+}
 
-impl<'a, T: Table> TrieDB for Libmdbx<'a, T> {
-    fn get(&self, key: NodeHashRLP) -> Result<Option<NodeRLP>, StoreError> {
+impl<'a, T: Table> TrieDB for Libmdbx<'a, T>
+where
+    T: Table<Key = Vec<u8>, Value = Vec<u8>>,
+{
+    fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, StoreError> {
         let txn = self.db.begin_read().map_err(StoreError::LibmdbxError)?;
         txn.get::<T>(key).map_err(StoreError::LibmdbxError)
     }
 
-    fn put(&self, key: NodeHashRLP, value: NodeRLP) -> Result<(), StoreError> {
+    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), StoreError> {
         let txn = self
             .db
             .begin_readwrite()
@@ -39,44 +44,47 @@ impl<'a, T: Table> TrieDB for Libmdbx<'a, T> {
 }
 
 #[cfg(test)]
-fn new_db() -> Database {
-    let tables = [table_info!(Nodes)].into_iter().collect();
-    Database::create(None, &tables).expect("Failed to create temp DB")
-}
-
-#[test]
-fn simple_addition() {
-    let inner_db = new_db();
-    let db = Libmdbx::<Nodes> { db: inner_db };
-    assert_eq!(db.get("hello".into()).unwrap(), None);
-    db.put("hello".into(), "value".into());
-    assert_eq!(db.get("hello".into()).unwrap(), Some("value".into()));
-}
-
-#[test]
-fn different_tables() {
-    table!(
-        /// vec to vec
-        ( TableA ) Vec<u8> => Vec<u8>
-    );
-    table!(
-        /// vec to vec
-        ( TableB ) Vec<u8> => Vec<u8>
-    );
-    let inner_db = new_db();
-    let tables = [table_info!(TableA), table_info!(TableB)]
-        .into_iter()
-        .collect();
-
-    let db = Database::create(None, &tables).unwrap();
-    let trie_dba = Libmdbx::<TableA> {
-        db: &db,
-        phantom: PhantomData,
+mod test {
+    use super::Libmdbx;
+    use crate::trie::test_utils::new_db;
+    use libmdbx::{
+        orm::{table, Database, Table},
+        table_info,
     };
-    let trie_dbb = Libmdbx::<TableB> {
-        db: &db,
-        phantom: PhantomData,
-    };
-    trie_dba.put("hello".into(), "value".into());
-    assert_eq!(trie_dbb.get("hello".into()).unwrap(), Some("value".into()));
+    table!(
+        /// NodeHash to Node table
+        ( Nodes )  Vec<u8> => Vec<u8>
+    );
+
+    use crate::trie::TrieDB;
+
+    #[test]
+    fn simple_addition() {
+        let inner_db = new_db::<Nodes>();
+        let db = Libmdbx::<Nodes>::new(&inner_db);
+        assert_eq!(db.get("hello".into()).unwrap(), None);
+        db.put("hello".into(), "value".into());
+        assert_eq!(db.get("hello".into()).unwrap(), Some("value".into()));
+    }
+
+    #[test]
+    fn different_tables() {
+        table!(
+            /// vec to vec
+            ( TableA ) Vec<u8> => Vec<u8>
+        );
+        table!(
+            /// vec to vec
+            ( TableB ) Vec<u8> => Vec<u8>
+        );
+        let tables = [table_info!(TableA), table_info!(TableB)]
+            .into_iter()
+            .collect();
+
+        let inner_db = Database::create(None, &tables).unwrap();
+        let db_a = Libmdbx::<TableA>::new(&inner_db);
+        let db_b = Libmdbx::<TableB>::new(&inner_db);
+        db_a.put("hello".into(), "value".into());
+        assert_eq!(db_b.get("hello".into()).unwrap(), None);
+    }
 }

--- a/crates/storage/trie/node/branch.rs
+++ b/crates/storage/trie/node/branch.rs
@@ -318,10 +318,11 @@ impl BranchNode {
 
 #[cfg(test)]
 mod test {
+    use crate::trie::db::libmdbx::Libmdbx;
     use ethereum_types::H256;
 
     use super::*;
-    use crate::trie::test_utils;
+    use crate::trie::test_utils::{new_db, TestNodes};
 
     use crate::{pmt_node, trie::Trie};
 
@@ -361,7 +362,8 @@ mod test {
 
     #[test]
     fn get_some() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -381,7 +383,8 @@ mod test {
 
     #[test]
     fn get_none() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -397,7 +400,8 @@ mod test {
 
     #[test]
     fn insert_self() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -417,7 +421,8 @@ mod test {
 
     #[test]
     fn insert_choice() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -438,7 +443,8 @@ mod test {
 
     #[test]
     fn insert_passthrough() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -468,7 +474,8 @@ mod test {
 
     #[test]
     fn remove_choice_into_inner() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -486,7 +493,8 @@ mod test {
 
     #[test]
     fn remove_choice() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -505,7 +513,8 @@ mod test {
 
     #[test]
     fn remove_choice_into_value() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -522,7 +531,8 @@ mod test {
 
     #[test]
     fn remove_value_into_inner() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -537,7 +547,8 @@ mod test {
 
     #[test]
     fn remove_value() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -553,7 +564,8 @@ mod test {
 
     #[test]
     fn compute_hash_two_choices() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 2 => leaf { vec![0x20] => vec![0x20] },
@@ -572,7 +584,8 @@ mod test {
 
     #[test]
     fn compute_hash_all_choices() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0x0 => leaf { vec![0x00] => vec![0x00] },
@@ -606,7 +619,8 @@ mod test {
 
     #[test]
     fn compute_hash_one_choice_with_value() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 2 => leaf { vec![0x20] => vec![0x20] },
@@ -625,7 +639,8 @@ mod test {
 
     #[test]
     fn compute_hash_all_choices_with_value() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0x0 => leaf { vec![0x00] => vec![0x00] },

--- a/crates/storage/trie/node/branch.rs
+++ b/crates/storage/trie/node/branch.rs
@@ -318,7 +318,7 @@ impl BranchNode {
 
 #[cfg(test)]
 mod test {
-    use crate::trie::db::libmdbx::Libmdbx;
+    use crate::trie::db::libmdbx::LibmdbxTrieDB;
     use ethereum_types::H256;
 
     use super::*;
@@ -363,7 +363,7 @@ mod test {
     #[test]
     fn get_some() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -384,7 +384,7 @@ mod test {
     #[test]
     fn get_none() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -401,7 +401,7 @@ mod test {
     #[test]
     fn insert_self() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -422,7 +422,7 @@ mod test {
     #[test]
     fn insert_choice() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -444,7 +444,7 @@ mod test {
     #[test]
     fn insert_passthrough() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -475,7 +475,7 @@ mod test {
     #[test]
     fn remove_choice_into_inner() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -494,7 +494,7 @@ mod test {
     #[test]
     fn remove_choice() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -514,7 +514,7 @@ mod test {
     #[test]
     fn remove_choice_into_value() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -532,7 +532,7 @@ mod test {
     #[test]
     fn remove_value_into_inner() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -548,7 +548,7 @@ mod test {
     #[test]
     fn remove_value() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -565,7 +565,7 @@ mod test {
     #[test]
     fn compute_hash_two_choices() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 2 => leaf { vec![0x20] => vec![0x20] },
@@ -585,7 +585,7 @@ mod test {
     #[test]
     fn compute_hash_all_choices() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0x0 => leaf { vec![0x00] => vec![0x00] },
@@ -620,7 +620,7 @@ mod test {
     #[test]
     fn compute_hash_one_choice_with_value() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 2 => leaf { vec![0x20] => vec![0x20] },
@@ -640,7 +640,7 @@ mod test {
     #[test]
     fn compute_hash_all_choices_with_value() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             branch {
                 0x0 => leaf { vec![0x00] => vec![0x00] },

--- a/crates/storage/trie/node/extension.rs
+++ b/crates/storage/trie/node/extension.rs
@@ -194,6 +194,8 @@ impl ExtensionNode {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::trie::db::libmdbx::Libmdbx;
+    use crate::trie::test_utils::{new_db, TestNodes};
     use crate::{
         pmt_node,
         trie::{nibble::Nibble, test_utils, Trie},
@@ -209,7 +211,8 @@ mod test {
 
     #[test]
     fn get_some() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -229,7 +232,8 @@ mod test {
 
     #[test]
     fn get_none() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -245,7 +249,8 @@ mod test {
 
     #[test]
     fn insert_passthrough() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -265,7 +270,8 @@ mod test {
 
     #[test]
     fn insert_branch() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -288,7 +294,8 @@ mod test {
 
     #[test]
     fn insert_branch_extension() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0, 0], branch {
                 0 => leaf { vec![0x00, 0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -311,7 +318,8 @@ mod test {
 
     #[test]
     fn insert_extension_branch() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0, 0], branch {
                 0 => leaf { vec![0x00, 0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -332,7 +340,8 @@ mod test {
 
     #[test]
     fn insert_extension_branch_extension() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0, 0], branch {
                 0 => leaf { vec![0x00, 0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -353,7 +362,8 @@ mod test {
 
     #[test]
     fn remove_none() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -371,7 +381,8 @@ mod test {
 
     #[test]
     fn remove_into_leaf() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -389,7 +400,8 @@ mod test {
 
     #[test]
     fn remove_into_extension() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x00] },

--- a/crates/storage/trie/node/extension.rs
+++ b/crates/storage/trie/node/extension.rs
@@ -194,7 +194,7 @@ impl ExtensionNode {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::trie::db::libmdbx::Libmdbx;
+    use crate::trie::db::libmdbx::LibmdbxTrieDB;
     use crate::trie::test_utils::{new_db, TestNodes};
     use crate::{
         pmt_node,
@@ -212,7 +212,7 @@ mod test {
     #[test]
     fn get_some() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -233,7 +233,7 @@ mod test {
     #[test]
     fn get_none() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -250,7 +250,7 @@ mod test {
     #[test]
     fn insert_passthrough() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -271,7 +271,7 @@ mod test {
     #[test]
     fn insert_branch() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -295,7 +295,7 @@ mod test {
     #[test]
     fn insert_branch_extension() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0, 0], branch {
                 0 => leaf { vec![0x00, 0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -319,7 +319,7 @@ mod test {
     #[test]
     fn insert_extension_branch() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0, 0], branch {
                 0 => leaf { vec![0x00, 0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -341,7 +341,7 @@ mod test {
     #[test]
     fn insert_extension_branch_extension() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0, 0], branch {
                 0 => leaf { vec![0x00, 0x00] => vec![0x12, 0x34, 0x56, 0x78] },
@@ -363,7 +363,7 @@ mod test {
     #[test]
     fn remove_none() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -382,7 +382,7 @@ mod test {
     #[test]
     fn remove_into_leaf() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x00] },
@@ -401,7 +401,7 @@ mod test {
     #[test]
     fn remove_into_extension() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             extension { [0], branch {
                 0 => leaf { vec![0x00] => vec![0x00] },

--- a/crates/storage/trie/node/leaf.rs
+++ b/crates/storage/trie/node/leaf.rs
@@ -158,7 +158,7 @@ impl LeafNode {
 mod test {
     use super::*;
     use crate::pmt_node;
-    use crate::trie::db::libmdbx::Libmdbx;
+    use crate::trie::db::libmdbx::LibmdbxTrieDB;
     use crate::trie::test_utils::{new_db, TestNodes};
     use crate::trie::{test_utils, Trie};
 
@@ -193,7 +193,7 @@ mod test {
     #[test]
     fn insert_replace() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             leaf { vec![0x12] => vec![0x12, 0x34, 0x56, 0x78] }
         };
@@ -213,7 +213,7 @@ mod test {
     #[test]
     fn insert_branch() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             leaf { vec![0x12] => vec![0x12, 0x34, 0x56, 0x78] }
         };
@@ -232,7 +232,7 @@ mod test {
     #[test]
     fn insert_extension_branch() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             leaf { vec![0x12] => vec![0x12, 0x34, 0x56, 0x78] }
         };
@@ -251,7 +251,7 @@ mod test {
     #[test]
     fn insert_extension_branch_value_self() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             leaf { vec![0x12] => vec![0x12, 0x34, 0x56, 0x78] }
         };
@@ -270,7 +270,7 @@ mod test {
     #[test]
     fn insert_extension_branch_value_other() {
         let db = new_db::<TestNodes>();
-        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
+        let mut trie = Trie::new(LibmdbxTrieDB::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             leaf { vec![0x12, 0x34] => vec![0x12, 0x34, 0x56, 0x78] }
         };

--- a/crates/storage/trie/node/leaf.rs
+++ b/crates/storage/trie/node/leaf.rs
@@ -158,6 +158,8 @@ impl LeafNode {
 mod test {
     use super::*;
     use crate::pmt_node;
+    use crate::trie::db::libmdbx::Libmdbx;
+    use crate::trie::test_utils::{new_db, TestNodes};
     use crate::trie::{test_utils, Trie};
 
     #[test]
@@ -190,7 +192,8 @@ mod test {
 
     #[test]
     fn insert_replace() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             leaf { vec![0x12] => vec![0x12, 0x34, 0x56, 0x78] }
         };
@@ -209,7 +212,8 @@ mod test {
 
     #[test]
     fn insert_branch() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             leaf { vec![0x12] => vec![0x12, 0x34, 0x56, 0x78] }
         };
@@ -227,7 +231,8 @@ mod test {
 
     #[test]
     fn insert_extension_branch() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             leaf { vec![0x12] => vec![0x12, 0x34, 0x56, 0x78] }
         };
@@ -245,7 +250,8 @@ mod test {
 
     #[test]
     fn insert_extension_branch_value_self() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             leaf { vec![0x12] => vec![0x12, 0x34, 0x56, 0x78] }
         };
@@ -263,7 +269,8 @@ mod test {
 
     #[test]
     fn insert_extension_branch_value_other() {
-        let mut trie = test_utils::new_temp_trie();
+        let db = new_db::<TestNodes>();
+        let mut trie = Trie::new(Libmdbx::<TestNodes>::new(&db));
         let node = pmt_node! { @(trie)
             leaf { vec![0x12, 0x34] => vec![0x12, 0x34, 0x56, 0x78] }
         };

--- a/crates/storage/trie/test_utils.rs
+++ b/crates/storage/trie/test_utils.rs
@@ -1,8 +1,30 @@
+use std::path::PathBuf;
+
 use super::{db::libmdbx::Libmdbx, state::TrieState, Trie};
 
-/// Creates a new trie based on a temporary DB
-pub fn new_temp_trie() -> Trie<Libmdbx> {
-    Trie::new(Libmdbx::init_temp())
+use libmdbx::{
+    orm::{table_info, Database, Table},
+    table,
+};
+
+table!(
+    /// Test table.
+    (TestNodes) Vec<u8> => Vec<u8>
+);
+
+pub fn new_db_with_path<T: Table>(path: PathBuf) -> Database {
+    let tables = [table_info!(T)].into_iter().collect();
+    Database::create(Some(path), &tables).expect("Failed creating db with path")
+}
+
+pub fn new_db<T: Table>() -> Database {
+    let tables = [table_info!(T)].into_iter().collect();
+    Database::create(None, &tables).expect("Failed to create temp DB")
+}
+
+pub fn open_db<T: Table>(path: &str) -> Database {
+    let tables = [table_info!(T)].into_iter().collect();
+    Database::open(path, &tables).expect("Failed to open DB")
 }
 
 #[macro_export]

--- a/crates/storage/trie/test_utils.rs
+++ b/crates/storage/trie/test_utils.rs
@@ -1,7 +1,5 @@
 use std::path::PathBuf;
 
-use super::{db::libmdbx::Libmdbx, state::TrieState, Trie};
-
 use libmdbx::{
     orm::{table_info, Database, Table},
     table,


### PR DESCRIPTION
**Motivation**

This PR allows us to have multiple tries, all using the same database, but different tables, so they can't collide with each other even if they were to share key space.

**Changes**

- Makes the `Libmdbx` implementation for the `TrieDB` trait generic. The type is a Table struct which specifies which table will be used in the trie.
- The `Libmdbx` struct now has a borrowed db instead of a moved one. This allows us to use a single db struct in several tries, which didn't work in the previous model (`resource temporarily unavailable`).
- Adds `test_utils` for creating a db. Most of the PR code is just changing tests, but the Trie code itself is 100% unchanged.

Closes #359 
