### PR TITLE
feat(L2): implement `Into<RpcRequest>` for EngineAPI request structs

### DIFF
--- a/crates/rpc/engine/fork_choice.rs
+++ b/crates/rpc/engine/fork_choice.rs
@@ -12,6 +12,7 @@ use crate::{
         fork_choice::{ForkChoiceResponse, ForkChoiceState, PayloadAttributesV3},
         payload::PayloadStatus,
     },
+    utils::RpcRequest,
     RpcErr, RpcHandler,
 };
 
@@ -20,6 +21,19 @@ pub struct ForkChoiceUpdatedV3 {
     pub fork_choice_state: ForkChoiceState,
     #[allow(unused)]
     pub payload_attributes: Option<PayloadAttributesV3>,
+}
+
+impl Into<RpcRequest> for ForkChoiceUpdatedV3 {
+    fn into(self) -> RpcRequest {
+        RpcRequest {
+            method: "engine_forkchoiceUpdatedV3".to_string(),
+            params: Some(vec![
+                serde_json::json!(self.fork_choice_state),
+                serde_json::json!(self.payload_attributes),
+            ]),
+            ..Default::default()
+        }
+    }
 }
 
 impl RpcHandler for ForkChoiceUpdatedV3 {

--- a/crates/rpc/engine/mod.rs
+++ b/crates/rpc/engine/mod.rs
@@ -2,10 +2,20 @@ pub mod exchange_transition_config;
 pub mod fork_choice;
 pub mod payload;
 
-use crate::{RpcErr, RpcHandler, Store};
+use crate::{utils::RpcRequest, RpcErr, RpcHandler, Store};
 use serde_json::{json, Value};
 
 pub type ExchangeCapabilitiesRequest = Vec<String>;
+
+impl Into<RpcRequest> for ExchangeCapabilitiesRequest {
+    fn into(self) -> RpcRequest {
+        RpcRequest {
+            method: "engine_exchangeCapabilities".to_string(),
+            params: Some(vec![serde_json::json!(self)]),
+            ..Default::default()
+        }
+    }
+}
 
 impl RpcHandler for ExchangeCapabilitiesRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {

--- a/crates/rpc/engine/payload.rs
+++ b/crates/rpc/engine/payload.rs
@@ -29,9 +29,9 @@ impl Into<RpcRequest> for NewPayloadV3Request {
         RpcRequest {
             method: "engine_newPayloadV3".to_string(),
             params: Some(vec![
-                serde_json::to_value(self.payload).unwrap(),
-                serde_json::to_value(self.expected_blob_versioned_hashes).unwrap(),
-                serde_json::to_value(self.parent_beacon_block_root).unwrap(),
+                serde_json::json!(self.payload),
+                serde_json::json!(self.expected_blob_versioned_hashes),
+                serde_json::json!(self.parent_beacon_block_root),
             ]),
             ..Default::default()
         }

--- a/crates/rpc/rpc.rs
+++ b/crates/rpc/rpc.rs
@@ -41,7 +41,7 @@ use utils::{
 };
 mod admin;
 mod authentication;
-mod engine;
+pub mod engine;
 mod eth;
 pub mod types;
 pub mod utils;

--- a/crates/rpc/utils.rs
+++ b/crates/rpc/utils.rs
@@ -155,6 +155,17 @@ impl RpcRequest {
     }
 }
 
+impl Default for RpcRequest {
+    fn default() -> Self {
+        RpcRequest {
+            id: RpcRequestId::Number(1),
+            jsonrpc: "2.0".to_string(),
+            method: "".to_string(),
+            params: None,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RpcErrorMetadata {
     pub code: i32,


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
This avoid us to repeat the JSON-RPC specification on every request we want to make with EngineAPI.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
The trait `Into<RpcRequest>` was implemented for every used EngineAPI request structure (e.g. `NewPayloadV3Request`) so we can create an Engine request and then convert it to an `RpcRequest`.

<!-- Link to issues: Resolves #111, Resolves #222 -->

