### PR TITLE
LEVM: Add Unit Tests for Various Opcodes

### DIFF
--- a/crates/levm/tests/tests.rs
+++ b/crates/levm/tests/tests.rs
@@ -141,6 +141,23 @@ fn add_op() {
 }
 
 #[test]
+fn mul_op(){
+    let mut vm = new_vm_with_ops(&[
+        Operation::Push32(U256::from(2)),
+        Operation::Push32(U256::from(3)),
+        Operation::Mul,
+        Operation::Stop,
+    ]);
+
+    vm.execute();
+
+    assert!(vm.current_call_frame_mut().stack.pop().unwrap() == U256::from(6));
+    assert!(vm.current_call_frame_mut().pc() == 68);
+}
+
+
+
+#[test]
 fn and_basic() {
     let mut vm = new_vm_with_ops(&[
         Operation::Push32(U256::from(0b1010)),


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
The objective is to add at least one unit test for every opcode, so that if we want to make changes in that opcode we can run it's own test and see if it breaks.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
### Status:
- ✅: Implemented
- 🚧: Work in Progress
- ❌: Not going to implement in this PR

### Opcodes Tests
•	Mul ✅
•	Sub🚧
•	Div🚧
•	Sdiv🚧
•	Mod🚧
•	SMod🚧
•	Addmod🚧
•	Mulmod🚧
•	Exp🚧
•	SignExtend🚧
•	Lt🚧
•	Gt🚧
•	Slt🚧
•	Sgt🚧
•	Eq🚧
•	IsZero🚧
•	SelfBalance🚧
•	Blobhash🚧
•	Gas🚧

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #682 

