### PR TITLE
refactor: payload execution error handling

### DIFF
--- a/crates/networking/rpc/types/payload.rs
+++ b/crates/networking/rpc/types/payload.rs
@@ -168,6 +168,14 @@ pub enum PayloadValidationStatus {
 impl PayloadStatus {
     // Convenience methods to create payload status
 
+    pub fn invalid_with(latest_valid_hash: H256, error: String) -> Self {
+        PayloadStatus {
+            status: PayloadValidationStatus::Invalid,
+            latest_valid_hash: Some(latest_valid_hash),
+            validation_error: Some(error),
+        }
+    }
+
     /// Creates a PayloadStatus with invalid status and error message
     pub fn invalid_with_err(error: &str) -> Self {
         PayloadStatus {


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

If the block executed in the `NewPayloadV3` handler fails because of a `ChainError::InvalidBlock` error, the error message is not passed to the `PayloadStatus` which obscures the failure reason and makes it difficult to debug.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

This PR:
- adds a message error to the `PayloadStatus` sent when the block execution fails because of  a `ChainError::InvalidBlock` error,
- adds tracing logs for this error case and also for the `ChainError::StoreError` case.

