### PR TITLE
fix: mark `network` parameter as required

### DIFF
--- a/cmd/ethereum_rust/cli.rs
+++ b/cmd/ethereum_rust/cli.rs
@@ -71,8 +71,8 @@ pub fn cli() -> Command {
         .arg(
             Arg::new("network")
                 .long("network")
-                .default_value("")
                 .value_name("GENESIS_FILE_PATH")
+                .required(true)
                 .action(ArgAction::Set),
         )
         .arg(


### PR DESCRIPTION
**Motivation**

Running the CLI will fail in unclear ways if no genesis file is passed.

**Description**

Make the parameter required so clap reports an error when it's missing.
