### PR TITLE
feat: add transaction validations to `mempool`

### DIFF
--- a/crates/blockchain/constants.rs
+++ b/crates/blockchain/constants.rs
@@ -1,3 +1,41 @@
+// === YELLOW PAPER constants ===
+
+/// Base gas cost for each non contract creating transaction
+pub const TX_GAS_COST: u64 = 21000;
+
+/// Base gas cost for each contract creating transaction
+pub const TX_CREATE_GAS_COST: u64 = 53000;
+
+// Gas cost for each zero byte on transaction data
+pub const TX_DATA_ZERO_GAS_COST: u64 = 4;
+
+// Gas cost for each init code word on transaction data
+pub const TX_INIT_CODE_WORD_GAS_COST: u64 = 2;
+
+// Gas cost for each address specified on access lists
+pub const TX_ACCESS_LIST_ADDRESS_GAS: u64 = 2400;
+
+// Gas cost for each storage key specified on access lists
+pub const TX_ACCESS_LIST_STORAGE_KEY_GAS: u64 = 1900;
+
+// Gas cost for each non zero byte on transaction data
+pub const TX_DATA_NON_ZERO_GAS: u64 = 68;
+
+// === EIP-170 constants ===
+
+// Max bytecode size
+pub const MAX_CODE_SIZE: usize = 0x6000;
+
+// === EIP-3860 constants ===
+
+// Max contract creation bytecode size
+pub const MAX_INITCODE_SIZE: usize = 2 * MAX_CODE_SIZE;
+
+// === EIP-2028 constants ===
+
+// Gas cost for each non zero byte on transaction data
+pub const TX_DATA_NON_ZERO_GAS_EIP2028: u64 = 16;
+
 // === EIP-4844 constants ===
 
 /// Gas consumption of a single data blob (== blob byte size).
@@ -14,3 +52,6 @@ pub const MAX_BLOB_NUMBER_PER_BLOCK: u64 = 2 * TARGET_BLOB_NUMBER_PER_BLOCK;
 
 /// Maximum consumable blob gas for data blobs per block.
 pub const MAX_BLOB_GAS_PER_BLOCK: u64 = MAX_BLOB_NUMBER_PER_BLOCK * GAS_PER_BLOB;
+
+// Minimum base fee per blob
+pub const MIN_BASE_FEE_PER_BLOB_GAS: u64 = 1;

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -43,8 +43,6 @@ pub enum MempoolError {
     StoreError(#[from] StoreError),
     #[error("Transaction max init code size exceeded")]
     TxMaxInitCodeSizeError,
-    #[error("Transaction value is negative")]
-    TxValueNegativeError,
     #[error("Transaction gas limit exceeded")]
     TxGasLimitExceededError,
     #[error("Transaction priority fee above gas fee")]

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -37,6 +37,20 @@ pub enum InvalidBlockError {
 
 #[derive(Debug, Error)]
 pub enum MempoolError {
+    #[error("No block header")]
+    NoBlockHeaderError,
     #[error("DB error: {0}")]
     StoreError(#[from] StoreError),
+    #[error("Transaction max init code size exceeded")]
+    TxMaxInitCodeSizeError,
+    #[error("Transaction value is negative")]
+    TxValueNegativeError,
+    #[error("Transaction gas limit exceeded")]
+    TxGasLimitExceededError,
+    #[error("Transaction priority fee above gas fee")]
+    TxGasOverflowError,
+    #[error("Transaction intrinsic gas overflow")]
+    TxTipAboveFeeCapError,
+    #[error("Transaction intrinsic gas cost above gas limit")]
+    TxIntrinsicGasCostAboveLimitError,
 }

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -51,4 +51,6 @@ pub enum MempoolError {
     TxTipAboveFeeCapError,
     #[error("Transaction intrinsic gas cost above gas limit")]
     TxIntrinsicGasCostAboveLimitError,
+    #[error("Transaction blob base fee too low")]
+    TxBlobBaseFeeTooLowError,
 }

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -1,10 +1,13 @@
 use crate::error::MempoolError;
-use ethereum_rust_core::{types::Transaction, H256};
+use ethereum_rust_core::{
+    types::{BlockHeader, ChainConfig, Transaction},
+    H256, U256,
+};
 use ethereum_rust_storage::Store;
 
 pub fn add_transaction(transaction: Transaction, store: Store) -> Result<H256, MempoolError> {
     // Validate transaction
-    validate_transaction(&transaction)?;
+    validate_transaction(&transaction, store.clone())?;
 
     let hash = transaction.compute_hash();
 
@@ -17,6 +20,38 @@ pub fn add_transaction(transaction: Transaction, store: Store) -> Result<H256, M
 pub fn get_transaction(hash: H256, store: Store) -> Result<Option<Transaction>, MempoolError> {
     Ok(store.get_transaction_from_pool(hash)?)
 }
+
+// Defined in [EIP-170](https://eips.ethereum.org/EIPS/eip-170)
+pub const MAX_CODE_SIZE: usize = 0x6000;
+// Defined in [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860)
+pub const MAX_INITCODE_SIZE: usize = 2 * MAX_CODE_SIZE;
+
+// Gas cost for each non zero byte on transaction data
+pub const TX_DATA_NON_ZERO_GAS: u64 = 68;
+// Gas cost for each non zero byte on transaction data, modified on [EIP-2028](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2028.md)
+pub const TX_DATA_NON_ZERO_GAS_EIP2028: u64 = 16;
+
+//TODO: THIS ALL SHOULD BE MOVED TO chain/constants
+
+// YELLOW PAPER CONSTANTS
+
+/// Base gas cost for each non contract creating transaction
+pub const TX_GAS_COST: u64 = 21000;
+
+/// Base gas cost for each contract creating transaction
+pub const TX_CREATE_GAS_COST: u64 = 53000;
+
+// Gas cost for each zero byte on transaction data
+pub const TX_DATA_ZERO_GAS_COST: u64 = 4;
+
+// Gas cost for each init code word on transaction data
+pub const TX_INIT_CODE_WORD_GAS_COST: u64 = 2;
+
+// Gas cost for each init code word on transaction data
+pub const TX_ACCESS_LIST_ADDRESS_GAS: u64 = 2400;
+
+// Gas cost for each init code word on transaction data
+pub const TX_ACCESS_LIST_STORAGE_KEY_GAS: u64 = 1900;
 
 /*
 
@@ -60,8 +95,111 @@ Stateful validations
  5. Ensure the transactor is able to add a new transaction. The number of transactions sent by an account may be limited by a certain configured value
 
 */
-fn validate_transaction(_transaction: &Transaction) -> Result<(), MempoolError> {
+
+fn validate_transaction(tx: &Transaction, store: Store) -> Result<(), MempoolError> {
     // TODO: Add validations here
 
+    let header_no = store
+        .get_latest_block_number()?
+        .ok_or(MempoolError::NoBlockHeaderError)?;
+    let header = store
+        .get_block_header(header_no)?
+        .ok_or(MempoolError::NoBlockHeaderError)?;
+    let config = store.get_chain_config()?;
+
+    // NOTE: We could add a tx size limit here, but it's not in the actual spec
+
+    // Check transaction value is positive
+    if tx.value() < U256::zero() {
+        return Err(MempoolError::TxValueNegativeError);
+    }
+
+    // Check init code size
+    if config.is_shanghai_activated(header.timestamp)
+        && tx.is_contract_creation()
+        && tx.data().len() > MAX_INITCODE_SIZE
+    {
+        return Err(MempoolError::TxMaxInitCodeSizeError);
+    }
+
+    // Check gas limit is less than header's gas limit
+    if header.gas_limit < tx.gas_limit() {
+        return Err(MempoolError::TxGasLimitExceededError);
+    }
+
+    // Check priority fee is less or equal than gas fee gap
+    if tx.max_priority_fee().unwrap_or(0) > tx.max_fee_per_gas().unwrap_or(0) {
+        return Err(MempoolError::TxTipAboveFeeCapError);
+    }
+
+    // Check that the gas limit is covers the gas needs for transaction metadata.
+    let intrinsic = transaction_intrinsic_gas(tx, &header, &config)?;
+    let gas_limit = tx.gas_limit();
+    if gas_limit < intrinsic {
+        println!("Gas limit is {gas_limit} and intrinsic consumption is {intrinsic}");
+        return Err(MempoolError::TxIntrinsicGasCostAboveLimitError);
+    }
+
     Ok(())
+}
+
+fn transaction_intrinsic_gas(
+    tx: &Transaction,
+    header: &BlockHeader,
+    config: &ChainConfig,
+) -> Result<u64, MempoolError> {
+    let is_contract_creation = tx.is_contract_creation();
+
+    let mut gas = if is_contract_creation {
+        TX_CREATE_GAS_COST
+    } else {
+        TX_GAS_COST
+    };
+
+    let data_len = tx.data().len() as u64;
+
+    if data_len > 0 {
+        let non_zero_gas_cost = if config.is_istanbul_activated(header.number) {
+            TX_DATA_NON_ZERO_GAS_EIP2028
+        } else {
+            TX_DATA_NON_ZERO_GAS
+        };
+
+        let non_zero_count = tx.data().iter().filter(|&&x| x != 0u8).count() as u64;
+
+        gas = gas
+            .checked_add(non_zero_count * non_zero_gas_cost)
+            .ok_or(MempoolError::TxGasOverflowError)?;
+
+        let zero_count = data_len - non_zero_count;
+
+        gas = gas
+            .checked_add(zero_count * TX_DATA_ZERO_GAS_COST)
+            .ok_or(MempoolError::TxGasOverflowError)?;
+
+        if is_contract_creation && config.is_shanghai_activated(header.timestamp) {
+            // Len in 32 bytes sized words
+            let len_in_words = data_len.saturating_add(31) / 32;
+
+            gas = gas
+                .checked_add(len_in_words * TX_INIT_CODE_WORD_GAS_COST)
+                .ok_or(MempoolError::TxGasOverflowError)?;
+        }
+    }
+
+    let storage_keys_count: u64 = tx
+        .access_list()
+        .iter()
+        .map(|(_, keys)| keys.len() as u64)
+        .sum();
+
+    gas = gas
+        .checked_add(tx.access_list().len() as u64 * TX_ACCESS_LIST_ADDRESS_GAS)
+        .ok_or(MempoolError::TxGasOverflowError)?;
+
+    gas = gas
+        .checked_add(storage_keys_count * TX_ACCESS_LIST_STORAGE_KEY_GAS)
+        .ok_or(MempoolError::TxGasOverflowError)?;
+
+    Ok(gas)
 }

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -109,11 +109,6 @@ fn validate_transaction(tx: &Transaction, store: Store) -> Result<(), MempoolErr
 
     // NOTE: We could add a tx size limit here, but it's not in the actual spec
 
-    // Check transaction value is positive
-    if tx.value() < U256::zero() {
-        return Err(MempoolError::TxValueNegativeError);
-    }
-
     // Check init code size
     if config.is_shanghai_activated(header.timestamp)
         && tx.is_contract_creation()
@@ -133,10 +128,7 @@ fn validate_transaction(tx: &Transaction, store: Store) -> Result<(), MempoolErr
     }
 
     // Check that the gas limit is covers the gas needs for transaction metadata.
-    let intrinsic = transaction_intrinsic_gas(tx, &header, &config)?;
-    let gas_limit = tx.gas_limit();
-    if gas_limit < intrinsic {
-        println!("Gas limit is {gas_limit} and intrinsic consumption is {intrinsic}");
+    if tx.gas_limit() < transaction_intrinsic_gas(tx, &header, &config)? {
         return Err(MempoolError::TxIntrinsicGasCostAboveLimitError);
     }
 

--- a/crates/core/types/genesis.rs
+++ b/crates/core/types/genesis.rs
@@ -9,7 +9,7 @@ use crate::rlp::encode::RLPEncode;
 
 use super::{
     code_hash, compute_receipts_root, compute_transactions_root, compute_withdrawals_root,
-    AccountInfo, AccountState, Block, BlockBody, BlockHeader, DEFAULT_OMMERS_HASH,
+    AccountInfo, AccountState, Block, BlockBody, BlockHeader, BlockNumber, DEFAULT_OMMERS_HASH,
     INITIAL_BASE_FEE,
 };
 
@@ -104,6 +104,10 @@ impl ChainConfig {
     pub fn is_cancun_activated(&self, block_timestamp: u64) -> bool {
         self.cancun_time
             .map_or(false, |time| time <= block_timestamp)
+    }
+
+    pub fn is_istanbul_activated(&self, block_number: BlockNumber) -> bool {
+        self.istanbul_block.map_or(false, |num| num <= block_number)
     }
 
     pub fn get_fork(&self, block_timestamp: u64) -> ForkId {

--- a/crates/core/types/transaction.rs
+++ b/crates/core/types/transaction.rs
@@ -22,7 +22,7 @@ pub enum Transaction {
     EIP4844Transaction(EIP4844Transaction),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct LegacyTransaction {
     pub nonce: u64,
     pub gas_price: u64,
@@ -37,7 +37,7 @@ pub struct LegacyTransaction {
     pub s: U256,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct EIP2930Transaction {
     pub chain_id: u64,
     pub nonce: u64,
@@ -52,7 +52,7 @@ pub struct EIP2930Transaction {
     pub signature_s: U256,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct EIP1559Transaction {
     pub chain_id: u64,
     pub nonce: u64,
@@ -157,9 +157,10 @@ impl RLPDecode for Transaction {
 }
 
 /// The transaction's kind: call or create.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub enum TxKind {
     Call(Address),
+    #[default]
     Create,
 }
 

--- a/crates/core/types/transaction.rs
+++ b/crates/core/types/transaction.rs
@@ -585,6 +585,24 @@ impl Transaction {
         }
     }
 
+    pub fn is_contract_creation(&self) -> bool {
+        match &self {
+            Transaction::LegacyTransaction(t) => matches!(t.to, TxKind::Create),
+            Transaction::EIP2930Transaction(t) => matches!(t.to, TxKind::Create),
+            Transaction::EIP1559Transaction(t) => matches!(t.to, TxKind::Create),
+            Transaction::EIP4844Transaction(_) => false,
+        }
+    }
+
+    pub fn max_fee_per_gas(&self) -> Option<u64> {
+        match self {
+            Transaction::LegacyTransaction(_tx) => None,
+            Transaction::EIP2930Transaction(_tx) => None,
+            Transaction::EIP1559Transaction(tx) => Some(tx.max_fee_per_gas),
+            Transaction::EIP4844Transaction(tx) => Some(tx.max_fee_per_gas),
+        }
+    }
+
     pub fn compute_hash(&self) -> H256 {
         keccak_hash::keccak(self.encode_canonical_to_vec())
     }

--- a/crates/core/types/transaction.rs
+++ b/crates/core/types/transaction.rs
@@ -68,7 +68,7 @@ pub struct EIP1559Transaction {
     pub signature_s: U256,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct EIP4844Transaction {
     pub chain_id: u64,
     pub nonce: u64,


### PR DESCRIPTION
**Motivation**

When a new transaction is going to be added to the mempool, first we need to run some very basic validations so we can easily discard those that would fail later on.

**Description**

This PR adds some transaction validations to the mempool, together with unit tests to ensure their correct behaviour.