### PR TITLE
feat: get state and storage tries by hash

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -31,7 +31,7 @@ pub fn add_block(block: &Block, storage: &Store) -> Result<(), ChainError> {
 
     // Validate if it can be the new head and find the parent
     let parent_header = find_parent_header(&block.header, storage)?;
-    let mut state = evm_state(storage.clone(), parent_header.number);
+    let mut state = evm_state(storage.clone(), block.header.parent_hash);
 
     // Validate the block pre-execution
     validate_block(block, &parent_header, &state)?;
@@ -45,7 +45,7 @@ pub fn add_block(block: &Block, storage: &Store) -> Result<(), ChainError> {
     // Apply the account updates over the last block's state and compute the new state root
     let new_state_root = state
         .database()
-        .apply_account_updates(parent_header.number, &account_updates)?
+        .apply_account_updates(block.header.parent_hash, &account_updates)?
         .unwrap_or_default();
 
     // Check state root matches the one in block header after execution

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -104,14 +104,14 @@ pub fn build_payload(args: &BuildPayloadArgs, storage: &Store) -> Result<Block, 
     };
     // Apply withdrawals & call beacon root contract, and obtain the new state root
     let spec_id = spec_id(storage, args.timestamp)?;
-    let mut evm_state = evm_state(storage.clone(), parent_block.number);
+    let mut evm_state = evm_state(storage.clone(), args.parent);
     if args.beacon_root.is_some() && spec_id == SpecId::CANCUN {
         beacon_root_contract_call(&mut evm_state, &payload.header, spec_id)?;
     }
     process_withdrawals(&mut evm_state, &args.withdrawals)?;
     let account_updates = get_state_transitions(&mut evm_state);
     payload.header.state_root = storage
-        .apply_account_updates(parent_block.number, &account_updates)?
+        .apply_account_updates(args.parent, &account_updates)?
         .unwrap_or_default();
     Ok(payload)
 }

--- a/crates/evm/db.rs
+++ b/crates/evm/db.rs
@@ -1,4 +1,4 @@
-use ethereum_rust_core::{types::BlockNumber, Address as CoreAddress, H256 as CoreH256};
+use ethereum_rust_core::{types::BlockHash, Address as CoreAddress, H256 as CoreH256};
 use ethereum_rust_storage::{error::StoreError, Store};
 use revm::primitives::{
     AccountInfo as RevmAccountInfo, Address as RevmAddress, Bytecode as RevmBytecode,
@@ -7,7 +7,7 @@ use revm::primitives::{
 
 pub struct StoreWrapper {
     pub store: Store,
-    pub block_number: BlockNumber,
+    pub block_hash: BlockHash,
 }
 
 impl revm::Database for StoreWrapper {
@@ -16,7 +16,7 @@ impl revm::Database for StoreWrapper {
     fn basic(&mut self, address: RevmAddress) -> Result<Option<RevmAccountInfo>, Self::Error> {
         let acc_info = match self
             .store
-            .get_account_info(self.block_number, CoreAddress::from(address.0.as_ref()))?
+            .get_account_info_by_hash(self.block_hash, CoreAddress::from(address.0.as_ref()))?
         {
             None => return Ok(None),
             Some(acc_info) => acc_info,
@@ -44,8 +44,8 @@ impl revm::Database for StoreWrapper {
     fn storage(&mut self, address: RevmAddress, index: RevmU256) -> Result<RevmU256, Self::Error> {
         Ok(self
             .store
-            .get_storage_at(
-                self.block_number,
+            .get_storage_at_hash(
+                self.block_hash,
                 CoreAddress::from(address.0.as_ref()),
                 CoreH256::from(index.to_be_bytes()),
             )?

--- a/crates/evm/evm.rs
+++ b/crates/evm/evm.rs
@@ -7,8 +7,8 @@ use std::cmp::min;
 
 use ethereum_rust_core::{
     types::{
-        AccountInfo, Block, BlockHeader, BlockNumber, Fork, GenericTransaction, Receipt,
-        Transaction, TxKind, Withdrawal, GWEI_TO_WEI, INITIAL_BASE_FEE,
+        AccountInfo, Block, BlockHash, BlockHeader, Fork, GenericTransaction, Receipt, Transaction,
+        TxKind, Withdrawal, GWEI_TO_WEI, INITIAL_BASE_FEE,
     },
     Address, BigEndianHash, H256, U256,
 };
@@ -330,13 +330,10 @@ pub fn process_withdrawals(
 }
 
 /// Builds EvmState from a Store
-pub fn evm_state(store: Store, block_number: BlockNumber) -> EvmState {
+pub fn evm_state(store: Store, block_hash: BlockHash) -> EvmState {
     EvmState(
         revm::db::State::builder()
-            .with_database(StoreWrapper {
-                store,
-                block_number,
-            })
+            .with_database(StoreWrapper { store, block_hash })
             .with_bundle_update()
             .without_state_clear()
             .build(),

--- a/crates/rpc/eth/transaction.rs
+++ b/crates/rpc/eth/transaction.rs
@@ -279,7 +279,7 @@ impl RpcHandler for CreateAccessListRequest {
         let (gas_used, access_list, error) = match ethereum_rust_evm::create_access_list(
             &self.transaction,
             &header,
-            &mut evm_state(storage, header.number),
+            &mut evm_state(storage, header.compute_block_hash()),
             SpecId::CANCUN,
         )? {
             (
@@ -477,7 +477,7 @@ fn simulate_tx(
     match ethereum_rust_evm::simulate_tx_from_generic(
         transaction,
         block_header,
-        &mut evm_state(storage, block_header.number),
+        &mut evm_state(storage, block_header.compute_block_hash()),
         spec_id,
     )? {
         ExecutionResult::Revert {

--- a/crates/storage/engines/api.rs
+++ b/crates/storage/engines/api.rs
@@ -206,7 +206,7 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     fn get_pending_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
 
     // Obtain the world state trie for the given block
-    fn state_trie(&self, block_number: BlockNumber) -> Result<Option<Trie>, StoreError>;
+    fn state_trie(&self, block_hash: BlockHash) -> Result<Option<Trie>, StoreError>;
 
     // Obtain a world state from an empty root
     // This method should be used when creating the genesis world state

--- a/crates/storage/engines/in_memory.rs
+++ b/crates/storage/engines/in_memory.rs
@@ -298,8 +298,11 @@ impl StoreEngine for Store {
         Ok(self.inner().chain_data.pending_block_number)
     }
 
-    fn state_trie(&self, block_number: BlockNumber) -> Result<Option<Trie>, StoreError> {
-        let Some(state_root) = self.get_block_header(block_number)?.map(|h| h.state_root) else {
+    fn state_trie(&self, block_hash: BlockHash) -> Result<Option<Trie>, StoreError> {
+        let Some(state_root) = self
+            .get_block_header_by_hash(block_hash)?
+            .map(|h| h.state_root)
+        else {
             return Ok(None);
         };
         let db = Box::new(InMemoryTrieDB::new(self.inner().state_trie_nodes.clone()));

--- a/crates/storage/engines/libmdbx.rs
+++ b/crates/storage/engines/libmdbx.rs
@@ -337,8 +337,11 @@ impl StoreEngine for Store {
         }
     }
 
-    fn state_trie(&self, block_number: BlockNumber) -> Result<Option<Trie>, StoreError> {
-        let Some(state_root) = self.get_block_header(block_number)?.map(|h| h.state_root) else {
+    fn state_trie(&self, block_hash: BlockHash) -> Result<Option<Trie>, StoreError> {
+        let Some(state_root) = self
+            .get_block_header_by_hash(block_hash)?
+            .map(|h| h.state_root)
+        else {
             return Ok(None);
         };
         let db = Box::new(LibmdbxTrieDB::<StateTrieNodes>::new(self.db.clone()));


### PR DESCRIPTION
**Changes**

- Change the access to tries in storage engines from number to hash
- In `storage.rs`, change methods from numbers to hashes if needed, and add wrappers when not.
- Make accesses by hash in `evm_state` construction, the trie db wrapper, blockchain, etc.

Regarding the note in the issue:

> Endpoints that should accept non canonical blocks:
> - newPayload
> - call

- `newPayload` uses `add_block`, which now uses hash to get the evm state. This will be useful for reorgs too.
- call gets called by number or string ids, but not by hash, so the number wrapper is supported.

Closes #443 