### PR TITLE
feat: remove `Mutex` from `Store`

### DIFF
--- a/cmd/ef_tests/test_runner.rs
+++ b/cmd/ef_tests/test_runner.rs
@@ -79,7 +79,7 @@ pub fn parse_test_file(path: &Path) -> HashMap<String, TestUnit> {
 
 /// Creats a new in-memory store and adds the genesis state
 pub fn build_store_for_test(test: &TestUnit) -> Store {
-    let mut store =
+    let store =
         Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
     let genesis = test.get_genesis();
     store

--- a/cmd/ethereum_rust/ethereum_rust.rs
+++ b/cmd/ethereum_rust/ethereum_rust.rs
@@ -80,7 +80,7 @@ async fn main() {
     let tcp_socket_addr =
         parse_socket_addr(tcp_addr, tcp_port).expect("Failed to parse addr and port");
 
-    let mut store = match matches.get_one::<String>("datadir") {
+    let store = match matches.get_one::<String>("datadir") {
         Some(data_dir) if !data_dir.is_empty() => Store::new(data_dir, EngineType::Libmdbx),
         _ => Store::new("storage.db", EngineType::InMemory),
     }

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -300,7 +300,7 @@ mod tests {
         let body = r#"{"jsonrpc":"2.0","id":1,"method":"eth_createAccessList","params":[{"from":"0x0c2c51a0990aee1d73c1228de158688341557508","nonce":"0x0","to":"0x0100000000000000000000000000000000000000","value":"0xa"},"0x00"]}"#;
         let request: RpcRequest = serde_json::from_str(body).unwrap();
         // Setup initial storage
-        let mut storage =
+        let storage =
             Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
         let genesis = read_execution_api_genesis_file();
         storage
@@ -323,7 +323,7 @@ mod tests {
         let body = r#"{"jsonrpc":"2.0","id":1,"method":"eth_createAccessList","params":[{"from":"0x0c2c51a0990aee1d73c1228de158688341557508","gas":"0xea60","gasPrice":"0x44103f2","input":"0x010203040506","nonce":"0x0","to":"0x7dcd17433742f4c0ca53122ab541d0ba67fc27df"},"0x00"]}"#;
         let request: RpcRequest = serde_json::from_str(body).unwrap();
         // Setup initial storage
-        let mut storage =
+        let storage =
             Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
         let genesis = read_execution_api_genesis_file();
         storage

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -3,14 +3,14 @@ use ethereum_rust_core::types::{
     Block, BlockBody, BlockHash, BlockHeader, BlockNumber, ChainConfig, Index, Receipt, Transaction,
 };
 use ethereum_types::{Address, H256};
-use std::fmt::Debug;
+use std::{fmt::Debug, panic::RefUnwindSafe};
 
 use crate::{error::StoreError, trie::Trie};
 
-pub trait StoreEngine: Debug + Send {
+pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     /// Add block header
     fn add_block_header(
-        &mut self,
+        &self,
         block_hash: BlockHash,
         block_header: BlockHeader,
     ) -> Result<(), StoreError>;
@@ -23,7 +23,7 @@ pub trait StoreEngine: Debug + Send {
 
     /// Add block body
     fn add_block_body(
-        &mut self,
+        &self,
         block_hash: BlockHash,
         block_body: BlockBody,
     ) -> Result<(), StoreError>;
@@ -44,7 +44,7 @@ pub trait StoreEngine: Debug + Send {
 
     /// Add block number for a given hash
     fn add_block_number(
-        &mut self,
+        &self,
         block_hash: BlockHash,
         block_number: BlockNumber,
     ) -> Result<(), StoreError>;
@@ -54,7 +54,7 @@ pub trait StoreEngine: Debug + Send {
 
     /// Store transaction location (block number and index of the transaction within the block)
     fn add_transaction_location(
-        &mut self,
+        &self,
         transaction_hash: H256,
         block_number: BlockNumber,
         block_hash: BlockHash,
@@ -69,7 +69,7 @@ pub trait StoreEngine: Debug + Send {
 
     /// Store transaction into pool table
     fn add_transaction_to_pool(
-        &mut self,
+        &self,
         hash: H256,
         transaction: Transaction,
     ) -> Result<(), StoreError>;
@@ -79,7 +79,7 @@ pub trait StoreEngine: Debug + Send {
 
     /// Add receipt
     fn add_receipt(
-        &mut self,
+        &self,
         block_hash: BlockHash,
         index: Index,
         receipt: Receipt,
@@ -93,7 +93,7 @@ pub trait StoreEngine: Debug + Send {
     ) -> Result<Option<Receipt>, StoreError>;
 
     /// Add account code
-    fn add_account_code(&mut self, code_hash: H256, code: Bytes) -> Result<(), StoreError>;
+    fn add_account_code(&self, code_hash: H256, code: Bytes) -> Result<(), StoreError>;
 
     /// Obtain account code via code hash
     fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, StoreError>;
@@ -139,41 +139,37 @@ pub trait StoreEngine: Debug + Send {
 
     /// Stores the chain configuration values, should only be called once after reading the genesis file
     /// Ignores previously stored values if present
-    fn set_chain_config(&mut self, chain_config: &ChainConfig) -> Result<(), StoreError>;
+    fn set_chain_config(&self, chain_config: &ChainConfig) -> Result<(), StoreError>;
 
     /// Returns the stored chain configuration
     fn get_chain_config(&self) -> Result<ChainConfig, StoreError>;
 
     // Update earliest block number
-    fn update_earliest_block_number(&mut self, block_number: BlockNumber)
-        -> Result<(), StoreError>;
+    fn update_earliest_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError>;
 
     // Obtain earliest block number
     fn get_earliest_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
 
     // Update finalized block number
-    fn update_finalized_block_number(
-        &mut self,
-        block_number: BlockNumber,
-    ) -> Result<(), StoreError>;
+    fn update_finalized_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError>;
 
     // Obtain finalized block number
     fn get_finalized_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
 
     // Update safe block number
-    fn update_safe_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError>;
+    fn update_safe_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError>;
 
     // Obtain safe block number
     fn get_safe_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
 
     // Update latest block number
-    fn update_latest_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError>;
+    fn update_latest_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError>;
 
     // Obtain latest block number
     fn get_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
 
     // Update pending block number
-    fn update_pending_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError>;
+    fn update_pending_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError>;
 
     // Obtain pending block number
     fn get_pending_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
@@ -188,12 +184,8 @@ pub trait StoreEngine: Debug + Send {
     // Obtain a storage trie from the given address and storage_root
     // Doesn't check if the account is stored
     // Used for internal store operations
-    fn open_storage_trie(&mut self, address: Address, storage_root: H256) -> Trie;
+    fn open_storage_trie(&self, address: Address, storage_root: H256) -> Trie;
 
     // Get the canonical block hash for a given block number.
-    fn set_canonical_block(
-        &mut self,
-        number: BlockNumber,
-        hash: BlockHash,
-    ) -> Result<(), StoreError>;
+    fn set_canonical_block(&self, number: BlockNumber, hash: BlockHash) -> Result<(), StoreError>;
 }

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -78,11 +78,7 @@ impl StoreEngine for Store {
         block_hash: BlockHash,
         block_header: BlockHeader,
     ) -> Result<(), StoreError> {
-        self.0
-            .lock()
-            .unwrap()
-            .headers
-            .insert(block_hash, block_header);
+        self.inner().headers.insert(block_hash, block_header);
         Ok(())
     }
 
@@ -100,22 +96,12 @@ impl StoreEngine for Store {
         block_hash: BlockHash,
         block_number: BlockNumber,
     ) -> Result<(), StoreError> {
-        self.0
-            .lock()
-            .unwrap()
-            .block_numbers
-            .insert(block_hash, block_number);
+        self.inner().block_numbers.insert(block_hash, block_number);
         Ok(())
     }
 
     fn get_block_number(&self, block_hash: BlockHash) -> Result<Option<BlockNumber>, StoreError> {
-        Ok(self
-            .0
-            .lock()
-            .unwrap()
-            .block_numbers
-            .get(&block_hash)
-            .copied())
+        Ok(self.inner().block_numbers.get(&block_hash).copied())
     }
 
     fn add_transaction_location(
@@ -125,9 +111,7 @@ impl StoreEngine for Store {
         block_hash: BlockHash,
         index: Index,
     ) -> Result<(), StoreError> {
-        self.0
-            .lock()
-            .unwrap()
+        self.inner()
             .transaction_locations
             .entry(transaction_hash)
             .or_default()
@@ -155,11 +139,7 @@ impl StoreEngine for Store {
         hash: H256,
         transaction: Transaction,
     ) -> Result<(), StoreError> {
-        self.0
-            .lock()
-            .unwrap()
-            .transaction_pool
-            .insert(hash, transaction);
+        self.inner().transaction_pool.insert(hash, transaction);
         Ok(())
     }
 
@@ -202,13 +182,7 @@ impl StoreEngine for Store {
     }
 
     fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, StoreError> {
-        Ok(self
-            .0
-            .lock()
-            .unwrap()
-            .account_codes
-            .get(&code_hash)
-            .cloned())
+        Ok(self.inner().account_codes.get(&code_hash).cloned())
     }
 
     fn set_chain_config(&self, chain_config: &ChainConfig) -> Result<(), StoreError> {
@@ -222,9 +196,7 @@ impl StoreEngine for Store {
     }
 
     fn update_earliest_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
-        self.0
-            .lock()
-            .unwrap()
+        self.inner()
             .chain_data
             .earliest_block_number
             .replace(block_number);
@@ -236,9 +208,7 @@ impl StoreEngine for Store {
     }
 
     fn update_finalized_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
-        self.0
-            .lock()
-            .unwrap()
+        self.inner()
             .chain_data
             .finalized_block_number
             .replace(block_number);
@@ -250,9 +220,7 @@ impl StoreEngine for Store {
     }
 
     fn update_safe_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
-        self.0
-            .lock()
-            .unwrap()
+        self.inner()
             .chain_data
             .safe_block_number
             .replace(block_number);
@@ -264,9 +232,7 @@ impl StoreEngine for Store {
     }
 
     fn update_latest_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
-        self.0
-            .lock()
-            .unwrap()
+        self.inner()
             .chain_data
             .latest_block_number
             .replace(block_number);
@@ -278,9 +244,7 @@ impl StoreEngine for Store {
     }
 
     fn update_pending_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
-        self.0
-            .lock()
-            .unwrap()
+        self.inner()
             .chain_data
             .pending_block_number
             .replace(block_number);

--- a/crates/storage/engines/libmdbx.rs
+++ b/crates/storage/engines/libmdbx.rs
@@ -66,7 +66,7 @@ impl Store {
 
 impl StoreEngine for Store {
     fn add_block_header(
-        &mut self,
+        &self,
         block_hash: BlockHash,
         block_header: BlockHeader,
     ) -> std::result::Result<(), StoreError> {
@@ -85,7 +85,7 @@ impl StoreEngine for Store {
     }
 
     fn add_block_body(
-        &mut self,
+        &self,
         block_hash: BlockHash,
         block_body: BlockBody,
     ) -> std::result::Result<(), StoreError> {
@@ -118,7 +118,7 @@ impl StoreEngine for Store {
     }
 
     fn add_block_number(
-        &mut self,
+        &self,
         block_hash: BlockHash,
         block_number: BlockNumber,
     ) -> std::result::Result<(), StoreError> {
@@ -132,7 +132,7 @@ impl StoreEngine for Store {
         self.read::<BlockNumbers>(block_hash.into())
     }
 
-    fn add_account_code(&mut self, code_hash: H256, code: Bytes) -> Result<(), StoreError> {
+    fn add_account_code(&self, code_hash: H256, code: Bytes) -> Result<(), StoreError> {
         self.write::<AccountCodes>(code_hash.into(), code.into())
     }
 
@@ -141,7 +141,7 @@ impl StoreEngine for Store {
     }
 
     fn add_receipt(
-        &mut self,
+        &self,
         block_hash: BlockHash,
         index: Index,
         receipt: Receipt,
@@ -162,7 +162,7 @@ impl StoreEngine for Store {
     }
 
     fn add_transaction_location(
-        &mut self,
+        &self,
         transaction_hash: H256,
         block_number: BlockNumber,
         block_hash: BlockHash,
@@ -192,7 +192,7 @@ impl StoreEngine for Store {
     }
 
     fn add_transaction_to_pool(
-        &mut self,
+        &self,
         hash: H256,
         transaction: Transaction,
     ) -> Result<(), StoreError> {
@@ -205,7 +205,7 @@ impl StoreEngine for Store {
     }
 
     /// Stores the chain config serialized as json
-    fn set_chain_config(&mut self, chain_config: &ChainConfig) -> Result<(), StoreError> {
+    fn set_chain_config(&self, chain_config: &ChainConfig) -> Result<(), StoreError> {
         self.write::<ChainData>(
             ChainDataIndex::ChainConfig,
             serde_json::to_string(chain_config)
@@ -226,10 +226,7 @@ impl StoreEngine for Store {
         }
     }
 
-    fn update_earliest_block_number(
-        &mut self,
-        block_number: BlockNumber,
-    ) -> Result<(), StoreError> {
+    fn update_earliest_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
         self.write::<ChainData>(
             ChainDataIndex::EarliestBlockNumber,
             block_number.encode_to_vec(),
@@ -245,10 +242,7 @@ impl StoreEngine for Store {
         }
     }
 
-    fn update_finalized_block_number(
-        &mut self,
-        block_number: BlockNumber,
-    ) -> Result<(), StoreError> {
+    fn update_finalized_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
         self.write::<ChainData>(
             ChainDataIndex::FinalizedBlockNumber,
             block_number.encode_to_vec(),
@@ -264,7 +258,7 @@ impl StoreEngine for Store {
         }
     }
 
-    fn update_safe_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
+    fn update_safe_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
         self.write::<ChainData>(
             ChainDataIndex::SafeBlockNumber,
             block_number.encode_to_vec(),
@@ -280,7 +274,7 @@ impl StoreEngine for Store {
         }
     }
 
-    fn update_latest_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
+    fn update_latest_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
         self.write::<ChainData>(
             ChainDataIndex::LatestBlockNumber,
             block_number.encode_to_vec(),
@@ -296,7 +290,7 @@ impl StoreEngine for Store {
         }
     }
 
-    fn update_pending_block_number(&mut self, block_number: BlockNumber) -> Result<(), StoreError> {
+    fn update_pending_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
         self.write::<ChainData>(
             ChainDataIndex::PendingBlockNumber,
             block_number.encode_to_vec(),
@@ -331,7 +325,7 @@ impl StoreEngine for Store {
         Ok(trie)
     }
 
-    fn open_storage_trie(&mut self, address: Address, storage_root: H256) -> Trie {
+    fn open_storage_trie(&self, address: Address, storage_root: H256) -> Trie {
         let db = Box::new(crate::trie::LibmdbxDupsortTrieDB::<
             StorageTriesNodes,
             [u8; 20],
@@ -339,11 +333,7 @@ impl StoreEngine for Store {
         Trie::open(db, storage_root)
     }
 
-    fn set_canonical_block(
-        &mut self,
-        number: BlockNumber,
-        hash: BlockHash,
-    ) -> Result<(), StoreError> {
+    fn set_canonical_block(&self, number: BlockNumber, hash: BlockHash) -> Result<(), StoreError> {
         self.write::<CanonicalBlockHashes>(number, hash.into())
     }
 }

--- a/crates/storage/storage.rs
+++ b/crates/storage/storage.rs
@@ -16,7 +16,7 @@ use ethereum_types::{Address, H256, U256};
 use sha3::{Digest as _, Keccak256};
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tracing::info;
 use trie::Trie;
 
@@ -28,7 +28,7 @@ mod trie;
 #[derive(Debug, Clone)]
 pub struct Store {
     // TODO: Check if we can remove this mutex and move it to the in_memory::Store struct
-    engine: Arc<Mutex<dyn StoreEngine>>,
+    engine: Arc<dyn StoreEngine>,
 }
 
 #[allow(dead_code)]
@@ -76,11 +76,11 @@ impl Store {
         let store = match engine_type {
             #[cfg(feature = "libmdbx")]
             EngineType::Libmdbx => Self {
-                engine: Arc::new(Mutex::new(LibmdbxStore::new(path)?)),
+                engine: Arc::new(LibmdbxStore::new(path)?),
             },
             #[cfg(feature = "in_memory")]
             EngineType::InMemory => Self {
-                engine: Arc::new(Mutex::new(InMemoryStore::new()?)),
+                engine: Arc::new(InMemoryStore::new()),
             },
         };
         info!("Started store engine");
@@ -92,7 +92,7 @@ impl Store {
         block_number: BlockNumber,
         address: Address,
     ) -> Result<Option<AccountInfo>, StoreError> {
-        let Some(state_trie) = self.engine.lock().unwrap().state_trie(block_number)? else {
+        let Some(state_trie) = self.engine.state_trie(block_number)? else {
             return Ok(None);
         };
         let hashed_address = hash_address(&address);
@@ -114,8 +114,6 @@ impl Store {
     ) -> Result<(), StoreError> {
         self.engine
             .clone()
-            .lock()
-            .unwrap()
             .add_block_header(block_hash, block_header)
     }
 
@@ -123,11 +121,7 @@ impl Store {
         &self,
         block_number: BlockNumber,
     ) -> Result<Option<BlockHeader>, StoreError> {
-        self.engine
-            .clone()
-            .lock()
-            .unwrap()
-            .get_block_header(block_number)
+        self.engine.clone().get_block_header(block_number)
     }
 
     pub fn add_block_body(
@@ -135,22 +129,14 @@ impl Store {
         block_hash: BlockHash,
         block_body: BlockBody,
     ) -> Result<(), StoreError> {
-        self.engine
-            .clone()
-            .lock()
-            .unwrap()
-            .add_block_body(block_hash, block_body)
+        self.engine.clone().add_block_body(block_hash, block_body)
     }
 
     pub fn get_block_body(
         &self,
         block_number: BlockNumber,
     ) -> Result<Option<BlockBody>, StoreError> {
-        self.engine
-            .clone()
-            .lock()
-            .unwrap()
-            .get_block_body(block_number)
+        self.engine.clone().get_block_body(block_number)
     }
 
     pub fn add_block_number(
@@ -160,8 +146,6 @@ impl Store {
     ) -> Result<(), StoreError> {
         self.engine
             .clone()
-            .lock()
-            .unwrap()
             .add_block_number(block_hash, block_number)
     }
 
@@ -169,11 +153,7 @@ impl Store {
         &self,
         block_hash: BlockHash,
     ) -> Result<Option<BlockNumber>, StoreError> {
-        self.engine
-            .clone()
-            .lock()
-            .unwrap()
-            .get_block_number(block_hash)
+        self.engine.clone().get_block_number(block_hash)
     }
 
     pub fn add_transaction_location(
@@ -183,22 +163,15 @@ impl Store {
         block_hash: BlockHash,
         index: Index,
     ) -> Result<(), StoreError> {
-        self.engine.lock().unwrap().add_transaction_location(
-            transaction_hash,
-            block_number,
-            block_hash,
-            index,
-        )
+        self.engine
+            .add_transaction_location(transaction_hash, block_number, block_hash, index)
     }
 
     pub fn get_transaction_location(
         &self,
         transaction_hash: H256,
     ) -> Result<Option<(BlockNumber, BlockHash, Index)>, StoreError> {
-        self.engine
-            .lock()
-            .unwrap()
-            .get_transaction_location(transaction_hash)
+        self.engine.get_transaction_location(transaction_hash)
     }
 
     pub fn add_transaction_to_pool(
@@ -206,30 +179,19 @@ impl Store {
         hash: H256,
         transaction: Transaction,
     ) -> Result<(), StoreError> {
-        self.engine
-            .lock()
-            .unwrap()
-            .add_transaction_to_pool(hash, transaction)
+        self.engine.add_transaction_to_pool(hash, transaction)
     }
 
     pub fn get_transaction_from_pool(&self, hash: H256) -> Result<Option<Transaction>, StoreError> {
-        self.engine.lock().unwrap().get_transaction_from_pool(hash)
+        self.engine.get_transaction_from_pool(hash)
     }
 
     fn add_account_code(&self, code_hash: H256, code: Bytes) -> Result<(), StoreError> {
-        self.engine
-            .clone()
-            .lock()
-            .unwrap()
-            .add_account_code(code_hash, code)
+        self.engine.clone().add_account_code(code_hash, code)
     }
 
     pub fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, StoreError> {
-        self.engine
-            .clone()
-            .lock()
-            .unwrap()
-            .get_account_code(code_hash)
+        self.engine.clone().get_account_code(code_hash)
     }
 
     pub fn get_code_by_account_address(
@@ -237,7 +199,7 @@ impl Store {
         block_number: BlockNumber,
         address: Address,
     ) -> Result<Option<Bytes>, StoreError> {
-        let Some(state_trie) = self.engine.lock().unwrap().state_trie(block_number)? else {
+        let Some(state_trie) = self.engine.state_trie(block_number)? else {
             return Ok(None);
         };
         let hashed_address = hash_address(&address);
@@ -252,7 +214,7 @@ impl Store {
         block_number: BlockNumber,
         address: Address,
     ) -> Result<Option<u64>, StoreError> {
-        let Some(state_trie) = self.engine.lock().unwrap().state_trie(block_number)? else {
+        let Some(state_trie) = self.engine.state_trie(block_number)? else {
             return Ok(None);
         };
         let hashed_address = hash_address(&address);
@@ -270,7 +232,7 @@ impl Store {
         block_number: BlockNumber,
         account_updates: &[AccountUpdate],
     ) -> Result<Option<H256>, StoreError> {
-        let Some(mut state_trie) = self.engine.lock().unwrap().state_trie(block_number)? else {
+        let Some(mut state_trie) = self.engine.state_trie(block_number)? else {
             return Ok(None);
         };
         for update in account_updates.iter() {
@@ -298,8 +260,6 @@ impl Store {
                 if !update.added_storage.is_empty() {
                     let mut storage_trie = self
                         .engine
-                        .lock()
-                        .unwrap()
                         .open_storage_trie(update.address, account_state.storage_root);
                     for (storage_key, storage_value) in &update.added_storage {
                         let hashed_key = hash_key(storage_key);
@@ -322,17 +282,13 @@ impl Store {
         &self,
         genesis_accounts: HashMap<Address, GenesisAccount>,
     ) -> Result<H256, StoreError> {
-        let mut genesis_state_trie = self.engine.lock().unwrap().new_state_trie()?;
+        let mut genesis_state_trie = self.engine.new_state_trie()?;
         for (address, account) in genesis_accounts {
             // Store account code (as this won't be stored in the trie)
             let code_hash = code_hash(&account.code);
             self.add_account_code(code_hash, account.code)?;
             // Store the account's storage in a clean storage trie and compute its root
-            let mut storage_trie = self
-                .engine
-                .lock()
-                .unwrap()
-                .open_storage_trie(address, *EMPTY_TRIE_HASH);
+            let mut storage_trie = self.engine.open_storage_trie(address, *EMPTY_TRIE_HASH);
             for (storage_key, storage_value) in account.storage {
                 if !storage_value.is_zero() {
                     let hashed_key = hash_key(&storage_key);
@@ -359,11 +315,7 @@ impl Store {
         index: Index,
         receipt: Receipt,
     ) -> Result<(), StoreError> {
-        self.engine
-            .clone()
-            .lock()
-            .unwrap()
-            .add_receipt(block_hash, index, receipt)
+        self.engine.clone().add_receipt(block_hash, index, receipt)
     }
 
     pub fn get_receipt(
@@ -371,11 +323,7 @@ impl Store {
         block_number: BlockNumber,
         index: Index,
     ) -> Result<Option<Receipt>, StoreError> {
-        self.engine
-            .clone()
-            .lock()
-            .unwrap()
-            .get_receipt(block_number, index)
+        self.engine.clone().get_receipt(block_number, index)
     }
 
     pub fn add_block(&self, block: Block) -> Result<(), StoreError> {
@@ -407,7 +355,7 @@ impl Store {
         Ok(())
     }
 
-    pub fn add_initial_state(&mut self, genesis: Genesis) -> Result<(), StoreError> {
+    pub fn add_initial_state(&self, genesis: Genesis) -> Result<(), StoreError> {
         info!("Storing initial state from genesis");
 
         // Obtain genesis block
@@ -442,10 +390,7 @@ impl Store {
         &self,
         transaction_hash: H256,
     ) -> Result<Option<Transaction>, StoreError> {
-        self.engine
-            .lock()
-            .unwrap()
-            .get_transaction_by_hash(transaction_hash)
+        self.engine.get_transaction_by_hash(transaction_hash)
     }
 
     pub fn get_transaction_by_location(
@@ -453,14 +398,11 @@ impl Store {
         block_hash: BlockHash,
         index: u64,
     ) -> Result<Option<Transaction>, StoreError> {
-        self.engine
-            .lock()
-            .unwrap()
-            .get_transaction_by_location(block_hash, index)
+        self.engine.get_transaction_by_location(block_hash, index)
     }
 
     pub fn get_block_by_hash(&self, block_hash: H256) -> Result<Option<Block>, StoreError> {
-        self.engine.lock().unwrap().get_block_by_hash(block_hash)
+        self.engine.get_block_by_hash(block_hash)
     }
 
     pub fn get_storage_at(
@@ -480,82 +422,64 @@ impl Store {
     }
 
     pub fn set_chain_config(&self, chain_config: &ChainConfig) -> Result<(), StoreError> {
-        self.engine.lock().unwrap().set_chain_config(chain_config)
+        self.engine.set_chain_config(chain_config)
     }
 
     pub fn get_chain_config(&self) -> Result<ChainConfig, StoreError> {
-        self.engine.lock().unwrap().get_chain_config()
+        self.engine.get_chain_config()
     }
 
     pub fn update_earliest_block_number(
         &self,
         block_number: BlockNumber,
     ) -> Result<(), StoreError> {
-        self.engine
-            .lock()
-            .unwrap()
-            .update_earliest_block_number(block_number)
+        self.engine.update_earliest_block_number(block_number)
     }
 
     pub fn get_earliest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        self.engine.lock().unwrap().get_earliest_block_number()
+        self.engine.get_earliest_block_number()
     }
 
     pub fn update_finalized_block_number(
         &self,
         block_number: BlockNumber,
     ) -> Result<(), StoreError> {
-        self.engine
-            .lock()
-            .unwrap()
-            .update_finalized_block_number(block_number)
+        self.engine.update_finalized_block_number(block_number)
     }
 
     pub fn get_finalized_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        self.engine.lock().unwrap().get_finalized_block_number()
+        self.engine.get_finalized_block_number()
     }
 
     pub fn update_safe_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
-        self.engine
-            .lock()
-            .unwrap()
-            .update_safe_block_number(block_number)
+        self.engine.update_safe_block_number(block_number)
     }
 
     pub fn get_safe_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        self.engine.lock().unwrap().get_safe_block_number()
+        self.engine.get_safe_block_number()
     }
 
     pub fn update_latest_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
-        self.engine
-            .lock()
-            .unwrap()
-            .update_latest_block_number(block_number)
+        self.engine.update_latest_block_number(block_number)
     }
 
     pub fn get_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        self.engine.lock().unwrap().get_latest_block_number()
+        self.engine.get_latest_block_number()
     }
 
     pub fn update_pending_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError> {
-        self.engine
-            .lock()
-            .unwrap()
-            .update_pending_block_number(block_number)
+        self.engine.update_pending_block_number(block_number)
     }
 
     pub fn get_pending_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        self.engine.lock().unwrap().get_pending_block_number()
+        self.engine.get_pending_block_number()
     }
     pub fn set_canonical_block(
         &self,
         number: BlockNumber,
         hash: BlockHash,
     ) -> Result<(), StoreError> {
-        self.engine
-            .lock()
-            .unwrap()
-            .set_canonical_block(number, hash)
+        self.engine.set_canonical_block(number, hash)
     }
 
     // Obtain the storage trie for the given account on the given block
@@ -565,7 +489,7 @@ impl Store {
         address: Address,
     ) -> Result<Option<Trie>, StoreError> {
         // Fetch Account from state_trie
-        let Some(state_trie) = self.engine.lock().unwrap().state_trie(block_number)? else {
+        let Some(state_trie) = self.engine.state_trie(block_number)? else {
             return Ok(None);
         };
         let hashed_address = hash_address(&address);
@@ -575,12 +499,7 @@ impl Store {
         let account = AccountState::decode(&encoded_account)?;
         // Open storage_trie
         let storage_root = account.storage_root;
-        Ok(Some(
-            self.engine
-                .lock()
-                .unwrap()
-                .open_storage_trie(address, storage_root),
-        ))
+        Ok(Some(self.engine.open_storage_trie(address, storage_root)))
     }
 
     pub fn get_account_state(
@@ -588,7 +507,7 @@ impl Store {
         block_number: BlockNumber,
         address: Address,
     ) -> Result<Option<AccountState>, StoreError> {
-        let Some(state_trie) = self.engine.lock().unwrap().state_trie(block_number)? else {
+        let Some(state_trie) = self.engine.state_trie(block_number)? else {
             return Ok(None);
         };
         let hashed_address = hash_address(&address);
@@ -603,7 +522,7 @@ impl Store {
         block_number: BlockNumber,
         address: &Address,
     ) -> Result<Option<Vec<Vec<u8>>>, StoreError> {
-        let Some(state_trie) = self.engine.lock().unwrap().state_trie(block_number)? else {
+        let Some(state_trie) = self.engine.state_trie(block_number)? else {
             return Ok(None);
         };
         Some(state_trie.get_proof(&hash_address(address))).transpose()
@@ -616,11 +535,7 @@ impl Store {
         storage_root: H256,
         storage_key: &H256,
     ) -> Result<Vec<Vec<u8>>, StoreError> {
-        let trie = self
-            .engine
-            .lock()
-            .unwrap()
-            .open_storage_trie(address, storage_root);
+        let trie = self.engine.open_storage_trie(address, storage_root);
         trie.get_proof(&hash_key(storage_key))
     }
 }
@@ -691,7 +606,7 @@ mod tests {
         run_test(&test_genesis_block, engine_type);
     }
 
-    fn test_genesis_block(mut store: Store) {
+    fn test_genesis_block(store: Store) {
         const GENESIS_KURTOSIS: &str = include_str!("../../test_data/genesis-kurtosis.json");
         const GENESIS_HIVE: &str = include_str!("../../test_data/genesis-hive.json");
         assert_ne!(GENESIS_KURTOSIS, GENESIS_HIVE);


### PR DESCRIPTION
**Motivation**
Currently, our Store contains an `Arc<Mutex<dyn StoreEngine>>`, but the mutex is not really needed for the libmbdx backend, it is only needed for the InMemory one. This means we should be able to move the mutex into the in memory engine and leave the libmdbx mutex-free.
This PR proposes moving this mutex into the InMemory engine and changing the structure of `Store` to:
```
pub struct Store {
    engine:  Arc<dyn StoreEngine>
}
```


<!-- Why does this pull request exist? What are its goals? -->

**Description**

* Change `Store.engine` type from `Arc<Mutex<dyn StoreEngine>>` to ` E: StoreEngine`,
* Wrap in memory store engine in `Arc<Mutex<>>`
* Rename implementations of `StoreEngine` to `LibmdbxStoreEngine` & `InMemoryStoreEngine` and expose them publicly
* Add method `new_temp` for `Store` to be used in tests instead of creating and removing directories "by hand".

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

