### PR TITLE
fix: correct typo in 'expected' variable name in fork_id tests

### DIFF
--- a/crates/core/types/fork_id.rs
+++ b/crates/core/types/fork_id.rs
@@ -105,8 +105,8 @@ mod tests {
             fork_hash: H32::zero(),
             fork_next: 0,
         };
-        let expexted = hex!("c6840000000080");
-        assert_eq!(fork.encode_to_vec(), expexted);
+        let expected = hex!("c6840000000080");
+        assert_eq!(fork.encode_to_vec(), expected);
     }
     #[test]
     fn encode_fork_id2() {
@@ -114,8 +114,8 @@ mod tests {
             fork_hash: H32::from_str("0xdeadbeef").unwrap(),
             fork_next: u64::from_str_radix("baddcafe", 16).unwrap(),
         };
-        let expexted = hex!("ca84deadbeef84baddcafe");
-        assert_eq!(fork.encode_to_vec(), expexted);
+        let expected = hex!("ca84deadbeef84baddcafe");
+        assert_eq!(fork.encode_to_vec(), expected);
     }
     #[test]
     fn encode_fork_id3() {
@@ -123,7 +123,7 @@ mod tests {
             fork_hash: H32::from_low_u64_le(u32::MAX.into()),
             fork_next: u64::MAX,
         };
-        let expexted = hex!("ce84ffffffff88ffffffffffffffff");
-        assert_eq!(fork.encode_to_vec(), expexted);
+        let expected = hex!("ce84ffffffff88ffffffffffffffff");
+        assert_eq!(fork.encode_to_vec(), expected);
     }
 }


### PR DESCRIPTION
**Motivation**

This pull request addresses a minor typo in the test functions of the ForkId encoding implementation, specifically correcting the misspelling of the variable name expexted to expected.

