### PR TITLE
feat: peers discovery lookups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint:
 
 CRATE ?= *
 test:
-	RUST_BACKTRACE=1 cargo test -p '$(CRATE)'
+	cargo test -p '$(CRATE)'
 
 clean:  clean-vectors
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint:
 
 CRATE ?= *
 test:
-	cargo test -p '$(CRATE)'
+	RUST_BACKTRACE=1 cargo test -p '$(CRATE)'
 
 clean:  clean-vectors
 	cargo clean

--- a/crates/net/discv4.rs
+++ b/crates/net/discv4.rs
@@ -307,8 +307,6 @@ pub struct FindNodeRequest {
     /// we keep track of this number since we will accept neighbor messages until the max_per_bucket
     pub nodes_sent: usize,
     /// unix timestamp tracking when we have sent the request
-    #[allow(unused)]
-    // todo use this field to invalidate if it took too much time
     pub sent_at: u64,
     /// a tokio sender, useful to wait for the response in lookups
     pub tx: Option<tokio::sync::mpsc::UnboundedSender<Vec<Node>>>,

--- a/crates/net/discv4.rs
+++ b/crates/net/discv4.rs
@@ -308,7 +308,10 @@ pub struct FindNodeRequest {
     pub nodes_sent: usize,
     /// unix timestamp tracking when we have sent the request
     #[allow(unused)]
+    // todo use this field to invalidate if it took too much time
     pub sent_at: u64,
+    /// a tokio sender, useful to wait for the response in lookups
+    pub tx: Option<tokio::sync::mpsc::UnboundedSender<Vec<Node>>>,
 }
 
 impl Default for FindNodeRequest {
@@ -316,6 +319,16 @@ impl Default for FindNodeRequest {
         Self {
             nodes_sent: 0,
             sent_at: time_now_unix(),
+            tx: None,
+        }
+    }
+}
+
+impl FindNodeRequest {
+    pub fn new_with_sender(sender: tokio::sync::mpsc::UnboundedSender<Vec<Node>>) -> Self {
+        Self {
+            tx: Some(sender),
+            ..Self::default()
         }
     }
 }

--- a/crates/net/discv4.rs
+++ b/crates/net/discv4.rs
@@ -308,7 +308,8 @@ pub struct FindNodeRequest {
     pub nodes_sent: usize,
     /// unix timestamp tracking when we have sent the request
     pub sent_at: u64,
-    /// a tokio sender, useful to wait for the response in lookups
+    /// if present, server will send the nodes through this channel when receiving neighbors
+    /// useful to wait for the response in lookups
     pub tx: Option<tokio::sync::mpsc::UnboundedSender<Vec<Node>>>,
 }
 

--- a/crates/net/kademlia.rs
+++ b/crates/net/kademlia.rs
@@ -265,6 +265,7 @@ impl PeerData {
         }
     }
 
+    #[allow(unused)]
     pub fn new_find_node_request(&mut self) {
         self.find_node_request = Some(FindNodeRequest::default());
     }

--- a/crates/net/kademlia.rs
+++ b/crates/net/kademlia.rs
@@ -30,6 +30,7 @@ impl KademliaTable {
         }
     }
 
+    #[allow(unused)]
     pub fn buckets(&self) -> &Vec<Bucket> {
         &self.buckets
     }

--- a/crates/net/kademlia.rs
+++ b/crates/net/kademlia.rs
@@ -10,7 +10,7 @@ const NUMBER_OF_BUCKETS: usize = 256;
 const MAX_NUMBER_OF_REPLACEMENTS: usize = 10;
 
 #[derive(Clone, Debug, Default)]
-struct Bucket {
+pub struct Bucket {
     pub peers: Vec<PeerData>,
     pub replacements: Vec<PeerData>,
 }
@@ -28,6 +28,10 @@ impl KademliaTable {
             local_node_id,
             buckets,
         }
+    }
+
+    pub fn buckets(&self) -> &Vec<Bucket> {
+        &self.buckets
     }
 
     pub fn get_by_node_id(&self, node_id: H512) -> Option<&PeerData> {
@@ -59,7 +63,7 @@ impl KademliaTable {
     }
 
     #[cfg(test)]
-    fn insert_node_on_custom_bucket(
+    pub fn insert_node_on_custom_bucket(
         &mut self,
         node: Node,
         bucket_idx: usize,
@@ -195,7 +199,7 @@ impl KademliaTable {
     }
 
     #[cfg(test)]
-    fn replace_peer_on_custom_bucket(
+    pub fn replace_peer_on_custom_bucket(
         &mut self,
         node_id: H512,
         bucket_idx: usize,

--- a/crates/net/kademlia.rs
+++ b/crates/net/kademlia.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use ethereum_rust_core::{H256, H512, U256};
 use sha3::{Digest, Keccak256};
+use tokio::sync::mpsc::UnboundedSender;
 
 pub const MAX_NODES_PER_BUCKET: usize = 16;
 const NUMBER_OF_BUCKETS: usize = 256;
@@ -266,6 +267,10 @@ impl PeerData {
 
     pub fn new_find_node_request(&mut self) {
         self.find_node_request = Some(FindNodeRequest::default());
+    }
+
+    pub fn new_find_node_request_with_sender(&mut self, sender: UnboundedSender<Vec<Node>>) {
+        self.find_node_request = Some(FindNodeRequest::new_with_sender(sender));
     }
 }
 

--- a/crates/net/net.rs
+++ b/crates/net/net.rs
@@ -196,13 +196,14 @@ async fn discover_peers_server(
                             let table = table.lock().await;
                             table.get_closest_nodes(msg.target)
                         };
+                        let nodes_chunks = nodes.chunks(4);
                         let expiration = get_expiration(20);
                         debug!("Sending neighbors!");
                         // we are sending the neighbors in 4 different messages as not to exceed the
                         // maximum packet size
-                        for i in 0..4 {
+                        for nodes in nodes_chunks {
                             let neighbors = discv4::Message::Neighbors(NeighborsMessage::new(
-                                nodes[i * 4..i * 4 + 4].to_vec(),
+                                nodes.to_vec(),
                                 expiration,
                             ));
                             let mut buf = Vec::new();

--- a/crates/net/net.rs
+++ b/crates/net/net.rs
@@ -619,8 +619,8 @@ async fn find_node_and_wait_for_response(
     let mut nodes = vec![];
 
     loop {
-        // wait as much as two seconds for the response
-        match tokio::time::timeout(Duration::from_secs(2), request_receiver.recv()).await {
+        // wait as much as 5 seconds for the response
+        match tokio::time::timeout(Duration::from_secs(5), request_receiver.recv()).await {
             Ok(Some(mut found_nodes)) => {
                 nodes.append(&mut found_nodes);
                 if nodes.len() == MAX_NODES_PER_BUCKET {

--- a/crates/net/net.rs
+++ b/crates/net/net.rs
@@ -614,9 +614,13 @@ async fn find_node_and_wait_for_response(
 
     let mut buf = Vec::new();
     msg.encode_with_header(&mut buf, signer);
-    socket.send_to(&buf, to_addr).await.unwrap();
+    let res = socket.send_to(&buf, to_addr).await;
 
     let mut nodes = vec![];
+
+    if res.is_err() {
+        return nodes;
+    }
 
     loop {
         // wait as much as 5 seconds for the response
@@ -654,7 +658,7 @@ async fn pong(socket: &UdpSocket, to_addr: SocketAddr, ping_hash: H256, signer: 
     let pong: discv4::Message = discv4::Message::Pong(PongMessage::new(to, ping_hash, expiration));
 
     pong.encode_with_header(&mut buf, signer);
-    socket.send_to(&buf, to_addr).await.unwrap();
+    let _ = socket.send_to(&buf, to_addr).await;
 }
 
 async fn serve_requests(tcp_addr: SocketAddr, signer: SigningKey) {

--- a/crates/net/net.rs
+++ b/crates/net/net.rs
@@ -374,11 +374,11 @@ const PEERS_RANDOM_LOOKUP_TIME_IN_MIN: usize = 30;
 ///    - Peers that have already been asked for nodes
 ///    - Peers that have been already seen
 ///    - Potential peers to query for nodes: a vector of up to 16 entries holding the closest peers to the pubkey.
-///    This vector is initially filled with nodes from our table.
+///      This vector is initially filled with nodes from our table.
 /// 3. We send a `find_node` to the closest 3 nodes (that we have not yet asked) from the pubkey.
 /// 4. We wait for the neighbors response and pushed or replace those that are closer to the potential peers.
 /// 5. We select three other nodes from the potential peers vector and do the same until one lookup
-///   doesn't have any node to ask.
+///    doesn't have any node to ask.
 ///
 /// See more https://github.com/ethereum/devp2p/blob/master/discv4.md#recursive-lookup
 async fn peers_lookup(

--- a/crates/net/net.rs
+++ b/crates/net/net.rs
@@ -416,7 +416,7 @@ async fn lookup(
 ) {
     let alpha = 3;
     let closest_nodes = table.lock().await.get_closest_nodes(target);
-    let queries = 0;
+    let mut queries = 0;
     for node in closest_nodes {
         if !asked_peers.contains(&node.node_id) {
             find_node(
@@ -432,6 +432,7 @@ async fn lookup(
                 peer.new_find_node_request();
             }
             asked_peers.insert(node.node_id);
+            queries += 1;
         }
 
         if queries == alpha {


### PR DESCRIPTION
**Motivation**

Implements lookups in the discovery server.

**Description**
In the discovery protocol, for every `x` unit of time (currently hardcoded to 30 min) we need to run lookups to find new peers and fill our buckets. In theory, we should preferably run lookups on the least filled buckets, that is: when sending `find_nodes`, we should set a public key (target field) such that its distance from the peer to be queried returns the corresponding bucket number. This step is not trivial at all unless we do some brute generation. Instead, we are just sending lookups to three randomly generated pub keys. See more [here](https://github.com/ethereum/devp2p/blob/master/discv4.md#recursive-lookup).

Changes in detail:
- Fix `find_node` request target field.
- New validation when inserting a node that checks if it is already inserted.
- `discovery peer` now spawns a new task for the lookups.
- `peers_lookup` function that handles the random lookups.

And here is the lookup flow in detail:
1. Every 30min we spawn three concurrent lookups: one closest to our pubkey and three others closest to a random generated pubkeys.
2. Every lookup starts with the closest nodes from our table. Each lookup keeps track of:
    - Peers that have already been asked for nodes
    - Peers that have been already seen
    - Potential peers to query for nodes: a vector of up to 16 entries holding the closest peers to the pubkey. This vector is initially filled with nodes from our table.
3. We send a `find_node` to the closest 3 nodes (that we have not yet asked) from the pubkey.
4. We wait for the neighbors' response and push or replace those who are closer to the potential peers.
5.  We select three other nodes from the potential peers vector and do the same until one lookup has no node to ask.

Finally, this implementation is supported by some custom unit and e2e tests.

Closes #154 

