### PR TITLE
feat: improve revalidation with liveness checks

### DIFF
--- a/crates/net/kademlia.rs
+++ b/crates/net/kademlia.rs
@@ -36,10 +36,6 @@ impl KademliaTable {
         &self.buckets
     }
 
-    pub fn buckets_mut(&mut self) -> &mut Vec<Bucket> {
-        &mut self.buckets
-    }
-
     pub fn get_by_node_id(&self, node_id: H512) -> Option<&PeerData> {
         let bucket = &self.buckets[bucket_number(node_id, self.local_node_id)];
         bucket

--- a/crates/net/kademlia.rs
+++ b/crates/net/kademlia.rs
@@ -195,11 +195,16 @@ impl KademliaTable {
                 if peers.len() < limit {
                     peers.push(peer.clone());
                 } else {
-                    for other_peer in &mut peers {
-                        if peer.last_ping > other_peer.last_ping {
-                            *other_peer = peer.clone();
-                            break;
+                    // replace the most recent from the list
+                    let mut most_recent_index = 0;
+                    for (i, other_peer) in peers.iter().enumerate() {
+                        if other_peer.last_pong > peers[most_recent_index].last_pong {
+                            most_recent_index = i;
                         }
+                    }
+
+                    if peer.last_pong < peers[most_recent_index].last_pong {
+                        peers[most_recent_index] = peer.clone();
                     }
                 }
             }

--- a/crates/net/kademlia.rs
+++ b/crates/net/kademlia.rs
@@ -312,7 +312,7 @@ impl PeerData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{node_id_from_signing_key, PROOF_EXPIRATION_IN_HS};
+    use crate::node_id_from_signing_key;
     use hex_literal::hex;
     use k256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng};
     use std::{

--- a/crates/net/net.rs
+++ b/crates/net/net.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashSet,
     net::SocketAddr,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -296,7 +295,7 @@ async fn peers_revalidation(
                     }
                 }
 
-                if peer.liveness <= 0 {
+                if peer.liveness == 0 {
                     let new_peer = table.lock().await.replace_peer(peer.node.node_id);
                     if let Some(new_peer) = new_peer {
                         let ping_hash = ping(

--- a/crates/net/net.rs
+++ b/crates/net/net.rs
@@ -312,7 +312,7 @@ async fn peers_revalidation(
         // first check that the peers we ping have responded
         for node_id in previously_pinged_peers.iter() {
             let mut table = table.lock().await;
-            let peer = table.get_by_node_id_mut(node_id.clone()).unwrap();
+            let peer = table.get_by_node_id_mut(*node_id).unwrap();
 
             if let Some(has_answered) = peer.revalidation {
                 if has_answered {
@@ -323,7 +323,7 @@ async fn peers_revalidation(
             }
 
             if peer.liveness == 0 {
-                let new_peer = table.replace_peer(node_id.clone());
+                let new_peer = table.replace_peer(*node_id);
                 if let Some(new_peer) = new_peer {
                     let ping_hash = ping(
                         &udp_socket,


### PR DESCRIPTION
**Motivation**

Implements liveness in peers for revalidations.

**Description**

This pr introduces an improvement over the current peer revalidations. This new form pings peers more often (every 30 secs) and keeps track of the ping answers, which provides generally good criteria to prefer some nodes over others when interacting in the `p2p` and choosing the initial seeders (or bootnodes see #398). 

Here is how the new revalidation flow works:
1. Every `30` seconds (by default) we ping the three least recently pinged peers: this may be fine now to keep simplicity, but we might prefer to choose three random peers instead to avoid the search which might become expensive as our buckets start to fill with more peers.
2.  In the next iteration we check if they have answered
     -  if they have: we increment the liveness field by one
     - otherwise: we decrement it by the livenes by `/ 3`.
3. If the liveness field is `0`, we delete it and insert a new one from the replacements table.

Closes #417

