### PR TITLE
feat: basic discovery startup

### DIFF
--- a/crates/net/net.rs
+++ b/crates/net/net.rs
@@ -421,8 +421,9 @@ async fn peers_lookup(
 ) {
     let mut interval = tokio::time::interval(Duration::from_secs(interval_time_in_seconds));
 
-    interval.tick().await;
     loop {
+        // Notice that the first tick is immediate,
+        // so as soon as the server starts we'll do a lookup with the seeder nodes.
         interval.tick().await;
 
         let mut handlers = vec![];


### PR DESCRIPTION
**Motivation**

Implements a basic startup with bootnodes param.

**Description**

Adds a basic discovery server startup from the cli `bootnodes` param. Basically, we take the vec of bootnodes and store them on the table, and ping them. Also modifies the code so that we run an initial lookup on startup, without waiting for the interval.

Here is an example of three nodes connecting to each other:

**node a**:
`cargo run --bin ethereum_rust --network test_data/kurtosis.json` 

We get the `enode` by querying the node_info:
`curl http://localhost:8545 \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}'`

**node b**
We start a new server passing the `node_a` `enode` as bootnodes

```bash
cargo run --bin ethereum_rust --network ./test_data/kurtosis.json --bootnodes=`NODE_A_ENODE` \
--authrpc.port=8552 --http.port=8546 --p2p.port=30305 --discovery.port=3036
```

**node c**
Finally, with `node_c` we connect to `node_b`. When the lookup runs, `node_c` should end up connecting to `node_a`:
```bash
 cargo run --bin ethereum_rust --network ./test_data/kurtosis.json --bootnodes=`NODE_B_ENODE`" \
--authrpc.port=8553 --http.port=8547 --p2p.port=30308 --discovery.port=30310
```

All nodes should be connected and pinging each other.

Advances on #398

