### PR TITLE
refactor: improve block header validation error handling

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -148,7 +148,9 @@ pub fn validate_block(
     match spec {
         SpecId::CANCUN => validate_cancun_header_fields(&block.header, parent_header)
             .map_err(InvalidBlockError::from)?,
-        _ => validate_no_cancun_header_fields(&block.header).map_err(InvalidBlockError::from)?,
+        _other_specs => {
+            validate_no_cancun_header_fields(&block.header).map_err(InvalidBlockError::from)?
+        }
     };
 
     if spec == SpecId::CANCUN {

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+use ethereum_rust_core::types::InvalidBlockHeaderError;
 use ethereum_rust_evm::EvmError;
 use ethereum_rust_storage::error::StoreError;
 
@@ -23,8 +24,8 @@ pub enum ChainError {
 pub enum InvalidBlockError {
     #[error("World State Root does not match the one in the header after executing")]
     StateRootMismatch,
-    #[error("Invalid Header, validation failed pre-execution")]
-    InvalidHeader,
+    #[error("Invalid Header, validation failed pre-execution: {0}")]
+    InvalidHeader(#[from] InvalidBlockHeaderError),
     #[error("Exceeded MAX_BLOB_GAS_PER_BLOCK")]
     ExceededMaxBlobGasPerBlock,
     #[error("Exceeded MAX_BLOB_NUMBER_PER_BLOCK")]


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

Nowadays important block validation errors are omitted. If a block is added to the blockchain and fails at header validation you have no clue which of all validations failed, only that the error was a `ChainError::InvalidBlock(InvalidBlockError::InvalidHeader)`.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

This PR proposes an improvement in the handling of block validation errors.
