### PR TITLE
feat: (L1) Add log level flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Ethereum Rust supports the following command line arguments:
 - `--discovery.addr <ADDRESS>`: UDP address for P2P discovery. Default value: 0.0.0.0.
 - `--discovery.port <PORT>`: UDP port for P2P discovery. Default value: 30303.
 - `--bootnodes <BOOTNODE_LIST>`: Comma separated enode URLs for P2P discovery bootstrap.
+- `--log-level <LOG_LEVEL>`: The verbosity level used for logs. Default value: info. possible values: info, debug, trace, warn, error
 
 ## Roadmap
 

--- a/cmd/ethereum_rust/cli.rs
+++ b/cmd/ethereum_rust/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Arg, ArgAction, Command};
+use clap::{arg, Arg, ArgAction, Command};
 use ethereum_rust_net::bootnode::BootNode;
 
 pub fn cli() -> Command {
@@ -19,6 +19,7 @@ pub fn cli() -> Command {
                 .value_name("PORT")
                 .action(ArgAction::Set),
         )
+        .arg(arg!(-v --verbose "Max verbosity for logs").required(false))
         .arg(
             Arg::new("authrpc.addr")
                 .long("authrpc.addr")

--- a/cmd/ethereum_rust/cli.rs
+++ b/cmd/ethereum_rust/cli.rs
@@ -1,5 +1,6 @@
-use clap::{arg, Arg, ArgAction, Command};
+use clap::{Arg, ArgAction, Command};
 use ethereum_rust_net::bootnode::BootNode;
+use tracing::Level;
 
 pub fn cli() -> Command {
     Command::new("ethereum_rust")
@@ -19,7 +20,13 @@ pub fn cli() -> Command {
                 .value_name("PORT")
                 .action(ArgAction::Set),
         )
-        .arg(arg!(-v --verbose "Max verbosity for logs").required(false))
+        .arg(
+            Arg::new("log-level")
+                .long("log-level")
+                .default_value(Level::INFO.as_str())
+                .value_name("LOG_LEVEL")
+                .action(ArgAction::Set),
+        )
         .arg(
             Arg::new("authrpc.addr")
                 .long("authrpc.addr")

--- a/cmd/ethereum_rust/cli.rs
+++ b/cmd/ethereum_rust/cli.rs
@@ -25,6 +25,7 @@ pub fn cli() -> Command {
                 .long("log-level")
                 .default_value(Level::INFO.as_str())
                 .value_name("LOG_LEVEL")
+                .required(false)
                 .action(ArgAction::Set),
         )
         .arg(

--- a/cmd/ethereum_rust/ethereum_rust.rs
+++ b/cmd/ethereum_rust/ethereum_rust.rs
@@ -9,6 +9,7 @@ use ethereum_rust_storage::{EngineType, Store};
 use k256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng};
 use std::future::IntoFuture;
 use std::path::Path;
+use std::str::FromStr;
 use std::time::Duration;
 use std::{
     fs::File,
@@ -39,15 +40,12 @@ async fn main() {
         return;
     }
 
-    let subscriber = if matches.get_flag("verbose") {
-        FmtSubscriber::builder()
-            .with_max_level(Level::DEBUG)
-            .finish()
-    } else {
-        FmtSubscriber::builder()
-            .with_max_level(Level::INFO)
-            .finish()
-    };
+    let log_level = matches
+        .get_one::<String>("log-level")
+        .expect("log-level is required");
+    let log_level = Level::from_str(&log_level).unwrap_or(Level::INFO);
+
+    let subscriber = FmtSubscriber::builder().with_max_level(log_level).finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 

--- a/cmd/ethereum_rust/ethereum_rust.rs
+++ b/cmd/ethereum_rust/ethereum_rust.rs
@@ -42,11 +42,9 @@ async fn main() {
 
     let log_level = matches
         .get_one::<String>("log-level")
-        .expect("log-level is required");
+        .expect("shouldn't happen, log-level is used with a default value");
     let log_level = Level::from_str(log_level).unwrap_or(Level::INFO);
-
     let subscriber = FmtSubscriber::builder().with_max_level(log_level).finish();
-
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
     let http_addr = matches

--- a/cmd/ethereum_rust/ethereum_rust.rs
+++ b/cmd/ethereum_rust/ethereum_rust.rs
@@ -43,7 +43,7 @@ async fn main() {
     let log_level = matches
         .get_one::<String>("log-level")
         .expect("shouldn't happen, log-level is used with a default value");
-    let log_level = Level::from_str(log_level).unwrap_or(Level::INFO);
+    let log_level = Level::from_str(log_level).expect("Not supported log level provided");
     let subscriber = FmtSubscriber::builder().with_max_level(log_level).finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 

--- a/cmd/ethereum_rust/ethereum_rust.rs
+++ b/cmd/ethereum_rust/ethereum_rust.rs
@@ -23,12 +23,6 @@ mod decode;
 
 #[tokio::main]
 async fn main() {
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::DEBUG)
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
-
     let matches = cli::cli().get_matches();
 
     if let Some(matches) = matches.subcommand_matches("removedb") {
@@ -44,6 +38,18 @@ async fn main() {
         }
         return;
     }
+
+    let subscriber = if matches.get_flag("verbose") {
+        FmtSubscriber::builder()
+            .with_max_level(Level::DEBUG)
+            .finish()
+    } else {
+        FmtSubscriber::builder()
+            .with_max_level(Level::INFO)
+            .finish()
+    };
+
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
     let http_addr = matches
         .get_one::<String>("http.addr")

--- a/cmd/ethereum_rust/ethereum_rust.rs
+++ b/cmd/ethereum_rust/ethereum_rust.rs
@@ -43,7 +43,7 @@ async fn main() {
     let log_level = matches
         .get_one::<String>("log-level")
         .expect("log-level is required");
-    let log_level = Level::from_str(&log_level).unwrap_or(Level::INFO);
+    let log_level = Level::from_str(log_level).unwrap_or(Level::INFO);
 
     let subscriber = FmtSubscriber::builder().with_max_level(log_level).finish();
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Add log level flag to the `CLI`

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
When running the program, now you can pass the `--log-level` flag, if it isn't used, the log-level will be `INFO` as default

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #692 
