### PR TITLE
feat: [WIP: Proposal] remove Arc<Mutex<>> from Store

### DIFF
--- a/cmd/ethereum_rust/ethereum_rust.rs
+++ b/cmd/ethereum_rust/ethereum_rust.rs
@@ -83,7 +83,7 @@ async fn main() {
     let store: Store<LibmdbxStoreEngine> = match matches.get_one::<String>("datadir") {
         Some(data_dir) if !data_dir.is_empty() => Store::new(data_dir),
         // TODO: A PR is in the works that will add a proper default location in this case
-        _ => Store::new("temp.db"),
+        _ => Store::new_temp(),
     }
     .expect("Failed to create Store");
 

--- a/cmd/ethereum_rust/ethereum_rust.rs
+++ b/cmd/ethereum_rust/ethereum_rust.rs
@@ -4,7 +4,7 @@ use ethereum_rust_core::types::{Block, Genesis};
 use ethereum_rust_net::bootnode::BootNode;
 use ethereum_rust_net::node_id_from_signing_key;
 use ethereum_rust_net::types::Node;
-use ethereum_rust_storage::{EngineType, Store};
+use ethereum_rust_storage::{LibmdbxStoreEngine, Store};
 use k256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng};
 use std::{
     fs::File,
@@ -80,9 +80,10 @@ async fn main() {
     let tcp_socket_addr =
         parse_socket_addr(tcp_addr, tcp_port).expect("Failed to parse addr and port");
 
-    let mut store = match matches.get_one::<String>("datadir") {
-        Some(data_dir) if !data_dir.is_empty() => Store::new(data_dir, EngineType::Libmdbx),
-        _ => Store::new("storage.db", EngineType::InMemory),
+    let store: Store<LibmdbxStoreEngine> = match matches.get_one::<String>("datadir") {
+        Some(data_dir) if !data_dir.is_empty() => Store::new(data_dir),
+        // TODO: A PR is in the works that will add a proper default location in this case
+        _ => Store::new("temp.db"),
     }
     .expect("Failed to create Store");
 

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -1,8 +1,11 @@
 use crate::error::MempoolError;
 use ethereum_rust_core::{types::Transaction, H256};
-use ethereum_rust_storage::Store;
+use ethereum_rust_storage::{Store, StoreEngine};
 
-pub fn add_transaction(transaction: Transaction, store: Store) -> Result<H256, MempoolError> {
+pub fn add_transaction<E: StoreEngine>(
+    transaction: Transaction,
+    store: Store<E>,
+) -> Result<H256, MempoolError> {
     // Validate transaction
     validate_transaction(&transaction)?;
 
@@ -14,7 +17,10 @@ pub fn add_transaction(transaction: Transaction, store: Store) -> Result<H256, M
     Ok(hash)
 }
 
-pub fn get_transaction(hash: H256, store: Store) -> Result<Option<Transaction>, MempoolError> {
+pub fn get_transaction<E: StoreEngine>(
+    hash: H256,
+    store: Store<E>,
+) -> Result<Option<Transaction>, MempoolError> {
     Ok(store.get_transaction_from_pool(hash)?)
 }
 

--- a/crates/evm/db.rs
+++ b/crates/evm/db.rs
@@ -1,16 +1,16 @@
 use ethereum_rust_core::{types::BlockNumber, Address as CoreAddress, H256 as CoreH256};
-use ethereum_rust_storage::{error::StoreError, Store};
+use ethereum_rust_storage::{error::StoreError, Store, StoreEngine};
 use revm::primitives::{
     AccountInfo as RevmAccountInfo, Address as RevmAddress, Bytecode as RevmBytecode,
     Bytes as RevmBytes, B256 as RevmB256, U256 as RevmU256,
 };
 
-pub struct StoreWrapper {
-    pub store: Store,
+pub struct StoreWrapper<E: StoreEngine> {
+    pub store: Store<E>,
     pub block_number: BlockNumber,
 }
 
-impl revm::Database for StoreWrapper {
+impl<E: StoreEngine> revm::Database for StoreWrapper<E> {
     type Error = StoreError;
 
     fn basic(&mut self, address: RevmAddress) -> Result<Option<RevmAccountInfo>, Self::Error> {

--- a/crates/rpc/admin/mod.rs
+++ b/crates/rpc/admin/mod.rs
@@ -1,6 +1,6 @@
 use ethereum_rust_core::types::ChainConfig;
 use ethereum_rust_net::types::Node;
-use ethereum_rust_storage::Store;
+use ethereum_rust_storage::{Store, StoreEngine};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -29,7 +29,7 @@ enum Protocol {
     Eth(ChainConfig),
 }
 
-pub fn node_info(storage: Store, local_node: Node) -> Result<Value, RpcErr> {
+pub fn node_info<E: StoreEngine>(storage: Store<E>, local_node: Node) -> Result<Value, RpcErr> {
     let enode_url = local_node.enode_url();
     let mut protocols = HashMap::new();
 

--- a/crates/rpc/engine/exchange_transition_config.rs
+++ b/crates/rpc/engine/exchange_transition_config.rs
@@ -1,5 +1,5 @@
 use ethereum_rust_core::{serde_utils, H256};
-use ethereum_rust_storage::Store;
+use ethereum_rust_storage::{Store, StoreEngine};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{info, warn};
@@ -43,7 +43,7 @@ impl RpcHandler for ExchangeTransitionConfigV1Req {
         Ok(ExchangeTransitionConfigV1Req { payload })
     }
 
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!("Received new engine request: {self}");
         let payload = &self.payload;
 

--- a/crates/rpc/engine/fork_choice.rs
+++ b/crates/rpc/engine/fork_choice.rs
@@ -1,4 +1,4 @@
-use ethereum_rust_storage::Store;
+use ethereum_rust_storage::{Store, StoreEngine};
 use serde_json::{json, Value};
 
 use crate::{
@@ -25,7 +25,7 @@ impl RpcHandler for ForkChoiceUpdatedV3 {
         })
     }
 
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         // Just a minimal implementation to pass rpc-compat Hive tests.
         // TODO (#50): Implement `engine_forkchoiceUpdatedV3`
         let safe = storage.get_block_number(self.fork_choice_state.safe_block_hash);

--- a/crates/rpc/engine/mod.rs
+++ b/crates/rpc/engine/mod.rs
@@ -3,6 +3,7 @@ pub mod fork_choice;
 pub mod payload;
 
 use crate::{RpcErr, RpcHandler, Store};
+use ethereum_rust_storage::StoreEngine;
 use serde_json::{json, Value};
 
 pub type ExchangeCapabilitiesRequest = Vec<String>;
@@ -17,7 +18,7 @@ impl RpcHandler for ExchangeCapabilitiesRequest {
             .and_then(|v| serde_json::from_value(v.clone()).map_err(|_| RpcErr::BadParams))
     }
 
-    fn handle(&self, _storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, _storage: Store<E>) -> Result<Value, RpcErr> {
         Ok(json!(*self))
     }
 }

--- a/crates/rpc/engine/payload.rs
+++ b/crates/rpc/engine/payload.rs
@@ -2,7 +2,7 @@ use ethereum_rust_blockchain::error::ChainError;
 use ethereum_rust_blockchain::{add_block, latest_valid_hash};
 use ethereum_rust_core::types::ForkId;
 use ethereum_rust_core::H256;
-use ethereum_rust_storage::Store;
+use ethereum_rust_storage::{Store, StoreEngine};
 use serde_json::Value;
 use tracing::{info, warn};
 
@@ -30,7 +30,7 @@ impl RpcHandler for NewPayloadV3Request {
         })
     }
 
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         let block_hash = self.payload.block_hash;
         info!("Received new payload with block hash: {block_hash}");
 

--- a/crates/rpc/eth/account.rs
+++ b/crates/rpc/eth/account.rs
@@ -1,4 +1,4 @@
-use ethereum_rust_storage::Store;
+use ethereum_rust_storage::{Store, StoreEngine};
 use serde_json::Value;
 use tracing::info;
 
@@ -38,7 +38,7 @@ impl RpcHandler for GetBalanceRequest {
             block: BlockIdentifierOrHash::parse(params[1].clone(), 1)?,
         })
     }
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!(
             "Requested balance of account {} at block {}",
             self.address, self.block
@@ -66,7 +66,7 @@ impl RpcHandler for GetCodeRequest {
             block: BlockIdentifierOrHash::parse(params[1].clone(), 1)?,
         })
     }
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!(
             "Requested code of account {} at block {}",
             self.address, self.block
@@ -96,7 +96,7 @@ impl RpcHandler for GetStorageAtRequest {
             block: BlockIdentifierOrHash::parse(params[2].clone(), 2)?,
         })
     }
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!(
             "Requested storage sot {} of account {} at block {}",
             self.storage_slot, self.address, self.block
@@ -125,7 +125,7 @@ impl RpcHandler for GetTransactionCountRequest {
             block: BlockIdentifierOrHash::parse(params[1].clone(), 1)?,
         })
     }
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!(
             "Requested nonce of account {} at block {}",
             self.address, self.block

--- a/crates/rpc/eth/block.rs
+++ b/crates/rpc/eth/block.rs
@@ -18,7 +18,7 @@ use ethereum_rust_core::{
         Receipt,
     },
 };
-use ethereum_rust_storage::Store;
+use ethereum_rust_storage::{Store, StoreEngine};
 
 pub struct GetBlockByNumberRequest {
     pub block: BlockIdentifier,
@@ -65,7 +65,7 @@ impl RpcHandler for GetBlockByNumberRequest {
             hydrated: serde_json::from_value(params[1].clone())?,
         })
     }
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!("Requested block with number: {}", self.block);
         let block_number = match self.block.resolve_block_number(&storage)? {
             Some(block_number) => block_number,
@@ -96,7 +96,7 @@ impl RpcHandler for GetBlockByHashRequest {
             hydrated: serde_json::from_value(params[1].clone())?,
         })
     }
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!("Requested block with hash: {}", self.block);
         let block_number = match storage.get_block_number(self.block)? {
             Some(number) => number,
@@ -126,7 +126,7 @@ impl RpcHandler for GetBlockTransactionCountRequest {
         })
     }
 
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!(
             "Requested transaction count for block with number: {}",
             self.block
@@ -156,7 +156,7 @@ impl RpcHandler for GetBlockReceiptsRequest {
         })
     }
 
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!("Requested receipts for block with number: {}", self.block);
         let block_number = match self.block.resolve_block_number(&storage)? {
             Some(block_number) => block_number,
@@ -186,7 +186,7 @@ impl RpcHandler for GetRawHeaderRequest {
         })
     }
 
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!(
             "Requested raw header for block with identifier: {}",
             self.block
@@ -216,7 +216,7 @@ impl RpcHandler for GetRawBlockRequest {
         })
     }
 
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!("Requested raw block: {}", self.block);
         let block_number = match self.block.resolve_block_number(&storage)? {
             Some(block_number) => block_number,
@@ -246,7 +246,7 @@ impl RpcHandler for GetRawReceipts {
         })
     }
 
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         let block_number = match self.block.resolve_block_number(&storage)? {
             Some(block_number) => block_number,
             _ => return Ok(Value::Null),
@@ -270,7 +270,7 @@ impl RpcHandler for BlockNumberRequest {
         Ok(Self {})
     }
 
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!("Requested latest block number");
         match storage.get_latest_block_number() {
             Ok(Some(block_number)) => {
@@ -286,7 +286,7 @@ impl RpcHandler for GetBlobBaseFee {
         Ok(Self {})
     }
 
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!("Requested blob gas price");
         match storage.get_latest_block_number() {
             Ok(Some(block_number)) => {
@@ -306,11 +306,11 @@ impl RpcHandler for GetBlobBaseFee {
     }
 }
 
-pub fn get_all_block_rpc_receipts(
+pub fn get_all_block_rpc_receipts<E: StoreEngine>(
     block_number: BlockNumber,
     header: BlockHeader,
     body: BlockBody,
-    storage: &Store,
+    storage: &Store<E>,
 ) -> Result<Vec<RpcReceipt>, RpcErr> {
     let mut receipts = Vec::new();
     // Check if this is the genesis block
@@ -349,11 +349,11 @@ pub fn get_all_block_rpc_receipts(
     Ok(receipts)
 }
 
-pub fn get_all_block_receipts(
+pub fn get_all_block_receipts<E: StoreEngine>(
     block_number: BlockNumber,
     header: BlockHeader,
     body: BlockBody,
-    storage: &Store,
+    storage: &Store<E>,
 ) -> Result<Vec<Receipt>, RpcErr> {
     let mut receipts = Vec::new();
     // Check if this is the genesis block

--- a/crates/rpc/eth/client.rs
+++ b/crates/rpc/eth/client.rs
@@ -1,6 +1,6 @@
 use tracing::info;
 
-use ethereum_rust_storage::Store;
+use ethereum_rust_storage::{Store, StoreEngine};
 use serde_json::Value;
 
 use crate::{utils::RpcErr, RpcHandler};
@@ -11,7 +11,7 @@ impl RpcHandler for ChainId {
         Ok(Self {})
     }
 
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!("Requested chain id");
         let chain_spec = storage.get_chain_config().map_err(|_| RpcErr::Internal)?;
         serde_json::to_value(format!("{:#x}", chain_spec.chain_id)).map_err(|_| RpcErr::Internal)
@@ -24,7 +24,7 @@ impl RpcHandler for Syncing {
         Ok(Self {})
     }
 
-    fn handle(&self, _storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, _storage: Store<E>) -> Result<Value, RpcErr> {
         Ok(Value::Bool(false))
     }
 }

--- a/crates/rpc/eth/fee_market.rs
+++ b/crates/rpc/eth/fee_market.rs
@@ -6,7 +6,7 @@ use tracing::info;
 
 use crate::{types::block_identifier::BlockIdentifier, utils::RpcErr, RpcHandler};
 use ethereum_rust_core::types::calculate_base_fee_per_blob_gas;
-use ethereum_rust_storage::Store;
+use ethereum_rust_storage::{Store, StoreEngine};
 
 #[derive(Clone, Debug)]
 pub struct FeeHistoryRequest {
@@ -57,7 +57,7 @@ impl RpcHandler for FeeHistoryRequest {
         })
     }
 
-    fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
+    fn handle<E: StoreEngine>(&self, storage: Store<E>) -> Result<Value, RpcErr> {
         info!(
             "Requested fee history for {} blocks starting from {}",
             self.block_count, self.newest_block
@@ -130,8 +130,8 @@ impl RpcHandler for FeeHistoryRequest {
 }
 
 impl FeeHistoryRequest {
-    fn get_range(
-        storage: &Store,
+    fn get_range<E: StoreEngine>(
+        storage: &Store<E>,
         block_num: u64,
         finish_block: &BlockIdentifier,
     ) -> Result<(u64, u64), RpcErr> {

--- a/crates/rpc/types/block_identifier.rs
+++ b/crates/rpc/types/block_identifier.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, str::FromStr};
 
 use ethereum_rust_core::types::{BlockHash, BlockHeader, BlockNumber};
-use ethereum_rust_storage::{error::StoreError, Store};
+use ethereum_rust_storage::{error::StoreError, Store, StoreEngine};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -31,7 +31,10 @@ pub enum BlockTag {
 }
 
 impl BlockIdentifier {
-    pub fn resolve_block_number(&self, storage: &Store) -> Result<Option<BlockNumber>, StoreError> {
+    pub fn resolve_block_number<E: StoreEngine>(
+        &self,
+        storage: &Store<E>,
+    ) -> Result<Option<BlockNumber>, StoreError> {
         match self {
             BlockIdentifier::Number(num) => Ok(Some(*num)),
             BlockIdentifier::Tag(tag) => match tag {
@@ -64,7 +67,10 @@ impl BlockIdentifier {
         Ok(BlockIdentifier::Number(block_number))
     }
 
-    pub fn resolve_block_header(&self, storage: &Store) -> Result<Option<BlockHeader>, StoreError> {
+    pub fn resolve_block_header<E: StoreEngine>(
+        &self,
+        storage: &Store<E>,
+    ) -> Result<Option<BlockHeader>, StoreError> {
         match self.resolve_block_number(storage)? {
             Some(block_number) => storage.get_block_header(block_number),
             _ => Ok(None),
@@ -74,7 +80,10 @@ impl BlockIdentifier {
 
 impl BlockIdentifierOrHash {
     #[allow(unused)]
-    pub fn resolve_block_number(&self, storage: &Store) -> Result<Option<BlockNumber>, StoreError> {
+    pub fn resolve_block_number<E: StoreEngine>(
+        &self,
+        storage: &Store<E>,
+    ) -> Result<Option<BlockNumber>, StoreError> {
         match self {
             BlockIdentifierOrHash::Identifier(id) => id.resolve_block_number(storage),
             BlockIdentifierOrHash::Hash(block_hash) => storage.get_block_number(*block_hash),
@@ -95,7 +104,7 @@ impl BlockIdentifierOrHash {
     }
 
     #[allow(unused)]
-    pub fn is_latest(&self, storage: &Store) -> Result<bool, StoreError> {
+    pub fn is_latest<E: StoreEngine>(&self, storage: &Store<E>) -> Result<bool, StoreError> {
         if self == &BlockTag::Latest {
             return Ok(true);
         }

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -12,7 +12,6 @@ pub trait StoreEngine: Debug + Send + Sync + Clone + std::panic::UnwindSafe {
     /// Creates a new engine on a given path
     fn new(path: &str) -> Result<Self, StoreError>;
 
-    #[cfg(test)]
     /// Creates a new engine on a temporary path, for testing purposes
     fn new_temp() -> Result<Self, StoreError>;
 

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -185,11 +185,9 @@ impl StoreEngine for InMemoryStoreEngine {
         block_number: BlockNumber,
         index: Index,
     ) -> Result<Option<Receipt>, StoreError> {
-        if let Some(hash) = self.0.lock().unwrap().canonical_hashes.get(&block_number) {
-            Ok(self
-                .0
-                .lock()
-                .unwrap()
+        let store = self.0.lock().unwrap();
+        if let Some(hash) = store.canonical_hashes.get(&block_number) {
+            Ok(store
                 .receipts
                 .get(hash)
                 .and_then(|entry| entry.get(&index))

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -14,8 +14,11 @@ use super::api::StoreEngine;
 
 pub type NodeMap = Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>;
 
-#[derive(Default)]
-pub struct Store {
+#[derive(Default, Clone)]
+pub struct InMemoryStoreEngine(Arc<Mutex<StoreInner>>);
+
+#[derive(Default, Debug)]
+struct StoreInner {
     chain_data: ChainData,
     block_numbers: HashMap<BlockHash, BlockNumber>,
     canonical_hashes: HashMap<BlockNumber, BlockHash>,
@@ -32,7 +35,7 @@ pub struct Store {
     storage_trie_nodes: HashMap<Address, NodeMap>,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct ChainData {
     chain_config: Option<ChainConfig>,
     earliest_block_number: Option<BlockNumber>,
@@ -42,68 +45,88 @@ struct ChainData {
     pending_block_number: Option<BlockNumber>,
 }
 
-impl Store {
-    pub fn new() -> Result<Self, StoreError> {
+impl StoreEngine for InMemoryStoreEngine {
+    fn new(_path: &str) -> Result<Self, StoreError> {
         Ok(Self::default())
     }
-}
 
-impl StoreEngine for Store {
+    #[cfg(test)]
+    fn new_temp() -> Result<Self, StoreError> {
+        Ok(Self::default())
+    }
+
     fn get_block_header(&self, block_number: u64) -> Result<Option<BlockHeader>, StoreError> {
-        if let Some(hash) = self.canonical_hashes.get(&block_number) {
-            Ok(self.headers.get(hash).cloned())
+        if let Some(hash) = self.0.lock().unwrap().canonical_hashes.get(&block_number) {
+            Ok(self.0.lock().unwrap().headers.get(hash).cloned())
         } else {
             Ok(None)
         }
     }
 
     fn get_block_body(&self, block_number: u64) -> Result<Option<BlockBody>, StoreError> {
-        if let Some(hash) = self.canonical_hashes.get(&block_number) {
-            Ok(self.bodies.get(hash).cloned())
+        if let Some(hash) = self.0.lock().unwrap().canonical_hashes.get(&block_number) {
+            Ok(self.0.lock().unwrap().bodies.get(hash).cloned())
         } else {
             Ok(None)
         }
     }
 
     fn add_block_header(
-        &mut self,
+        &self,
         block_hash: BlockHash,
         block_header: BlockHeader,
     ) -> Result<(), StoreError> {
-        self.headers.insert(block_hash, block_header);
+        self.0
+            .lock()
+            .unwrap()
+            .headers
+            .insert(block_hash, block_header);
         Ok(())
     }
 
     fn add_block_body(
-        &mut self,
+        &self,
         block_hash: BlockHash,
         block_body: BlockBody,
     ) -> Result<(), StoreError> {
-        self.bodies.insert(block_hash, block_body);
+        self.0.lock().unwrap().bodies.insert(block_hash, block_body);
         Ok(())
     }
 
     fn add_block_number(
-        &mut self,
+        &self,
         block_hash: BlockHash,
         block_number: BlockNumber,
     ) -> Result<(), StoreError> {
-        self.block_numbers.insert(block_hash, block_number);
+        self.0
+            .lock()
+            .unwrap()
+            .block_numbers
+            .insert(block_hash, block_number);
         Ok(())
     }
 
     fn get_block_number(&self, block_hash: BlockHash) -> Result<Option<BlockNumber>, StoreError> {
-        Ok(self.block_numbers.get(&block_hash).copied())
+        Ok(self
+            .0
+            .lock()
+            .unwrap()
+            .block_numbers
+            .get(&block_hash)
+            .copied())
     }
 
     fn add_transaction_location(
-        &mut self,
+        &self,
         transaction_hash: H256,
         block_number: BlockNumber,
         block_hash: BlockHash,
         index: Index,
     ) -> Result<(), StoreError> {
-        self.transaction_locations
+        self.0
+            .lock()
+            .unwrap()
+            .transaction_locations
             .entry(transaction_hash)
             .or_default()
             .push((block_number, block_hash, index));
@@ -115,35 +138,45 @@ impl StoreEngine for Store {
         transaction_hash: H256,
     ) -> Result<Option<(BlockNumber, BlockHash, Index)>, StoreError> {
         Ok(self
+            .0
+            .lock()
+            .unwrap()
             .transaction_locations
             .get(&transaction_hash)
             .and_then(|v| {
                 v.iter()
-                    .find(|(number, hash, _index)| self.canonical_hashes.get(number) == Some(hash))
+                    .find(|(number, hash, _index)| {
+                        self.0.lock().unwrap().canonical_hashes.get(number) == Some(hash)
+                    })
                     .copied()
             }))
     }
 
     fn add_transaction_to_pool(
-        &mut self,
+        &self,
         hash: H256,
         transaction: Transaction,
     ) -> Result<(), StoreError> {
-        self.transaction_pool.insert(hash, transaction);
+        self.0
+            .lock()
+            .unwrap()
+            .transaction_pool
+            .insert(hash, transaction);
         Ok(())
     }
 
     fn get_transaction_from_pool(&self, hash: H256) -> Result<Option<Transaction>, StoreError> {
-        Ok(self.transaction_pool.get(&hash).cloned())
+        Ok(self.0.lock().unwrap().transaction_pool.get(&hash).cloned())
     }
 
     fn add_receipt(
-        &mut self,
+        &self,
         block_hash: BlockHash,
         index: Index,
         receipt: Receipt,
     ) -> Result<(), StoreError> {
-        let entry = self.receipts.entry(block_hash).or_default();
+        let mut store = self.0.lock().unwrap();
+        let entry = store.receipts.entry(block_hash).or_default();
         entry.insert(index, receipt);
         Ok(())
     }
@@ -153,8 +186,11 @@ impl StoreEngine for Store {
         block_number: BlockNumber,
         index: Index,
     ) -> Result<Option<Receipt>, StoreError> {
-        if let Some(hash) = self.canonical_hashes.get(&block_number) {
+        if let Some(hash) = self.0.lock().unwrap().canonical_hashes.get(&block_number) {
             Ok(self
+                .0
+                .lock()
+                .unwrap()
                 .receipts
                 .get(hash)
                 .and_then(|entry| entry.get(&index))
@@ -164,74 +200,99 @@ impl StoreEngine for Store {
         }
     }
 
-    fn add_account_code(&mut self, code_hash: H256, code: Bytes) -> Result<(), StoreError> {
-        self.account_codes.insert(code_hash, code);
+    fn add_account_code(&self, code_hash: H256, code: Bytes) -> Result<(), StoreError> {
+        self.0.lock().unwrap().account_codes.insert(code_hash, code);
         Ok(())
     }
 
     fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, StoreError> {
-        Ok(self.account_codes.get(&code_hash).cloned())
+        Ok(self
+            .0
+            .lock()
+            .unwrap()
+            .account_codes
+            .get(&code_hash)
+            .cloned())
     }
 
-    fn set_chain_config(&mut self, chain_config: &ChainConfig) -> Result<(), StoreError> {
+    fn set_chain_config(&self, chain_config: &ChainConfig) -> Result<(), StoreError> {
         // Store cancun timestamp
-        self.chain_data.chain_config = Some(*chain_config);
+        self.0.lock().unwrap().chain_data.chain_config = Some(*chain_config);
         Ok(())
     }
 
     fn get_chain_config(&self) -> Result<ChainConfig, StoreError> {
-        Ok(self.chain_data.chain_config.unwrap())
+        Ok(self.0.lock().unwrap().chain_data.chain_config.unwrap())
     }
 
-    fn update_earliest_block_number(
-        &mut self,
-        block_number: BlockNumber,
-    ) -> Result<(), StoreError> {
-        self.chain_data.earliest_block_number.replace(block_number);
+    fn update_earliest_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.0
+            .lock()
+            .unwrap()
+            .chain_data
+            .earliest_block_number
+            .replace(block_number);
         Ok(())
     }
 
     fn get_earliest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        Ok(self.chain_data.earliest_block_number)
+        Ok(self.0.lock().unwrap().chain_data.earliest_block_number)
     }
 
-    fn update_finalized_block_number(
-        &mut self,
-        block_number: BlockNumber,
-    ) -> Result<(), StoreError> {
-        self.chain_data.finalized_block_number.replace(block_number);
+    fn update_finalized_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.0
+            .lock()
+            .unwrap()
+            .chain_data
+            .finalized_block_number
+            .replace(block_number);
         Ok(())
     }
 
     fn get_finalized_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        Ok(self.chain_data.finalized_block_number)
+        Ok(self.0.lock().unwrap().chain_data.finalized_block_number)
     }
 
-    fn update_safe_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
-        self.chain_data.safe_block_number.replace(block_number);
+    fn update_safe_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.0
+            .lock()
+            .unwrap()
+            .chain_data
+            .safe_block_number
+            .replace(block_number);
         Ok(())
     }
 
     fn get_safe_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        Ok(self.chain_data.safe_block_number)
+        Ok(self.0.lock().unwrap().chain_data.safe_block_number)
     }
 
-    fn update_latest_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
-        self.chain_data.latest_block_number.replace(block_number);
+    fn update_latest_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.0
+            .lock()
+            .unwrap()
+            .chain_data
+            .latest_block_number
+            .replace(block_number);
         Ok(())
     }
 
     fn get_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        Ok(self.chain_data.latest_block_number)
+        Ok(self.0.lock().unwrap().chain_data.latest_block_number)
     }
 
-    fn update_pending_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
-        self.chain_data.pending_block_number.replace(block_number);
+    fn update_pending_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
+        self.0
+            .lock()
+            .unwrap()
+            .chain_data
+            .pending_block_number
+            .replace(block_number);
         Ok(())
     }
 
     fn get_pending_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        Ok(self.chain_data.pending_block_number)
+        Ok(self.0.lock().unwrap().chain_data.pending_block_number)
     }
 
     fn state_trie(&self, block_number: BlockNumber) -> Result<Option<Trie>, StoreError> {
@@ -239,7 +300,7 @@ impl StoreEngine for Store {
             return Ok(None);
         };
         let db = Box::new(crate::trie::InMemoryTrieDB::new(
-            self.state_trie_nodes.clone(),
+            self.0.lock().unwrap().state_trie_nodes.clone(),
         ));
         let trie = Trie::open(db, state_root);
         Ok(Some(trie))
@@ -247,14 +308,15 @@ impl StoreEngine for Store {
 
     fn new_state_trie(&self) -> Result<Trie, StoreError> {
         let db = Box::new(crate::trie::InMemoryTrieDB::new(
-            self.state_trie_nodes.clone(),
+            self.0.lock().unwrap().state_trie_nodes.clone(),
         ));
         let trie = Trie::new(db);
         Ok(trie)
     }
 
-    fn open_storage_trie(&mut self, address: Address, storage_root: H256) -> Trie {
-        let trie_backend = self.storage_trie_nodes.entry(address).or_default();
+    fn open_storage_trie(&self, address: Address, storage_root: H256) -> Trie {
+        let mut store = self.0.lock().unwrap();
+        let trie_backend = store.storage_trie_nodes.entry(address).or_default();
         let db = Box::new(crate::trie::InMemoryTrieDB::new(trie_backend.clone()));
         Trie::open(db, storage_root)
     }
@@ -263,27 +325,23 @@ impl StoreEngine for Store {
         &self,
         block_hash: BlockHash,
     ) -> Result<Option<BlockBody>, StoreError> {
-        Ok(self.bodies.get(&block_hash).cloned())
+        Ok(self.0.lock().unwrap().bodies.get(&block_hash).cloned())
     }
 
     fn get_block_header_by_hash(
         &self,
         block_hash: BlockHash,
     ) -> Result<Option<BlockHeader>, StoreError> {
-        Ok(self.headers.get(&block_hash).cloned())
+        Ok(self.0.lock().unwrap().headers.get(&block_hash).cloned())
     }
 
-    fn set_canonical_block(
-        &mut self,
-        number: BlockNumber,
-        hash: BlockHash,
-    ) -> Result<(), StoreError> {
-        self.canonical_hashes.insert(number, hash);
+    fn set_canonical_block(&self, number: BlockNumber, hash: BlockHash) -> Result<(), StoreError> {
+        self.0.lock().unwrap().canonical_hashes.insert(number, hash);
         Ok(())
     }
 }
 
-impl Debug for Store {
+impl Debug for InMemoryStoreEngine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("In Memory Store").finish()
     }

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -138,17 +138,13 @@ impl StoreEngine for InMemoryStoreEngine {
         &self,
         transaction_hash: H256,
     ) -> Result<Option<(BlockNumber, BlockHash, Index)>, StoreError> {
-        Ok(self
-            .0
-            .lock()
-            .unwrap()
+        let store = self.0.lock().unwrap();
+        Ok(store
             .transaction_locations
             .get(&transaction_hash)
             .and_then(|v| {
                 v.iter()
-                    .find(|(number, hash, _index)| {
-                        self.0.lock().unwrap().canonical_hashes.get(number) == Some(hash)
-                    })
+                    .find(|(number, hash, _index)| store.canonical_hashes.get(number) == Some(hash))
                     .copied()
             }))
     }

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -50,7 +50,6 @@ impl StoreEngine for InMemoryStoreEngine {
         Ok(Self::default())
     }
 
-    #[cfg(test)]
     fn new_temp() -> Result<Self, StoreError> {
         Ok(Self::default())
     }

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -55,16 +55,18 @@ impl StoreEngine for InMemoryStoreEngine {
     }
 
     fn get_block_header(&self, block_number: u64) -> Result<Option<BlockHeader>, StoreError> {
-        if let Some(hash) = self.0.lock().unwrap().canonical_hashes.get(&block_number) {
-            Ok(self.0.lock().unwrap().headers.get(hash).cloned())
+        let store = self.0.lock().unwrap();
+        if let Some(hash) = store.canonical_hashes.get(&block_number) {
+            Ok(store.headers.get(hash).cloned())
         } else {
             Ok(None)
         }
     }
 
     fn get_block_body(&self, block_number: u64) -> Result<Option<BlockBody>, StoreError> {
-        if let Some(hash) = self.0.lock().unwrap().canonical_hashes.get(&block_number) {
-            Ok(self.0.lock().unwrap().bodies.get(hash).cloned())
+        let store = self.0.lock().unwrap();
+        if let Some(hash) = store.canonical_hashes.get(&block_number) {
+            Ok(store.bodies.get(hash).cloned())
         } else {
             Ok(None)
         }

--- a/crates/storage/engines/libmdbx.rs
+++ b/crates/storage/engines/libmdbx.rs
@@ -66,7 +66,6 @@ impl StoreEngine for LibmdbxStoreEngine {
         })
     }
 
-    #[cfg(test)]
     fn new_temp() -> Result<Self, StoreError> {
         Ok(Self {
             db: Arc::new(init_db(None::<&str>)),

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -22,7 +22,6 @@ pub use engines::{api::StoreEngine, in_memory::InMemoryStoreEngine, libmdbx::Lib
 
 #[derive(Debug, Clone)]
 pub struct Store<E: StoreEngine> {
-    // TODO: Check if we can remove this mutex and move it to the in_memory::Store struct
     engine: E,
 }
 
@@ -67,7 +66,6 @@ impl<E: StoreEngine> Store<E> {
         })
     }
 
-    #[cfg(test)]
     pub fn new_temp() -> Result<Self, StoreError> {
         Ok(Self {
             engine: E::new_temp()?,


### PR DESCRIPTION
**Motivation**
Currently, our Store contains an `Arc<Mutex<dyn StoreEngine>>`, but the mutex is not really needed for the libmbdx backend, it is only needed for the InMemory one. This means we should be able to move the mutex into the in memory engine and leave the libmdbx mutex-free.
This PR proposes moving this mutex into the InMemory engine and changing the structure of `Store` to:
```
pub struct Store<E: StoreEngine> {
    engine: E,
}
```


<!-- Why does this pull request exist? What are its goals? -->

**Description**

* Change `Store.engine` type from `Arc<Mutex<dyn StoreEngine>>` to ` E: StoreEngine`,
* Wrap in memory store engine in `Arc<Mutex<>>`
* Rename implementations of `StoreEngine` to `LibmdbxStoreEngine` & `InMemoryStoreEngine` and expose them publicly
* Add method `new_temp` for `Store` to be used in tests instead of creating and removing directories "by hand".

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

