### PR TITLE
Using declarative macro to implement RLPEncode trait for Uint types

### DIFF
--- a/crates/core/rlp/encode.rs
+++ b/crates/core/rlp/encode.rs
@@ -46,111 +46,33 @@ impl RLPEncode for bool {
 }
 
 // integer types impls
+macro_rules! implRLPEncodeForUIntTypes {
+    ($($uIntType:ty),+) => {$(
+        impl RLPEncode for $uIntType {
+            fn encode(&self, buf: &mut dyn BufMut) {
+                match *self {
+                    // 0, also known as null or the empty string is 0x80
+                    0 => buf.put_u8(RLP_NULL),
 
-impl RLPEncode for u8 {
-    fn encode(&self, buf: &mut dyn BufMut) {
-        match *self {
-            // 0, also known as null or the empty string is 0x80
-            0 => buf.put_u8(RLP_NULL),
-            // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
-            n @ 1..=0x7f => buf.put_u8(n),
-            // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a
-            // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
-            n => {
-                let mut bytes = ArrayVec::<[u8; 8]>::new();
-                bytes.extend_from_slice(&n.to_be_bytes());
-                let start = bytes.iter().position(|&x| x != 0).unwrap();
-                let len = bytes.len() - start;
-                buf.put_u8(RLP_NULL + len as u8);
-                buf.put_slice(&bytes[start..]);
+                    // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
+                    n @ 1..=0x7f => buf.put_u8(n as u8),
+
+                    // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a
+                    // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
+                    n => {
+                        let mut bytes = ArrayVec::<[u8; 8]>::new();
+                        bytes.extend_from_slice(&n.to_be_bytes());
+                        let start = bytes.iter().position(|&x| x != 0).unwrap();
+                        let len = bytes.len() - start;
+                        buf.put_u8(RLP_NULL + len as u8);
+                        buf.put_slice(&bytes[start..]);
+                    }
+                }
             }
         }
-    }
+    )+};
 }
-
-impl RLPEncode for u16 {
-    fn encode(&self, buf: &mut dyn BufMut) {
-        match *self {
-            // 0, also known as null or the empty string is 0x80
-            0 => buf.put_u8(RLP_NULL),
-            // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
-            n @ 1..=0x7f => buf.put_u8(n as u8),
-            // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a
-            // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
-            n => {
-                let mut bytes = ArrayVec::<[u8; 8]>::new();
-                bytes.extend_from_slice(&n.to_be_bytes());
-                let start = bytes.iter().position(|&x| x != 0).unwrap();
-                let len = bytes.len() - start;
-                buf.put_u8(RLP_NULL + len as u8);
-                buf.put_slice(&bytes[start..]);
-            }
-        }
-    }
-}
-
-impl RLPEncode for u32 {
-    fn encode(&self, buf: &mut dyn BufMut) {
-        match *self {
-            // 0, also known as null or the empty string is 0x80
-            0 => buf.put_u8(RLP_NULL),
-            // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
-            n @ 1..=0x7f => buf.put_u8(n as u8),
-            // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a
-            // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
-            n => {
-                let mut bytes = ArrayVec::<[u8; 8]>::new();
-                bytes.extend_from_slice(&n.to_be_bytes());
-                let start = bytes.iter().position(|&x| x != 0).unwrap();
-                let len = bytes.len() - start;
-                buf.put_u8(RLP_NULL + len as u8);
-                buf.put_slice(&bytes[start..]);
-            }
-        }
-    }
-}
-
-impl RLPEncode for u64 {
-    fn encode(&self, buf: &mut dyn BufMut) {
-        match *self {
-            // 0, also known as null or the empty string is 0x80
-            0 => buf.put_u8(RLP_NULL),
-            // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
-            n @ 1..=0x7f => buf.put_u8(n as u8),
-            // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a
-            // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
-            n => {
-                let mut bytes = ArrayVec::<[u8; 8]>::new();
-                bytes.extend_from_slice(&n.to_be_bytes());
-                let start = bytes.iter().position(|&x| x != 0).unwrap();
-                let len = bytes.len() - start;
-                buf.put_u8(RLP_NULL + len as u8);
-                buf.put_slice(&bytes[start..]);
-            }
-        }
-    }
-}
-
-impl RLPEncode for usize {
-    fn encode(&self, buf: &mut dyn BufMut) {
-        match *self {
-            // 0, also known as null or the empty string is 0x80
-            0 => buf.put_u8(RLP_NULL),
-            // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
-            n @ 1..=0x7f => buf.put_u8(n as u8),
-            // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a
-            // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
-            n => {
-                let mut bytes = ArrayVec::<[u8; 8]>::new();
-                bytes.extend_from_slice(&n.to_be_bytes());
-                let start = bytes.iter().position(|&x| x != 0).unwrap();
-                let len = bytes.len() - start;
-                buf.put_u8(RLP_NULL + len as u8);
-                buf.put_slice(&bytes[start..]);
-            }
-        }
-    }
-}
+implRLPEncodeForUIntTypes!(u8, u16, u32, u64, usize);
 
 impl RLPEncode for () {
     fn encode(&self, buf: &mut dyn BufMut) {


### PR DESCRIPTION
I've reduced the amount of code in the **core/rlp/encode module**, by using **declarative macro to implement the RLPEncode trait for unsigned integer types**. I think this way is much cleaner and maintainable.