### PR TITLE
feat: implement `get_proof` for `Trie`

### DIFF
--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -759,6 +759,23 @@ mod test {
 
         }
 
+        #[test]
+        fn proptest_compare_proof(data in btree_set(vec(any::<u8>(), 1..100), 1..100)) {
+            let mut trie = Trie::new_temp();
+            let mut cita_trie = cita_trie();
+
+            for val in data.iter(){
+                trie.insert(val.clone(), val.clone()).unwrap();
+                cita_trie.insert(val.clone(), val.clone()).unwrap();
+            }
+            let _ = cita_trie.root();
+            for val in data.iter(){
+                let proof = trie.get_proof(val).unwrap();
+                let cita_proof = cita_trie.get_proof(val).unwrap();
+                prop_assert_eq!(proof, cita_proof);
+            }
+        }
+
     }
 
     fn cita_trie() -> CitaTrie<CitaMemoryDB, HasherKeccak> {

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -892,4 +892,22 @@ mod test {
         let trie_proof = trie.get_proof(&vec![183]).unwrap();
         assert_eq!(cita_proof, trie_proof);
     }
+
+    #[test]
+    fn get_proof_removed_value() {
+        let a = vec![5, 0, 0, 0, 0];
+        let b = vec![6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let mut cita_trie = cita_trie();
+        let mut trie = Trie::new_temp();
+        cita_trie.insert(a.clone(), a.clone()).unwrap();
+        cita_trie.insert(b.clone(), b.clone()).unwrap();
+        trie.insert(a.clone(), a.clone()).unwrap();
+        trie.insert(b.clone(), b.clone()).unwrap();
+        trie.remove(a.clone()).unwrap();
+        cita_trie.remove(&a).unwrap();
+        let _ = cita_trie.root();
+        let cita_proof = cita_trie.get_proof(&a).unwrap();
+        let trie_proof = trie.get_proof(&a).unwrap();
+        assert_eq!(cita_proof, trie_proof);
+    }
 }

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -130,6 +130,9 @@ impl Trie {
             .unwrap_or(*EMPTY_TRIE_HASH))
     }
 
+    /// Obtain a merkle proof for the given path.
+    /// The proof will contain all the encoded nodes traversed until reaching the node where the path is stored (including this last node).
+    /// The proof will still be constructed even if the path is not stored in the trie, proving its absence.
     pub fn get_proof(&self, path: &PathRLP) -> Result<Vec<Vec<u8>>, StoreError> {
         // Will store all the encoded nodes traversed until reaching the node containing the path
         let mut node_path = Vec::new();

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -824,11 +824,23 @@ mod test {
         let mut cita_trie = cita_trie();
         let mut trie = Trie::new_temp();
         cita_trie
-            .insert(vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0], vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0])
+            .insert(
+                vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            )
             .unwrap();
-        trie.insert(vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0], vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0]).unwrap();
-        let cita_proof = cita_trie.get_proof(&vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0]).unwrap();
-        let trie_proof = trie.get_proof(&vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0]).unwrap();
+        trie.insert(
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        )
+        .unwrap();
+        let _ = cita_trie.root();
+        let cita_proof = cita_trie
+            .get_proof(&vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+            .unwrap();
+        let trie_proof = trie
+            .get_proof(&vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+            .unwrap();
         assert_eq!(cita_proof, trie_proof);
     }
 }

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -817,4 +817,18 @@ mod test {
         let trie_proof = trie.get_proof(&b"duck".to_vec()).unwrap();
         assert_eq!(cita_proof, trie_proof);
     }
+
+    #[test]
+    fn get_proof_one_big_leaf() {
+        // Trie -> Leaf[[0,0,0,0,0,0,0,0,0,0,0,0,0,0]]
+        let mut cita_trie = cita_trie();
+        let mut trie = Trie::new_temp();
+        cita_trie
+            .insert(vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0], vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0])
+            .unwrap();
+        trie.insert(vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0], vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0]).unwrap();
+        let cita_proof = cita_trie.get_proof(&vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0]).unwrap();
+        let trie_proof = trie.get_proof(&vec![0,0,0,0,0,0,0,0,0,0,0,0,0,0]).unwrap();
+        assert_eq!(cita_proof, trie_proof);
+    }
 }

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -843,4 +843,22 @@ mod test {
             .unwrap();
         assert_eq!(cita_proof, trie_proof);
     }
+
+    #[test]
+    fn get_proof_path_in_branch() {
+        // Trie -> Extension[Branch[ [Leaf[[183,0,0,0,0,0]]], [183]]]
+        let mut cita_trie = cita_trie();
+        let mut trie = Trie::new_temp();
+        cita_trie.insert(vec![183], vec![183]).unwrap();
+        cita_trie
+            .insert(vec![183, 0, 0, 0, 0, 0], vec![183, 0, 0, 0, 0, 0])
+            .unwrap();
+        trie.insert(vec![183], vec![183]).unwrap();
+        trie.insert(vec![183, 0, 0, 0, 0, 0], vec![183, 0, 0, 0, 0, 0])
+            .unwrap();
+        let _ = cita_trie.root();
+        let cita_proof = cita_trie.get_proof(&vec![183]).unwrap();
+        let trie_proof = trie.get_proof(&vec![183]).unwrap();
+        assert_eq!(cita_proof, trie_proof);
+    }
 }

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -136,6 +136,10 @@ impl Trie {
         let Some(root) = &self.root else {
             return Ok(node_path);
         };
+        // If the root is an inlined leaf, return it
+        if let NodeHash::Inline(node) = root {
+            return Ok(vec![node.to_vec()]);
+        }
         let root_node = self
             .state
             .get_node(root.clone())?

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -136,9 +136,9 @@ impl Trie {
         let Some(root) = &self.root else {
             return Ok(node_path);
         };
-        // If the root is an inlined leaf, return it
+        // If the root is inlined, add it to the node_path
         if let NodeHash::Inline(node) = root {
-            return Ok(vec![node.to_vec()]);
+            node_path.push(node.to_vec());
         }
         let root_node = self
             .state
@@ -794,9 +794,8 @@ mod test {
             .insert(b"goose".to_vec(), b"goose".to_vec())
             .unwrap();
         trie.insert(b"duck".to_vec(), b"duck".to_vec()).unwrap();
-        trie
-            .insert(b"goose".to_vec(), b"goose".to_vec())
-            .unwrap();
+        trie.insert(b"goose".to_vec(), b"goose".to_vec()).unwrap();
+        let _ = cita_trie.root();
         let cita_proof = cita_trie.get_proof(&b"duck".to_vec()).unwrap();
         let trie_proof = trie.get_proof(&b"duck".to_vec()).unwrap();
         assert_eq!(cita_proof, trie_proof);

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -133,6 +133,7 @@ impl Trie {
     /// Obtain a merkle proof for the given path.
     /// The proof will contain all the encoded nodes traversed until reaching the node where the path is stored (including this last node).
     /// The proof will still be constructed even if the path is not stored in the trie, proving its absence.
+    #[allow(unused)]
     pub fn get_proof(&self, path: &PathRLP) -> Result<Vec<Vec<u8>>, StoreError> {
         // Will store all the encoded nodes traversed until reaching the node containing the path
         let mut node_path = Vec::new();

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -763,4 +763,17 @@ mod test {
 
         CitaTrie::new(Arc::clone(&memdb), Arc::clone(&hasher))
     }
+
+    #[test]
+    fn get_proof_one_leaf() {
+        let mut cita_trie = cita_trie();
+        let mut trie = Trie::new_temp();
+        cita_trie
+            .insert(b"duck".to_vec(), b"duckling".to_vec())
+            .unwrap();
+        trie.insert(b"duck".to_vec(), b"duckling".to_vec()).unwrap();
+        let cita_proof = cita_trie.get_proof(&b"duck".to_vec()).unwrap();
+        let trie_proof = trie.get_proof(&b"duck".to_vec()).unwrap();
+        assert_eq!(cita_proof, trie_proof);
+    }
 }

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -885,26 +885,14 @@ mod test {
     #[test]
     fn get_proof_one_big_leaf() {
         // Trie -> Leaf[[0,0,0,0,0,0,0,0,0,0,0,0,0,0]]
+        let val = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         let mut cita_trie = cita_trie();
         let mut trie = Trie::new_temp();
-        cita_trie
-            .insert(
-                vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            )
-            .unwrap();
-        trie.insert(
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        )
-        .unwrap();
+        cita_trie.insert(val.clone(), val.clone()).unwrap();
+        trie.insert(val.clone(), val.clone()).unwrap();
         let _ = cita_trie.root();
-        let cita_proof = cita_trie
-            .get_proof(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-            .unwrap();
-        let trie_proof = trie
-            .get_proof(&vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-            .unwrap();
+        let cita_proof = cita_trie.get_proof(&val).unwrap();
+        let trie_proof = trie.get_proof(&val).unwrap();
         assert_eq!(cita_proof, trie_proof);
     }
 

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -130,6 +130,20 @@ impl Trie {
             .unwrap_or(*EMPTY_TRIE_HASH))
     }
 
+    pub fn get_proof(&self, path: &PathRLP) -> Result<Vec<Vec<u8>>, StoreError> {
+        // Will store all the encoded nodes traversed until reaching the node containing the path
+        let mut node_path = Vec::new();
+        let Some(root) = &self.root else {
+            return Ok(node_path);
+        };
+        let root_node = self
+            .state
+            .get_node(root.clone())?
+            .expect("inconsistent tree structure");
+        root_node.get_path(&self.state, NibbleSlice::new(path), &mut node_path)?;
+        Ok(node_path)
+    }
+
     #[cfg(test)]
     /// Creates a new Trie based on a temporary Libmdbx DB
     fn new_temp() -> Self {

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -854,7 +854,7 @@ mod test {
             .insert(b"duck".to_vec(), b"duckling".to_vec())
             .unwrap();
         trie.insert(b"duck".to_vec(), b"duckling".to_vec()).unwrap();
-        let cita_proof = cita_trie.get_proof(&b"duck".to_vec()).unwrap();
+        let cita_proof = cita_trie.get_proof(b"duck".as_ref()).unwrap();
         let trie_proof = trie.get_proof(&b"duck".to_vec()).unwrap();
         assert_eq!(cita_proof, trie_proof);
     }
@@ -873,7 +873,7 @@ mod test {
         trie.insert(b"duck".to_vec(), b"duck".to_vec()).unwrap();
         trie.insert(b"goose".to_vec(), b"goose".to_vec()).unwrap();
         let _ = cita_trie.root();
-        let cita_proof = cita_trie.get_proof(&b"duck".to_vec()).unwrap();
+        let cita_proof = cita_trie.get_proof(b"duck".as_ref()).unwrap();
         let trie_proof = trie.get_proof(&b"duck".to_vec()).unwrap();
         assert_eq!(cita_proof, trie_proof);
     }
@@ -896,7 +896,7 @@ mod test {
         .unwrap();
         let _ = cita_trie.root();
         let cita_proof = cita_trie
-            .get_proof(&vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+            .get_proof(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
             .unwrap();
         let trie_proof = trie
             .get_proof(&vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
@@ -917,7 +917,7 @@ mod test {
         trie.insert(vec![183, 0, 0, 0, 0, 0], vec![183, 0, 0, 0, 0, 0])
             .unwrap();
         let _ = cita_trie.root();
-        let cita_proof = cita_trie.get_proof(&vec![183]).unwrap();
+        let cita_proof = cita_trie.get_proof(&[183]).unwrap();
         let trie_proof = trie.get_proof(&vec![183]).unwrap();
         assert_eq!(cita_proof, trie_proof);
     }

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -766,12 +766,33 @@ mod test {
 
     #[test]
     fn get_proof_one_leaf() {
+        // Trie -> Leaf["duck"]
         let mut cita_trie = cita_trie();
         let mut trie = Trie::new_temp();
         cita_trie
             .insert(b"duck".to_vec(), b"duckling".to_vec())
             .unwrap();
         trie.insert(b"duck".to_vec(), b"duckling".to_vec()).unwrap();
+        let cita_proof = cita_trie.get_proof(&b"duck".to_vec()).unwrap();
+        let trie_proof = trie.get_proof(&b"duck".to_vec()).unwrap();
+        assert_eq!(cita_proof, trie_proof);
+    }
+
+    #[test]
+    fn get_proof_two_leaves() {
+        // Trie -> Branch[Leaf["duck"] Leaf["goose"]]
+        let mut cita_trie = cita_trie();
+        let mut trie = Trie::new_temp();
+        cita_trie
+            .insert(b"duck".to_vec(), b"duck".to_vec())
+            .unwrap();
+        cita_trie
+            .insert(b"goose".to_vec(), b"goose".to_vec())
+            .unwrap();
+        trie.insert(b"duck".to_vec(), b"duck".to_vec()).unwrap();
+        trie
+            .insert(b"goose".to_vec(), b"goose".to_vec())
+            .unwrap();
         let cita_proof = cita_trie.get_proof(&b"duck".to_vec()).unwrap();
         let trie_proof = trie.get_proof(&b"duck".to_vec()).unwrap();
         assert_eq!(cita_proof, trie_proof);

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -780,7 +780,7 @@ mod test {
 
     #[test]
     fn get_proof_two_leaves() {
-        // Trie -> Branch[Leaf["duck"] Leaf["goose"]]
+        // Trie -> Extension[Branch[Leaf["duck"] Leaf["goose"]]]
         let mut cita_trie = cita_trie();
         let mut trie = Trie::new_temp();
         cita_trie

--- a/crates/storage/trie/node.rs
+++ b/crates/storage/trie/node.rs
@@ -90,7 +90,7 @@ impl Node {
         match self {
             Node::Branch(n) => n.get_path(state, path, node_path),
             Node::Extension(n) => n.get_path(state, path, node_path),
-            Node::Leaf(_) => Ok(()),
+            Node::Leaf(n) => n.get_path(path, node_path),
         }
     }
 

--- a/crates/storage/trie/node.rs
+++ b/crates/storage/trie/node.rs
@@ -80,6 +80,7 @@ impl Node {
 
     /// Traverses own subtrie until reaching the node containing `path`
     /// Appends all encoded nodes traversed to `node_path` (including self)
+    /// Only nodes with encoded len over or equal to 32 bytes are included
     pub fn get_path(
         &self,
         state: &TrieState,

--- a/crates/storage/trie/node.rs
+++ b/crates/storage/trie/node.rs
@@ -88,9 +88,9 @@ impl Node {
         node_path: &mut Vec<Vec<u8>>,
     ) -> Result<(), StoreError> {
         match self {
-            Node::Branch(n) => todo!(),
-            Node::Extension(n) => todo!(),
-            Node::Leaf(n) => n.get_path(path, node_path),
+            Node::Branch(n) => n.get_path(state, path, node_path),
+            Node::Extension(n) => n.get_path(state, path, node_path),
+            Node::Leaf(_) => Ok(()),
         }
     }
 

--- a/crates/storage/trie/node.rs
+++ b/crates/storage/trie/node.rs
@@ -79,7 +79,7 @@ impl Node {
     }
 
     /// Traverses own subtrie until reaching the node containing `path`
-    /// Appends all encoded nodes traversed to `node_path`
+    /// Appends all encoded nodes traversed to `node_path` (including self)
     pub fn get_path(
         &self,
         state: &TrieState,
@@ -89,7 +89,7 @@ impl Node {
         match self {
             Node::Branch(n) => todo!(),
             Node::Extension(n) => todo!(),
-            Node::Leaf(n) => todo!(),
+            Node::Leaf(n) => n.get_path(path, node_path),
         }
     }
 

--- a/crates/storage/trie/node.rs
+++ b/crates/storage/trie/node.rs
@@ -78,6 +78,21 @@ impl Node {
         }
     }
 
+    /// Traverses own subtrie until reaching the node containing `path`
+    /// Appends all encoded nodes traversed to `node_path`
+    pub fn get_path(
+        &self,
+        state: &TrieState,
+        path: NibbleSlice,
+        node_path: &mut Vec<Vec<u8>>,
+    ) -> Result<(), StoreError> {
+        match self {
+            Node::Branch(n) => todo!(),
+            Node::Extension(n) => todo!(),
+            Node::Leaf(n) => todo!(),
+        }
+    }
+
     pub fn insert_self(
         self,
         path_offset: usize,

--- a/crates/storage/trie/node/branch.rs
+++ b/crates/storage/trie/node/branch.rs
@@ -260,8 +260,11 @@ impl BranchNode {
         Ok((new_node, value))
     }
 
-    /// Computes the node's hash given the offset in the path traversed before reaching this node
     pub fn compute_hash(&self) -> NodeHash {
+        NodeHash::from_encoded_raw(self.encode_raw())
+    }
+
+    pub fn encode_raw(&self) -> Vec<u8> {
         let hash_choice = |node_hash: &NodeHash| -> (Vec<u8>, usize) {
             if node_hash.is_valid() {
                 match node_hash {
@@ -301,7 +304,7 @@ impl BranchNode {
             Some(value) => encoder.write_bytes(value),
             None => encoder.write_bytes(&[]),
         }
-        encoder.hash()
+        encoder.finalize()
     }
 
     /// Inserts the node into the state and returns its hash

--- a/crates/storage/trie/node/branch.rs
+++ b/crates/storage/trie/node/branch.rs
@@ -320,14 +320,13 @@ impl BranchNode {
         mut path: NibbleSlice,
         node_path: &mut Vec<Vec<u8>>,
     ) -> Result<(), StoreError> {
-        // TODO: Check the case in which the branch contains the path
+        // Add self to node_path (if not inlined in parent)
+        let encoded = self.encode_raw();
+        if encoded.len() >= 32 {
+            node_path.push(encoded);
+        };
         // Check the corresponding choice and delegate accordingly if present.
         if let Some(choice) = path.next().map(usize::from) {
-            // Add self to node_path (if not inlined in parent)
-            let encoded = self.encode_raw();
-            if dbg!(encoded.len()) >= 32 {
-                node_path.push(encoded);
-            };
             // Continue to child
             let child_hash = &self.choices[choice];
             if child_hash.is_valid() {
@@ -337,9 +336,6 @@ impl BranchNode {
                 child_node.get_path(state, path, node_path)?;
             }
         }
-        // else {
-        //     // Return internal value if present.
-        // }
         Ok(())
     }
 }

--- a/crates/storage/trie/node/branch.rs
+++ b/crates/storage/trie/node/branch.rs
@@ -260,10 +260,12 @@ impl BranchNode {
         Ok((new_node, value))
     }
 
+    /// Computes the node's hash
     pub fn compute_hash(&self) -> NodeHash {
         NodeHash::from_encoded_raw(self.encode_raw())
     }
 
+    /// Encodes the node
     pub fn encode_raw(&self) -> Vec<u8> {
         let hash_choice = |node_hash: &NodeHash| -> (Vec<u8>, usize) {
             if node_hash.is_valid() {
@@ -314,6 +316,9 @@ impl BranchNode {
         Ok(hash)
     }
 
+    /// Traverses own subtrie until reaching the node containing `path`
+    /// Appends all encoded nodes traversed to `node_path` (including self)
+    /// Only nodes with encoded len over or equal to 32 bytes are included
     pub fn get_path(
         &self,
         state: &TrieState,

--- a/crates/storage/trie/node/extension.rs
+++ b/crates/storage/trie/node/extension.rs
@@ -161,10 +161,12 @@ impl ExtensionNode {
         }
     }
 
+    /// Computes the node's hash
     pub fn compute_hash(&self) -> NodeHash {
         NodeHash::from_encoded_raw(self.encode_raw())
     }
 
+    /// Encodes the node
     pub fn encode_raw(&self) -> Vec<u8> {
         let child_hash = &self.child;
         let prefix_len = NodeEncoder::path_len(self.prefix.len());
@@ -190,6 +192,9 @@ impl ExtensionNode {
         Ok(hash)
     }
 
+    /// Traverses own subtrie until reaching the node containing `path`
+    /// Appends all encoded nodes traversed to `node_path` (including self)
+    /// Only nodes with encoded len over or equal to 32 bytes are included
     pub fn get_path(
         &self,
         state: &TrieState,

--- a/crates/storage/trie/node/extension.rs
+++ b/crates/storage/trie/node/extension.rs
@@ -1,7 +1,7 @@
 use crate::error::StoreError;
 use crate::trie::nibble::NibbleSlice;
 use crate::trie::nibble::NibbleVec;
-use crate::trie::node_hash::{NodeHash, NodeEncoder, PathKind};
+use crate::trie::node_hash::{NodeEncoder, NodeHash, PathKind};
 use crate::trie::state::TrieState;
 use crate::trie::ValueRLP;
 
@@ -162,6 +162,10 @@ impl ExtensionNode {
     }
 
     pub fn compute_hash(&self) -> NodeHash {
+        NodeHash::from_encoded_raw(self.encode_raw())
+    }
+
+    pub fn encode_raw(&self) -> Vec<u8> {
         let child_hash = &self.child;
         let prefix_len = NodeEncoder::path_len(self.prefix.len());
         let child_len = match child_hash {
@@ -176,7 +180,7 @@ impl ExtensionNode {
             NodeHash::Inline(x) => encoder.write_raw(x),
             NodeHash::Hashed(x) => encoder.write_bytes(&x.0),
         }
-        encoder.hash()
+        encoder.finalize()
     }
 
     /// Inserts the node into the state and returns its hash

--- a/crates/storage/trie/node/extension.rs
+++ b/crates/storage/trie/node/extension.rs
@@ -1,7 +1,7 @@
 use crate::error::StoreError;
 use crate::trie::nibble::NibbleSlice;
 use crate::trie::nibble::NibbleVec;
-use crate::trie::node_hash::{NodeHash, NodeHasher, PathKind};
+use crate::trie::node_hash::{NodeHash, NodeEncoder, PathKind};
 use crate::trie::state::TrieState;
 use crate::trie::ValueRLP;
 
@@ -163,20 +163,20 @@ impl ExtensionNode {
 
     pub fn compute_hash(&self) -> NodeHash {
         let child_hash = &self.child;
-        let prefix_len = NodeHasher::path_len(self.prefix.len());
+        let prefix_len = NodeEncoder::path_len(self.prefix.len());
         let child_len = match child_hash {
             NodeHash::Inline(ref x) => x.len(),
-            NodeHash::Hashed(x) => NodeHasher::bytes_len(32, x[0]),
+            NodeHash::Hashed(x) => NodeEncoder::bytes_len(32, x[0]),
         };
 
-        let mut hasher = NodeHasher::new();
-        hasher.write_list_header(prefix_len + child_len);
-        hasher.write_path_vec(&self.prefix, PathKind::Extension);
+        let mut encoder = NodeEncoder::new();
+        encoder.write_list_header(prefix_len + child_len);
+        encoder.write_path_vec(&self.prefix, PathKind::Extension);
         match child_hash {
-            NodeHash::Inline(x) => hasher.write_raw(x),
-            NodeHash::Hashed(x) => hasher.write_bytes(&x.0),
+            NodeHash::Inline(x) => encoder.write_raw(x),
+            NodeHash::Hashed(x) => encoder.write_bytes(&x.0),
         }
-        hasher.finalize()
+        encoder.hash()
     }
 
     /// Inserts the node into the state and returns its hash

--- a/crates/storage/trie/node/extension.rs
+++ b/crates/storage/trie/node/extension.rs
@@ -189,6 +189,27 @@ impl ExtensionNode {
         state.insert_node(self.into(), hash.clone());
         Ok(hash)
     }
+
+    pub fn get_path(
+        &self,
+        state: &TrieState,
+        mut path: NibbleSlice,
+        node_path: &mut Vec<Vec<u8>>,
+    ) -> Result<(), StoreError> {
+        if path.skip_prefix(&self.prefix) {
+            // Add self to node_path (if not inlined in parent)
+            let encoded = self.encode_raw();
+            if encoded.len() >= 32 {
+                node_path.push(encoded);
+            };
+            // Continue to child
+            let child_node = state
+                .get_node(self.child.clone())?
+                .expect("inconsistent internal tree structure");
+            child_node.get_path(state, path, node_path)?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/storage/trie/node/extension.rs
+++ b/crates/storage/trie/node/extension.rs
@@ -196,13 +196,13 @@ impl ExtensionNode {
         mut path: NibbleSlice,
         node_path: &mut Vec<Vec<u8>>,
     ) -> Result<(), StoreError> {
+        // Add self to node_path (if not inlined in parent)
+        let encoded = self.encode_raw();
+        if encoded.len() >= 32 {
+            node_path.push(encoded);
+        };
+        // Continue to child
         if path.skip_prefix(&self.prefix) {
-            // Add self to node_path (if not inlined in parent)
-            let encoded = self.encode_raw();
-            if encoded.len() >= 32 {
-                node_path.push(encoded);
-            };
-            // Continue to child
             let child_node = state
                 .get_node(self.child.clone())?
                 .expect("inconsistent internal tree structure");

--- a/crates/storage/trie/node/leaf.rs
+++ b/crates/storage/trie/node/leaf.rs
@@ -162,7 +162,11 @@ impl LeafNode {
         node_path: &mut Vec<Vec<u8>>,
     ) -> Result<(), StoreError> {
         if self.path == path.data() {
-            node_path.push(self.encode_raw(path.offset()));
+            let encoded = self.encode_raw(path.offset());
+            // Inlined node would have already been committed?
+            if encoded.len() >= 32 {
+                node_path.push(encoded);
+            }
         }
         Ok(())
     }

--- a/crates/storage/trie/node/leaf.rs
+++ b/crates/storage/trie/node/leaf.rs
@@ -118,7 +118,13 @@ impl LeafNode {
         })
     }
 
+    /// Computes the node's hash given the offset in the path traversed before reaching this node
     pub fn compute_hash(&self, offset: usize) -> NodeHash {
+        NodeHash::from_encoded_raw(self.encode_raw(offset))
+    }
+
+    /// Encodes the node given the offset in the path traversed before reaching this node
+    pub fn encode_raw(&self, offset: usize) -> Vec<u8> {
         let encoded_value = &self.value;
         let encoded_path = &self.path;
 
@@ -135,7 +141,7 @@ impl LeafNode {
         encoder.write_list_header(path_len + value_len);
         encoder.write_path_slice(&path, PathKind::Leaf);
         encoder.write_bytes(encoded_value);
-        encoder.hash()
+        encoder.finalize()
     }
 
     /// Inserts the node into the state and returns its hash

--- a/crates/storage/trie/node/leaf.rs
+++ b/crates/storage/trie/node/leaf.rs
@@ -322,7 +322,7 @@ mod test {
     }
 
     #[test]
-    fn patito() {
+    fn compute_hash() {
         let node = LeafNode::new(b"key".to_vec(), b"value".to_vec());
         let node_hash_ref = node.compute_hash(0);
         assert_eq!(

--- a/crates/storage/trie/node/leaf.rs
+++ b/crates/storage/trie/node/leaf.rs
@@ -156,6 +156,7 @@ impl LeafNode {
         Ok(hash)
     }
 
+    /// Encodes the node and appends it to `node_path` if the encoded node is 32 or more bytes long
     pub fn get_path(
         &self,
         path: NibbleSlice,

--- a/crates/storage/trie/node/leaf.rs
+++ b/crates/storage/trie/node/leaf.rs
@@ -161,12 +161,9 @@ impl LeafNode {
         path: NibbleSlice,
         node_path: &mut Vec<Vec<u8>>,
     ) -> Result<(), StoreError> {
-        if self.path == path.data() {
-            let encoded = self.encode_raw(path.offset());
-            // Inlined node would have already been committed?
-            if encoded.len() >= 32 {
-                node_path.push(encoded);
-            }
+        let encoded = self.encode_raw(path.offset());
+        if encoded.len() >= 32 {
+            node_path.push(encoded);
         }
         Ok(())
     }

--- a/crates/storage/trie/node/leaf.rs
+++ b/crates/storage/trie/node/leaf.rs
@@ -155,6 +155,17 @@ impl LeafNode {
         state.insert_node(self.into(), hash.clone());
         Ok(hash)
     }
+
+    pub fn get_path(
+        &self,
+        path: NibbleSlice,
+        node_path: &mut Vec<Vec<u8>>,
+    ) -> Result<(), StoreError> {
+        if self.path == path.data() {
+            node_path.push(self.encode_raw(path.offset()));
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/storage/trie/node/leaf.rs
+++ b/crates/storage/trie/node/leaf.rs
@@ -155,17 +155,6 @@ impl LeafNode {
         state.insert_node(self.into(), hash.clone());
         Ok(hash)
     }
-
-    pub fn get_path(
-        &self,
-        path: NibbleSlice,
-        node_path: &mut Vec<Vec<u8>>,
-    ) -> Result<(), StoreError> {
-        if self.path == path.data() {
-            node_path.push(self.encode_raw(path.offset()));
-        }
-        Ok(())
-    }
 }
 
 #[cfg(test)]

--- a/crates/storage/trie/node/leaf.rs
+++ b/crates/storage/trie/node/leaf.rs
@@ -3,7 +3,7 @@ use crate::{
     trie::{
         nibble::NibbleSlice,
         node::BranchNode,
-        node_hash::{NodeHash, NodeHasher, PathKind},
+        node_hash::{NodeEncoder, NodeHash, PathKind},
         state::TrieState,
         PathRLP, ValueRLP,
     },
@@ -125,17 +125,17 @@ impl LeafNode {
         let mut path = NibbleSlice::new(encoded_path);
         path.offset_add(offset);
 
-        let path_len = NodeHasher::path_len(path.len());
-        let value_len = NodeHasher::bytes_len(
+        let path_len = NodeEncoder::path_len(path.len());
+        let value_len = NodeEncoder::bytes_len(
             encoded_value.len(),
             encoded_value.first().copied().unwrap_or_default(),
         );
 
-        let mut hasher = NodeHasher::new();
-        hasher.write_list_header(path_len + value_len);
-        hasher.write_path_slice(&path, PathKind::Leaf);
-        hasher.write_bytes(encoded_value);
-        hasher.finalize()
+        let mut encoder = crate::trie::node_hash::NodeEncoder::new();
+        encoder.write_list_header(path_len + value_len);
+        encoder.write_path_slice(&path, PathKind::Leaf);
+        encoder.write_bytes(encoded_value);
+        encoder.hash()
     }
 
     /// Inserts the node into the state and returns its hash
@@ -304,7 +304,7 @@ mod test {
     }
 
     #[test]
-    fn compute_hash() {
+    fn patito() {
         let node = LeafNode::new(b"key".to_vec(), b"value".to_vec());
         let node_hash_ref = node.compute_hash(0);
         assert_eq!(

--- a/crates/storage/trie/node_hash.rs
+++ b/crates/storage/trie/node_hash.rs
@@ -45,6 +45,15 @@ impl AsRef<[u8]> for NodeHash {
 }
 
 impl NodeHash {
+    /// Returns the `NodeHash` of an encoded node (encoded using the NodeEncoder)
+    pub fn from_encoded_raw(encoded: Vec<u8>) -> NodeHash {
+        if encoded.len() >= 32 {
+            let hash = Keccak256::new_with_prefix(&encoded).finalize();
+            NodeHash::Hashed(H256::from_slice(hash.as_slice()))
+        } else {
+            NodeHash::Inline(encoded)
+        }
+    }
     /// Returns the finalized hash
     /// NOTE: This will hash smaller nodes, only use to get the final root hash, not for intermediate node hashes
     pub fn finalize(self) -> H256 {
@@ -240,15 +249,6 @@ impl NodeEncoder {
         } else {
             self.write_len(0x80, 0xB7, value.len());
             self.write_raw(value);
-        }
-    }
-
-    pub fn hash(self) -> NodeHash {
-        if self.encoded.len() >= 32 {
-            let hash = Keccak256::new_with_prefix(&self.encoded).finalize();
-            NodeHash::Hashed(H256::from_slice(hash.as_slice()))
-        } else {
-            NodeHash::Inline(self.encoded.clone())
         }
     }
 

--- a/crates/storage/trie/node_hash.rs
+++ b/crates/storage/trie/node_hash.rs
@@ -1,21 +1,9 @@
-use std::cmp::min;
-
 use ethereum_rust_core::rlp::{decode::RLPDecode, encode::RLPEncode};
 use ethereum_types::H256;
 use libmdbx::orm::{Decodable, Encodable};
 use sha3::{Digest, Keccak256};
 
-type Output = digest::Output<Keccak256>;
-
 use super::nibble::{NibbleSlice, NibbleVec};
-
-#[derive(Default)]
-pub struct NodeHasher {
-    hash: Output,
-    len: usize,
-    hasher: Keccak256,
-    no_inline: bool,
-}
 
 /// Struct representing a trie node hash
 /// If the encoded node is less than 32 bits, contains the encoded node itself
@@ -25,133 +13,6 @@ pub struct NodeHasher {
 pub enum NodeHash {
     Hashed(H256),
     Inline(Vec<u8>),
-}
-
-impl NodeHasher {
-    pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
-    }
-
-    pub const fn path_len(value_len: usize) -> usize {
-        Self::bytes_len((value_len >> 1) + 1, 0)
-    }
-
-    pub const fn bytes_len(value_len: usize, first_value: u8) -> usize {
-        match value_len {
-            1 if first_value < 128 => 1,
-            l if l < 56 => l + 1,
-            l => l + compute_byte_usage(l) + 1,
-        }
-    }
-
-    pub fn write_list_header(&mut self, children_len: usize) {
-        self.write_len(0xC0, 0xF7, children_len);
-    }
-
-    fn write_len(&mut self, short_base: u8, long_base: u8, value: usize) {
-        match value {
-            l if l < 56 => self.write_raw(&[short_base + l as u8]),
-            l => {
-                let l_len = compute_byte_usage(l);
-                self.write_raw(&[long_base + l_len as u8]);
-                self.write_raw(&l.to_be_bytes()[size_of::<usize>() - l_len..]);
-            }
-        }
-    }
-
-    pub fn write_raw(&mut self, value: &[u8]) {
-        let mut length = self.len;
-        let mut hash = self.hash;
-
-        let mut current_pos = 0;
-        while current_pos < value.len() {
-            let copy_len = min(32 - length, value.len() - current_pos);
-
-            let target_slice = &mut hash[length..length + copy_len];
-            let source_slice = &value[current_pos..current_pos + copy_len];
-            target_slice.copy_from_slice(source_slice);
-
-            current_pos += copy_len;
-            length += copy_len;
-
-            if length == 32 {
-                self.no_inline = true;
-                self.hasher.update(hash);
-                length = 0;
-            }
-        }
-        self.hash = hash;
-        self.len = length;
-    }
-
-    pub fn write_path_slice(&mut self, value: &NibbleSlice, kind: PathKind) {
-        let mut flag = kind.into_flag();
-
-        // TODO: Do not use iterators.
-        let nibble_count = value.clone().count();
-        let nibble_iter = if nibble_count & 0x01 != 0 {
-            let mut iter = value.clone();
-            flag |= 0x10;
-            flag |= iter.next().unwrap() as u8;
-            iter
-        } else {
-            value.clone()
-        };
-
-        let i2 = nibble_iter.clone().skip(1).step_by(2);
-        if nibble_count > 1 {
-            self.write_len(0x80, 0xB7, (nibble_count >> 1) + 1);
-        }
-        self.write_raw(&[flag]);
-        for (a, b) in nibble_iter.step_by(2).zip(i2) {
-            self.write_raw(&[((a as u8) << 4) | (b as u8)]);
-        }
-    }
-
-    pub fn write_path_vec(&mut self, value: &NibbleVec, kind: PathKind) {
-        let mut flag = kind.into_flag();
-
-        // TODO: Do not use iterators.
-        let nibble_count = value.len();
-        let nibble_iter = if nibble_count & 0x01 != 0 {
-            let mut iter = value.iter();
-            flag |= 0x10;
-            flag |= iter.next().unwrap() as u8;
-            iter
-        } else {
-            value.iter()
-        };
-
-        let i2 = nibble_iter.clone().skip(1).step_by(2);
-        if nibble_count > 1 {
-            self.write_len(0x80, 0xB7, (nibble_count >> 1) + 1);
-        }
-        self.write_raw(&[flag]);
-        for (a, b) in nibble_iter.step_by(2).zip(i2) {
-            self.write_raw(&[((a as u8) << 4) | (b as u8)]);
-        }
-    }
-
-    pub fn write_bytes(&mut self, value: &[u8]) {
-        if value.len() == 1 && value[0] < 128 {
-            self.write_raw(&[value[0]]);
-        } else {
-            self.write_len(0x80, 0xB7, value.len());
-            self.write_raw(value);
-        }
-    }
-
-    pub fn finalize(mut self) -> NodeHash {
-        if self.no_inline {
-            let hash = self.hash;
-            self.hasher.update(&hash[..self.len]);
-            NodeHash::Hashed(H256::from_slice(self.hasher.finalize().as_slice()))
-        } else {
-            NodeHash::Inline(self.hash[..self.len].to_vec())
-        }
-    }
 }
 
 const fn compute_byte_usage(value: usize) -> usize {
@@ -279,5 +140,119 @@ impl RLPDecode for NodeHash {
         (hash, rest) = RLPDecode::decode_unfinished(rlp)?;
         let hash = NodeHash::from(hash);
         Ok((hash, rest))
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct NodeEncoder {
+    encoded: Vec<u8>,
+}
+
+impl NodeEncoder {
+    pub fn new() -> Self {
+        Self {
+            ..Default::default()
+        }
+    }
+
+    pub const fn path_len(value_len: usize) -> usize {
+        Self::bytes_len((value_len >> 1) + 1, 0)
+    }
+
+    pub const fn bytes_len(value_len: usize, first_value: u8) -> usize {
+        match value_len {
+            1 if first_value < 128 => 1,
+            l if l < 56 => l + 1,
+            l => l + compute_byte_usage(l) + 1,
+        }
+    }
+
+    pub fn write_list_header(&mut self, children_len: usize) {
+        self.write_len(0xC0, 0xF7, children_len);
+    }
+
+    fn write_len(&mut self, short_base: u8, long_base: u8, value: usize) {
+        match value {
+            l if l < 56 => self.write_raw(&[short_base + l as u8]),
+            l => {
+                let l_len = compute_byte_usage(l);
+                self.write_raw(&[long_base + l_len as u8]);
+                self.write_raw(&l.to_be_bytes()[size_of::<usize>() - l_len..]);
+            }
+        }
+    }
+
+    pub fn write_raw(&mut self, value: &[u8]) {
+        self.encoded.extend_from_slice(value);
+    }
+
+    pub fn write_path_slice(&mut self, value: &NibbleSlice, kind: PathKind) {
+        let mut flag = kind.into_flag();
+
+        // TODO: Do not use iterators.
+        let nibble_count = value.clone().count();
+        let nibble_iter = if nibble_count & 0x01 != 0 {
+            let mut iter = value.clone();
+            flag |= 0x10;
+            flag |= iter.next().unwrap() as u8;
+            iter
+        } else {
+            value.clone()
+        };
+
+        let i2 = nibble_iter.clone().skip(1).step_by(2);
+        if nibble_count > 1 {
+            self.write_len(0x80, 0xB7, (nibble_count >> 1) + 1);
+        }
+        self.write_raw(&[flag]);
+        for (a, b) in nibble_iter.step_by(2).zip(i2) {
+            self.write_raw(&[((a as u8) << 4) | (b as u8)]);
+        }
+    }
+
+    pub fn write_path_vec(&mut self, value: &NibbleVec, kind: PathKind) {
+        let mut flag = kind.into_flag();
+
+        // TODO: Do not use iterators.
+        let nibble_count = value.len();
+        let nibble_iter = if nibble_count & 0x01 != 0 {
+            let mut iter = value.iter();
+            flag |= 0x10;
+            flag |= iter.next().unwrap() as u8;
+            iter
+        } else {
+            value.iter()
+        };
+
+        let i2 = nibble_iter.clone().skip(1).step_by(2);
+        if nibble_count > 1 {
+            self.write_len(0x80, 0xB7, (nibble_count >> 1) + 1);
+        }
+        self.write_raw(&[flag]);
+        for (a, b) in nibble_iter.step_by(2).zip(i2) {
+            self.write_raw(&[((a as u8) << 4) | (b as u8)]);
+        }
+    }
+
+    pub fn write_bytes(&mut self, value: &[u8]) {
+        if value.len() == 1 && value[0] < 128 {
+            self.write_raw(&[value[0]]);
+        } else {
+            self.write_len(0x80, 0xB7, value.len());
+            self.write_raw(value);
+        }
+    }
+
+    pub fn hash(self) -> NodeHash {
+        if self.encoded.len() >= 32 {
+            let hash = Keccak256::new_with_prefix(&self.encoded).finalize();
+            NodeHash::Hashed(H256::from_slice(hash.as_slice()))
+        } else {
+            NodeHash::Inline(self.encoded.clone())
+        }
+    }
+
+    pub fn finalize(self) -> Vec<u8> {
+        self.encoded
     }
 }


### PR DESCRIPTION
**Motivation**
Adding support for Trie::get_proof so we can use it in rpc endpoint etc_getProof

<!-- Why does this pull request exist? What are its goals? -->

**Description**

* Add `Trie` method `get_proof`
* Add protests for `Trie::get_proof`

Other:


* Replace `NodeHasher` with `NodeEncoder`, which behaves similarly, but instead of building up the node's hash, it builds up the node's encoded format, leaving the hashing to a later instance

* Add method `encode_raw` for all node variants


* Add `NodeHash` method `from_encoded_raw` which will hash the encoded node returned by the `NodeEncoder`
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but is needed in order to implement #291 

