### PR TITLE
LEVM: Fix SMod Opcode

### DIFF
--- a/crates/levm/src/vm.rs
+++ b/crates/levm/src/vm.rs
@@ -310,9 +310,8 @@ impl VM {
                     self.env.consumed_gas += gas_cost::MOD
                 }
                 Opcode::SMOD => {
-                    // Check gas limit for the operation
                     if self.env.consumed_gas + gas_cost::SMOD > self.env.gas_limit {
-                        break; // should revert the transaction
+                        break; // should revert the tx
                     }
 
                     let dividend = current_call_frame.stack.pop().unwrap();
@@ -339,7 +338,7 @@ impl VM {
                         remainder = negate(remainder);
                     }
                     current_call_frame.stack.push(remainder);
-                    self.env.consumed_gas += gas_cost::SMOD;
+                    self.env.consumed_gas += gas_cost::SMOD
                 }
                 Opcode::ADDMOD => {
                     if self.env.consumed_gas + gas_cost::ADDMOD > self.env.gas_limit {

--- a/crates/levm/tests/tests.rs
+++ b/crates/levm/tests/tests.rs
@@ -258,6 +258,9 @@ fn smod_op(){
 
     let c = U256::from_str_radix("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe", 16).unwrap();
 
+    // println!("{c}");
+    // println!("{}", vm.current_call_frame_mut().stack.pop().unwrap());
+
     // I think the test is fine but SMOD may be implemented wrong? Result should be -2, not 2.
     assert!(vm.current_call_frame_mut().stack.pop().unwrap() == c);
 }

--- a/crates/levm/tests/tests.rs
+++ b/crates/levm/tests/tests.rs
@@ -258,10 +258,6 @@ fn smod_op(){
 
     let c = U256::from_str_radix("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe", 16).unwrap();
 
-    // println!("{c}");
-    // println!("{}", vm.current_call_frame_mut().stack.pop().unwrap());
-
-    // I think the test is fine but SMOD may be implemented wrong? Result should be -2, not 2.
     assert!(vm.current_call_frame_mut().stack.pop().unwrap() == c);
 }
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
SMod opcode wasn't working properly with negative numbers.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- Fix SMod behavior with negative numbers. Now `remainder` has the same sign as the `dividend`

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #703 

