### PR TITLE
fix(L2 - CLI): solc path

### DIFF
--- a/cmd/ethereum_rust_l2/src/commands/stack.rs
+++ b/cmd/ethereum_rust_l2/src/commands/stack.rs
@@ -143,6 +143,16 @@ fn deploy_l1(
     deployer_private_key: &str,
     contracts_path: &PathBuf,
 ) -> eyre::Result<()> {
+    // Run 'which solc' to get the path of the solc binary
+    let solc_path_output = std::process::Command::new("which")
+        .arg("solc")
+        .output()
+        .expect("Failed to execute command");
+
+    let solc_path = String::from_utf8_lossy(&solc_path_output.stdout)
+        .trim()
+        .to_string();
+
     let cmd = std::process::Command::new("forge")
         .current_dir(contracts_path)
         .arg("script")
@@ -152,6 +162,8 @@ fn deploy_l1(
         .arg("--private-key")
         .arg(deployer_private_key) // TODO: In the future this must be the operator's private key.
         .arg("--broadcast")
+        .arg("--use")
+        .arg(solc_path)
         .spawn()?
         .wait()?;
     if !cmd.success() {

--- a/cmd/ethereum_rust_l2/src/commands/stack.rs
+++ b/cmd/ethereum_rust_l2/src/commands/stack.rs
@@ -144,10 +144,7 @@ fn deploy_l1(
     contracts_path: &PathBuf,
 ) -> eyre::Result<()> {
     // Run 'which solc' to get the path of the solc binary
-    let solc_path_output = std::process::Command::new("which")
-        .arg("solc")
-        .output()
-        .expect("Failed to execute command");
+    let solc_path_output = std::process::Command::new("which").arg("solc").output()?;
 
     let solc_path = String::from_utf8_lossy(&solc_path_output.stdout)
         .trim()


### PR DESCRIPTION
**Motivation**
if `asdf` is being used, `solc` is not found.

**Description**
Before executing the `start` cmd, search for the solc path system-wide with `which` and use it explicitly.


