### PR TITLE
feat: (levm) Update error handling 

### DIFF
--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -139,7 +139,7 @@ impl CallFrame {
         if !self.valid_jump(jump_address) {
             return false;
         }
-        self.pc = jump_address.as_usize() + 1;
+        self.pc = jump_address.as_usize();
         true
     }
 

--- a/crates/vm/levm/src/constants.rs
+++ b/crates/vm/levm/src/constants.rs
@@ -1,5 +1,6 @@
 pub const SUCCESS_FOR_CALL: i32 = 1;
 pub const REVERT_FOR_CALL: i32 = 0;
+pub const HALT_FOR_CALL: i32 = 2;
 pub const SUCCESS_FOR_RETURN: i32 = 1;
 pub const REVERT_FOR_CREATE: i32 = 0;
 pub const MAX_CODE_SIZE: usize = 0x6000;
@@ -84,3 +85,4 @@ pub mod call_opcode {
     pub const BASIC_FALLBACK_FUNCTION_STIPEND: u64 = 2_300;
     pub const VALUE_TO_EMPTY_ACCOUNT_COST: u64 = 25_000;
 }
+pub const STACK_LIMIT: usize = 1024;

--- a/crates/vm/levm/src/lib.rs
+++ b/crates/vm/levm/src/lib.rs
@@ -7,3 +7,4 @@ pub mod operations;
 pub mod primitives;
 pub mod transaction;
 pub mod vm;
+pub mod vm_result;

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -10,6 +10,7 @@ use crate::{
     opcodes::Opcode,
     primitives::{Address, Bytes, H256, H32, U256, U512},
     transaction::{TransactTo, TxEnv},
+    vm_result::{ExecutionResult, ResultReason, VMError},
 };
 extern crate ethereum_rust_rlp;
 use ethereum_rust_rlp::encode::RLPEncode;
@@ -18,6 +19,7 @@ use sha3::{Digest, Keccak256};
 
 #[derive(Clone, Default, Debug)]
 pub struct Account {
+    pub address: Address,
     pub balance: U256,
     pub bytecode: Bytes,
     pub nonce: u64,
@@ -32,12 +34,14 @@ pub struct StorageSlot {
 
 impl Account {
     pub fn new(
+        address: Address,
         balance: U256,
         bytecode: Bytes,
         nonce: u64,
         storage: HashMap<U256, StorageSlot>,
     ) -> Self {
         Self {
+            address,
             balance,
             bytecode,
             storage,
@@ -67,6 +71,10 @@ impl Account {
     pub fn with_nonce(mut self, nonce: u64) -> Self {
         self.nonce = nonce;
         self
+    }
+
+    pub fn increment_nonce(&mut self) {
+        self.nonce += 1;
     }
 }
 
@@ -110,6 +118,12 @@ impl Db {
     pub fn add_account(&mut self, address: Address, account: Account) {
         self.accounts.insert(address, account);
     }
+
+    pub fn increment_account_nonce(&mut self, address: &Address) {
+        if let Some(acc) = self.accounts.get_mut(address) {
+            acc.increment_nonce()
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -136,7 +150,7 @@ pub struct Environment {
 
 #[derive(Debug, Clone, Default)]
 pub struct VM {
-    call_frames: Vec<CallFrame>,
+    pub call_frames: Vec<CallFrame>,
     pub env: Environment,
     /// Information that is acted upon immediately following the
     /// transaction.
@@ -173,7 +187,7 @@ impl VM {
             }
         };
 
-        let caller = match tx_env.transact_to {
+        let to = match tx_env.transact_to {
             TransactTo::Call(addr) => addr,
             TransactTo::Create => tx_env.msg_sender,
         };
@@ -185,15 +199,16 @@ impl VM {
 
         // TODO: this is mostly placeholder
         let initial_call_frame = CallFrame::new(
-            U256::MAX,
             tx_env.msg_sender,
-            caller,
+            to,
             code_addr,
-            Default::default(),
+            None,
             bytecode,
             tx_env.value,
             tx_env.data,
             false,
+            U256::zero(),
+            0,
         );
 
         let env = Environment {
@@ -210,65 +225,94 @@ impl VM {
         }
     }
 
-    pub fn execute(&mut self) {
+    pub fn write_success_result(call_frame: CallFrame, reason: ResultReason) -> ExecutionResult {
+        ExecutionResult::Success {
+            reason,
+            logs: call_frame.logs.clone(),
+            return_data: call_frame.returndata.clone(),
+        }
+    }
+
+    pub fn execute(&mut self) -> Result<ExecutionResult, VMError> {
         let block_env = self.env.block.clone();
-        let mut current_call_frame = self.call_frames.pop().unwrap();
+        let mut current_call_frame = self.call_frames.pop().ok_or(VMError::FatalError)?; // if this happens during execution, we are cooked 💀
         loop {
             let opcode = current_call_frame.next_opcode().unwrap_or(Opcode::STOP);
             match opcode {
-                Opcode::STOP => break,
+                Opcode::STOP => {
+                    self.call_frames.push(current_call_frame.clone());
+                    return Ok(Self::write_success_result(
+                        current_call_frame,
+                        ResultReason::Stop,
+                    ));
+                }
                 Opcode::ADD => {
                     if self.env.consumed_gas + gas_cost::ADD > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let augend = current_call_frame.stack.pop().unwrap();
-                    let addend = current_call_frame.stack.pop().unwrap();
+                    let augend = current_call_frame.stack.pop()?;
+                    let addend = current_call_frame.stack.pop()?;
                     let sum = augend.overflowing_add(addend).0;
-                    current_call_frame.stack.push(sum);
+                    current_call_frame.stack.push(sum)?;
                     self.env.consumed_gas += gas_cost::ADD
                 }
                 Opcode::MUL => {
                     if self.env.consumed_gas + gas_cost::MUL > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let multiplicand = current_call_frame.stack.pop().unwrap();
-                    let multiplier = current_call_frame.stack.pop().unwrap();
+                    let multiplicand = current_call_frame.stack.pop()?;
+                    let multiplier = current_call_frame.stack.pop()?;
                     let product = multiplicand.overflowing_mul(multiplier).0;
-                    current_call_frame.stack.push(product);
+                    current_call_frame.stack.push(product)?;
                     self.env.consumed_gas += gas_cost::MUL
                 }
                 Opcode::SUB => {
                     if self.env.consumed_gas + gas_cost::SUB > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let minuend = current_call_frame.stack.pop().unwrap();
-                    let subtrahend = current_call_frame.stack.pop().unwrap();
+                    let minuend = current_call_frame.stack.pop()?;
+                    let subtrahend = current_call_frame.stack.pop()?;
                     let difference = minuend.overflowing_sub(subtrahend).0;
-                    current_call_frame.stack.push(difference);
+                    current_call_frame.stack.push(difference)?;
                     self.env.consumed_gas += gas_cost::SUB
                 }
                 Opcode::DIV => {
                     if self.env.consumed_gas + gas_cost::DIV > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let dividend = current_call_frame.stack.pop().unwrap();
-                    let divisor = current_call_frame.stack.pop().unwrap();
+                    let dividend = current_call_frame.stack.pop()?;
+                    let divisor = current_call_frame.stack.pop()?;
                     if divisor.is_zero() {
-                        current_call_frame.stack.push(U256::zero());
+                        current_call_frame.stack.push(U256::zero())?;
                         continue;
                     }
                     let quotient = dividend / divisor;
-                    current_call_frame.stack.push(quotient);
+                    current_call_frame.stack.push(quotient)?;
                     self.env.consumed_gas += gas_cost::DIV
                 }
                 Opcode::SDIV => {
                     if self.env.consumed_gas + gas_cost::SDIV > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let dividend = current_call_frame.stack.pop().unwrap();
-                    let divisor = current_call_frame.stack.pop().unwrap();
+                    let dividend = current_call_frame.stack.pop()?;
+                    let divisor = current_call_frame.stack.pop()?;
                     if divisor.is_zero() {
-                        current_call_frame.stack.push(U256::zero());
+                        current_call_frame.stack.push(U256::zero())?;
                         continue;
                     }
 
@@ -292,31 +336,37 @@ impl VM {
                         quotient
                     };
 
-                    current_call_frame.stack.push(quotient);
+                    current_call_frame.stack.push(quotient)?;
                     self.env.consumed_gas += gas_cost::SDIV
                 }
                 Opcode::MOD => {
                     if self.env.consumed_gas + gas_cost::MOD > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let dividend = current_call_frame.stack.pop().unwrap();
-                    let divisor = current_call_frame.stack.pop().unwrap();
+                    let dividend = current_call_frame.stack.pop()?;
+                    let divisor = current_call_frame.stack.pop()?;
                     if divisor.is_zero() {
-                        current_call_frame.stack.push(U256::zero());
+                        current_call_frame.stack.push(U256::zero())?;
                         continue;
                     }
                     let remainder = dividend % divisor;
-                    current_call_frame.stack.push(remainder);
+                    current_call_frame.stack.push(remainder)?;
                     self.env.consumed_gas += gas_cost::MOD
                 }
                 Opcode::SMOD => {
                     if self.env.consumed_gas + gas_cost::SMOD > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let dividend = current_call_frame.stack.pop().unwrap();
-                    let divisor = current_call_frame.stack.pop().unwrap();
+                    let dividend = current_call_frame.stack.pop()?;
+                    let divisor = current_call_frame.stack.pop()?;
                     if divisor.is_zero() {
-                        current_call_frame.stack.push(U256::zero());
+                        current_call_frame.stack.push(U256::zero())?;
                         continue;
                     }
 
@@ -340,18 +390,21 @@ impl VM {
                         remainder
                     };
 
-                    current_call_frame.stack.push(remainder);
+                    current_call_frame.stack.push(remainder)?;
                     self.env.consumed_gas += gas_cost::SMOD
                 }
                 Opcode::ADDMOD => {
                     if self.env.consumed_gas + gas_cost::ADDMOD > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let augend = current_call_frame.stack.pop().unwrap();
-                    let addend = current_call_frame.stack.pop().unwrap();
-                    let divisor = current_call_frame.stack.pop().unwrap();
+                    let augend = current_call_frame.stack.pop()?;
+                    let addend = current_call_frame.stack.pop()?;
+                    let divisor = current_call_frame.stack.pop()?;
                     if divisor.is_zero() {
-                        current_call_frame.stack.push(U256::zero());
+                        current_call_frame.stack.push(U256::zero())?;
                         continue;
                     }
                     let (sum, overflow) = augend.overflowing_add(addend);
@@ -360,18 +413,21 @@ impl VM {
                         remainder = remainder.overflowing_sub(divisor).0;
                     }
 
-                    current_call_frame.stack.push(remainder);
+                    current_call_frame.stack.push(remainder)?;
                     self.env.consumed_gas += gas_cost::ADDMOD
                 }
                 Opcode::MULMOD => {
                     if self.env.consumed_gas + gas_cost::MULMOD > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let multiplicand = U512::from(current_call_frame.stack.pop().unwrap());
-                    let multiplier = U512::from(current_call_frame.stack.pop().unwrap());
-                    let divisor = U512::from(current_call_frame.stack.pop().unwrap());
+                    let multiplicand = U512::from(current_call_frame.stack.pop()?);
+                    let multiplier = U512::from(current_call_frame.stack.pop()?);
+                    let divisor = U512::from(current_call_frame.stack.pop()?);
                     if divisor.is_zero() {
-                        current_call_frame.stack.push(U256::zero());
+                        current_call_frame.stack.push(U256::zero())?;
                         continue;
                     }
 
@@ -389,30 +445,36 @@ impl VM {
                     // after reverse we get the [0, 0, ...., 255, 120] which is the correct order for the little endian u256
                     result.reverse();
                     let remainder = U256::from(result.as_slice());
-                    current_call_frame.stack.push(remainder);
+                    current_call_frame.stack.push(remainder)?;
                     self.env.consumed_gas += gas_cost::MULMOD
                 }
                 Opcode::EXP => {
-                    let base = current_call_frame.stack.pop().unwrap();
-                    let exponent = current_call_frame.stack.pop().unwrap();
+                    let base = current_call_frame.stack.pop()?;
+                    let exponent = current_call_frame.stack.pop()?;
 
                     let exponent_byte_size = (exponent.bits() as u64 + 7) / 8;
                     let gas_cost =
                         gas_cost::EXP_STATIC + gas_cost::EXP_DYNAMIC_BASE * exponent_byte_size;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
 
                     let power = base.overflowing_pow(exponent).0;
-                    current_call_frame.stack.push(power);
+                    current_call_frame.stack.push(power)?;
                     self.env.consumed_gas += gas_cost
                 }
                 Opcode::SIGNEXTEND => {
                     if self.env.consumed_gas + gas_cost::SIGNEXTEND > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let byte_size = current_call_frame.stack.pop().unwrap();
-                    let value_to_extend = current_call_frame.stack.pop().unwrap();
+                    let byte_size = current_call_frame.stack.pop()?;
+                    let value_to_extend = current_call_frame.stack.pop()?;
 
                     let bits_per_byte = U256::from(8);
                     let sign_bit_position_on_byte = 7;
@@ -427,35 +489,44 @@ impl VM {
                     } else {
                         value_to_extend & sign_bit_mask
                     };
-                    current_call_frame.stack.push(result);
+                    current_call_frame.stack.push(result)?;
                     self.env.consumed_gas += gas_cost::SIGNEXTEND
                 }
                 Opcode::LT => {
                     if self.env.consumed_gas + gas_cost::LT > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let lho = current_call_frame.stack.pop().unwrap();
-                    let rho = current_call_frame.stack.pop().unwrap();
+                    let lho = current_call_frame.stack.pop()?;
+                    let rho = current_call_frame.stack.pop()?;
                     let result = if lho < rho { U256::one() } else { U256::zero() };
-                    current_call_frame.stack.push(result);
+                    current_call_frame.stack.push(result)?;
                     self.env.consumed_gas += gas_cost::LT
                 }
                 Opcode::GT => {
                     if self.env.consumed_gas + gas_cost::GT > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let lho = current_call_frame.stack.pop().unwrap();
-                    let rho = current_call_frame.stack.pop().unwrap();
+                    let lho = current_call_frame.stack.pop()?;
+                    let rho = current_call_frame.stack.pop()?;
                     let result = if lho > rho { U256::one() } else { U256::zero() };
-                    current_call_frame.stack.push(result);
+                    current_call_frame.stack.push(result)?;
                     self.env.consumed_gas += gas_cost::GT
                 }
                 Opcode::SLT => {
                     if self.env.consumed_gas + gas_cost::SLT > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let lho = current_call_frame.stack.pop().unwrap();
-                    let rho = current_call_frame.stack.pop().unwrap();
+                    let lho = current_call_frame.stack.pop()?;
+                    let rho = current_call_frame.stack.pop()?;
                     let lho_is_negative = lho.bit(255);
                     let rho_is_negative = rho.bit(255);
                     let result = if lho_is_negative == rho_is_negative {
@@ -473,15 +544,18 @@ impl VM {
                             U256::zero()
                         }
                     };
-                    current_call_frame.stack.push(result);
+                    current_call_frame.stack.push(result)?;
                     self.env.consumed_gas += gas_cost::SLT
                 }
                 Opcode::SGT => {
                     if self.env.consumed_gas + gas_cost::SGT > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let lho = current_call_frame.stack.pop().unwrap();
-                    let rho = current_call_frame.stack.pop().unwrap();
+                    let lho = current_call_frame.stack.pop()?;
+                    let rho = current_call_frame.stack.pop()?;
                     let lho_is_negative = lho.bit(255);
                     let rho_is_negative = rho.bit(255);
                     let result = if lho_is_negative == rho_is_negative {
@@ -499,39 +573,53 @@ impl VM {
                             U256::zero()
                         }
                     };
-                    current_call_frame.stack.push(result);
+                    current_call_frame.stack.push(result)?;
                     self.env.consumed_gas += gas_cost::SGT
                 }
                 Opcode::EQ => {
                     if self.env.consumed_gas + gas_cost::EQ > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let lho = current_call_frame.stack.pop().unwrap();
-                    let rho = current_call_frame.stack.pop().unwrap();
+                    let lho = current_call_frame.stack.pop()?;
+                    let rho = current_call_frame.stack.pop()?;
                     let result = if lho == rho {
                         U256::one()
                     } else {
                         U256::zero()
                     };
-                    current_call_frame.stack.push(result);
+                    current_call_frame.stack.push(result)?;
                     self.env.consumed_gas += gas_cost::EQ
                 }
                 Opcode::ISZERO => {
                     if self.env.consumed_gas + gas_cost::ISZERO > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let operand = current_call_frame.stack.pop().unwrap();
+                    let operand = current_call_frame.stack.pop()?;
                     let result = if operand == U256::zero() {
                         U256::one()
                     } else {
                         U256::zero()
                     };
-                    current_call_frame.stack.push(result);
+                    current_call_frame.stack.push(result)?;
                     self.env.consumed_gas += gas_cost::ISZERO
                 }
                 Opcode::KECCAK256 => {
-                    let offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let size = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                    let offset = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let size = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
 
                     let minimum_word_size = (size + WORD_SIZE - 1) / WORD_SIZE;
                     let memory_expansion_cost =
@@ -540,7 +628,10 @@ impl VM {
                         + gas_cost::KECCAK25_DYNAMIC_BASE * minimum_word_size as u64
                         + memory_expansion_cost as u64;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
 
                     let value_bytes = current_call_frame.memory.load_range(offset, size);
@@ -550,34 +641,55 @@ impl VM {
                     let result = hasher.finalize();
                     current_call_frame
                         .stack
-                        .push(U256::from_big_endian(&result));
+                        .push(U256::from_big_endian(&result))?;
                     self.env.consumed_gas += gas_cost
                 }
                 Opcode::CALLDATALOAD => {
                     if self.env.consumed_gas + gas_cost::CALLDATALOAD > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let offset: usize = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                    let offset: usize = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
                     let value = U256::from_big_endian(
                         &current_call_frame.calldata.slice(offset..offset + 32),
                     );
-                    current_call_frame.stack.push(value);
+                    current_call_frame.stack.push(value)?;
                     self.env.consumed_gas += gas_cost::CALLDATALOAD
                 }
                 Opcode::CALLDATASIZE => {
                     if self.env.consumed_gas + gas_cost::CALLDATASIZE > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     current_call_frame
                         .stack
-                        .push(U256::from(current_call_frame.calldata.len()));
+                        .push(U256::from(current_call_frame.calldata.len()))?;
                     self.env.consumed_gas += gas_cost::CALLDATASIZE
                 }
                 Opcode::CALLDATACOPY => {
-                    let dest_offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let calldata_offset: usize =
-                        current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let size: usize = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                    let dest_offset = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let calldata_offset: usize = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let size: usize = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
 
                     let minimum_word_size = (size + WORD_SIZE - 1) / WORD_SIZE;
                     let memory_expansion_cost =
@@ -586,7 +698,10 @@ impl VM {
                         + gas_cost::CALLDATACOPY_DYNAMIC_BASE * minimum_word_size as u64
                         + memory_expansion_cost;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     self.env.consumed_gas += gas_cost;
                     if size == 0 {
@@ -600,18 +715,32 @@ impl VM {
                 }
                 Opcode::RETURNDATASIZE => {
                     if self.env.consumed_gas + gas_cost::RETURNDATASIZE > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     current_call_frame
                         .stack
-                        .push(U256::from(current_call_frame.returndata.len()));
+                        .push(U256::from(current_call_frame.returndata.len()))?;
                     self.env.consumed_gas += gas_cost::RETURNDATASIZE
                 }
                 Opcode::RETURNDATACOPY => {
-                    let dest_offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let returndata_offset: usize =
-                        current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let size: usize = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                    let dest_offset = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let returndata_offset: usize = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let size: usize = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
 
                     let minimum_word_size = (size + WORD_SIZE - 1) / WORD_SIZE;
                     let memory_expansion_cost =
@@ -620,7 +749,10 @@ impl VM {
                         + gas_cost::RETURNDATACOPY_DYNAMIC_BASE * minimum_word_size as u64
                         + memory_expansion_cost;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     self.env.consumed_gas += gas_cost;
                     if size == 0 {
@@ -633,44 +765,58 @@ impl VM {
                 }
                 Opcode::JUMP => {
                     if self.env.consumed_gas + gas_cost::JUMP > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let jump_address = current_call_frame.stack.pop().unwrap();
-                    current_call_frame.jump(jump_address);
-                    self.env.consumed_gas += gas_cost::JUMP
+                    let jump_address = current_call_frame.stack.pop()?;
+
+                    if !current_call_frame.jump(jump_address) {
+                        self.env.consumed_gas = self.env.gas_limit;
+                        return Err(VMError::InvalidJump);
+                    }
+                    self.env.consumed_gas += gas_cost::JUMP;
                 }
                 Opcode::JUMPI => {
-                    if self.env.consumed_gas + gas_cost::JUMPI > self.env.gas_limit {
-                        break; // should revert the tx
-                    }
-                    let jump_address = current_call_frame.stack.pop().unwrap();
-                    let condition = current_call_frame.stack.pop().unwrap();
-                    if condition != U256::zero() {
-                        current_call_frame.jump(jump_address);
+                    let jump_address = current_call_frame.stack.pop()?;
+                    let condition = current_call_frame.stack.pop()?;
+                    if condition != U256::zero() && !current_call_frame.jump(jump_address) {
+                        self.env.consumed_gas = self.env.gas_limit;
+                        return Err(VMError::InvalidJump);
                     }
                     self.env.consumed_gas += gas_cost::JUMPI
                 }
                 Opcode::JUMPDEST => {
                     // just consume some gas, jumptable written at the start
                     if self.env.consumed_gas + gas_cost::JUMPDEST > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     self.env.consumed_gas += gas_cost::JUMPDEST
                 }
                 Opcode::PC => {
                     if self.env.consumed_gas + gas_cost::PC > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     current_call_frame
                         .stack
-                        .push(U256::from(current_call_frame.pc - 1));
+                        .push(U256::from(current_call_frame.pc - 1))?;
                     self.env.consumed_gas += gas_cost::PC
                 }
                 Opcode::BLOCKHASH => {
                     if self.env.consumed_gas + gas_cost::BLOCKHASH > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let block_number = current_call_frame.stack.pop().unwrap();
+                    let block_number = current_call_frame.stack.pop()?;
 
                     self.env.consumed_gas += gas_cost::BLOCKHASH;
                     // If number is not in the valid range (last 256 blocks), return zero.
@@ -682,218 +828,281 @@ impl VM {
                             .saturating_sub(U256::from(LAST_AVAILABLE_BLOCK_LIMIT))
                         || block_number >= self.env.block.number
                     {
-                        current_call_frame.stack.push(U256::zero());
+                        current_call_frame.stack.push(U256::zero())?;
                         continue;
                     }
 
                     if let Some(block_hash) = self.db.block_hashes.get(&block_number) {
                         current_call_frame
                             .stack
-                            .push(U256::from_big_endian(&block_hash.0));
+                            .push(U256::from_big_endian(&block_hash.0))?;
                     } else {
-                        current_call_frame.stack.push(U256::zero());
+                        current_call_frame.stack.push(U256::zero())?;
                     };
                 }
                 Opcode::COINBASE => {
                     if self.env.consumed_gas + gas_cost::COINBASE > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let coinbase = block_env.coinbase;
-                    current_call_frame.stack.push(address_to_word(coinbase));
+                    current_call_frame.stack.push(address_to_word(coinbase))?;
                     self.env.consumed_gas += gas_cost::COINBASE
                 }
                 Opcode::TIMESTAMP => {
                     if self.env.consumed_gas + gas_cost::TIMESTAMP > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let timestamp = block_env.timestamp;
-                    current_call_frame.stack.push(timestamp);
+                    current_call_frame.stack.push(timestamp)?;
                     self.env.consumed_gas += gas_cost::TIMESTAMP
                 }
                 Opcode::NUMBER => {
                     if self.env.consumed_gas + gas_cost::NUMBER > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let block_number = block_env.number;
-                    current_call_frame.stack.push(block_number);
+                    current_call_frame.stack.push(block_number)?;
                     self.env.consumed_gas += gas_cost::NUMBER
                 }
                 Opcode::PREVRANDAO => {
                     if self.env.consumed_gas + gas_cost::PREVRANDAO > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let randao = block_env.prev_randao.unwrap_or_default();
                     current_call_frame
                         .stack
-                        .push(U256::from_big_endian(randao.0.as_slice()));
+                        .push(U256::from_big_endian(randao.0.as_slice()))?;
                     self.env.consumed_gas += gas_cost::PREVRANDAO
                 }
                 Opcode::GASLIMIT => {
                     if self.env.consumed_gas + gas_cost::GASLIMIT > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let gas_limit = block_env.gas_limit;
-                    current_call_frame.stack.push(U256::from(gas_limit));
+                    current_call_frame.stack.push(U256::from(gas_limit))?;
                     self.env.consumed_gas += gas_cost::GASLIMIT
                 }
                 Opcode::CHAINID => {
                     if self.env.consumed_gas + gas_cost::CHAINID > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let chain_id = block_env.chain_id;
-                    current_call_frame.stack.push(U256::from(chain_id));
+                    current_call_frame.stack.push(U256::from(chain_id))?;
                     self.env.consumed_gas += gas_cost::CHAINID
                 }
                 Opcode::SELFBALANCE => {
                     if self.env.consumed_gas + gas_cost::SELFBALANCE > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     self.env.consumed_gas += gas_cost::SELFBALANCE;
                     todo!("when we have accounts implemented");
                 }
                 Opcode::BASEFEE => {
                     if self.env.consumed_gas + gas_cost::BASEFEE > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let base_fee = block_env.base_fee_per_gas;
-                    current_call_frame.stack.push(base_fee);
+                    current_call_frame.stack.push(base_fee)?;
                     self.env.consumed_gas += gas_cost::BASEFEE
                 }
                 Opcode::BLOBHASH => {
                     if self.env.consumed_gas + gas_cost::BLOBHASH > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     self.env.consumed_gas += gas_cost::BLOBHASH;
                     todo!("when we have tx implemented");
                 }
                 Opcode::BLOBBASEFEE => {
                     if self.env.consumed_gas + gas_cost::BLOBBASEFEE > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let blob_base_fee = block_env.calculate_blob_gas_price();
-                    current_call_frame.stack.push(blob_base_fee);
+                    current_call_frame.stack.push(blob_base_fee)?;
                     self.env.consumed_gas += gas_cost::BLOBBASEFEE
                 }
                 Opcode::PUSH0 => {
                     if self.env.consumed_gas + gas_cost::PUSH0 > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    current_call_frame.stack.push(U256::zero());
+                    current_call_frame.stack.push(U256::zero())?;
                     self.env.consumed_gas += gas_cost::PUSH0
                 }
                 // PUSHn
                 op if (Opcode::PUSH1..Opcode::PUSH32).contains(&op) => {
                     if self.env.consumed_gas + gas_cost::PUSHN > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let n_bytes = (op as u8) - (Opcode::PUSH1 as u8) + 1;
                     let next_n_bytes = current_call_frame
                         .bytecode
                         .get(current_call_frame.pc()..current_call_frame.pc() + n_bytes as usize)
-                        .expect("invalid bytecode");
+                        .ok_or(VMError::InvalidBytecode)?; // this shouldn't really happen during execution
                     let value_to_push = U256::from(next_n_bytes);
-                    current_call_frame.stack.push(value_to_push);
+                    current_call_frame.stack.push(value_to_push)?;
                     current_call_frame.increment_pc_by(n_bytes as usize);
                     self.env.consumed_gas += gas_cost::PUSHN
                 }
                 Opcode::PUSH32 => {
                     if self.env.consumed_gas + gas_cost::PUSHN > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let next_32_bytes = current_call_frame
                         .bytecode
                         .get(current_call_frame.pc()..current_call_frame.pc() + WORD_SIZE)
-                        .unwrap();
+                        .ok_or(VMError::InvalidBytecode)?;
                     let value_to_push = U256::from(next_32_bytes);
-                    current_call_frame.stack.push(value_to_push);
+                    current_call_frame.stack.push(value_to_push)?;
                     current_call_frame.increment_pc_by(WORD_SIZE);
                     self.env.consumed_gas += gas_cost::PUSHN
                 }
                 Opcode::AND => {
                     if self.env.consumed_gas + gas_cost::AND > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let a = current_call_frame.stack.pop().unwrap();
-                    let b = current_call_frame.stack.pop().unwrap();
-                    current_call_frame.stack.push(a & b);
+                    let a = current_call_frame.stack.pop()?;
+                    let b = current_call_frame.stack.pop()?;
+                    current_call_frame.stack.push(a & b)?;
                     self.env.consumed_gas += gas_cost::AND
                 }
                 Opcode::OR => {
                     if self.env.consumed_gas + gas_cost::OR > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let a = current_call_frame.stack.pop().unwrap();
-                    let b = current_call_frame.stack.pop().unwrap();
-                    current_call_frame.stack.push(a | b);
+                    let a = current_call_frame.stack.pop()?;
+                    let b = current_call_frame.stack.pop()?;
+                    current_call_frame.stack.push(a | b)?;
                     self.env.consumed_gas += gas_cost::OR
                 }
                 Opcode::XOR => {
                     if self.env.consumed_gas + gas_cost::XOR > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let a = current_call_frame.stack.pop().unwrap();
-                    let b = current_call_frame.stack.pop().unwrap();
-                    current_call_frame.stack.push(a ^ b);
+                    let a = current_call_frame.stack.pop()?;
+                    let b = current_call_frame.stack.pop()?;
+                    current_call_frame.stack.push(a ^ b)?;
                     self.env.consumed_gas += gas_cost::XOR
                 }
                 Opcode::NOT => {
                     if self.env.consumed_gas + gas_cost::NOT > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let a = current_call_frame.stack.pop().unwrap();
-                    current_call_frame.stack.push(!a);
+                    let a = current_call_frame.stack.pop()?;
+                    current_call_frame.stack.push(!a)?;
                     self.env.consumed_gas += gas_cost::NOT
                 }
                 Opcode::BYTE => {
                     if self.env.consumed_gas + gas_cost::BYTE > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let op1 = current_call_frame.stack.pop().unwrap();
-                    let op2 = current_call_frame.stack.pop().unwrap();
+                    let op1 = current_call_frame.stack.pop()?;
+                    let op2 = current_call_frame.stack.pop()?;
 
                     let byte_index = op1.try_into().unwrap_or(usize::MAX);
 
                     if byte_index < WORD_SIZE {
                         current_call_frame
                             .stack
-                            .push(U256::from(op2.byte(WORD_SIZE - 1 - byte_index)));
+                            .push(U256::from(op2.byte(WORD_SIZE - 1 - byte_index)))?;
                     } else {
-                        current_call_frame.stack.push(U256::zero());
+                        current_call_frame.stack.push(U256::zero())?;
                     }
                     self.env.consumed_gas += gas_cost::BYTE
                 }
                 Opcode::SHL => {
                     if self.env.consumed_gas + gas_cost::SHL > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let shift = current_call_frame.stack.pop().unwrap();
-                    let value = current_call_frame.stack.pop().unwrap();
+                    let shift = current_call_frame.stack.pop()?;
+                    let value = current_call_frame.stack.pop()?;
                     if shift < U256::from(256) {
-                        current_call_frame.stack.push(value << shift);
+                        current_call_frame.stack.push(value << shift)?;
                     } else {
-                        current_call_frame.stack.push(U256::zero());
+                        current_call_frame.stack.push(U256::zero())?;
                     }
                     self.env.consumed_gas += gas_cost::SHL
                 }
                 Opcode::SHR => {
                     if self.env.consumed_gas + gas_cost::SHR > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let shift = current_call_frame.stack.pop().unwrap();
-                    let value = current_call_frame.stack.pop().unwrap();
+                    let shift = current_call_frame.stack.pop()?;
+                    let value = current_call_frame.stack.pop()?;
                     if shift < U256::from(256) {
-                        current_call_frame.stack.push(value >> shift);
+                        current_call_frame.stack.push(value >> shift)?;
                     } else {
-                        current_call_frame.stack.push(U256::zero());
+                        current_call_frame.stack.push(U256::zero())?;
                     }
                     self.env.consumed_gas += gas_cost::SHR
                 }
                 Opcode::SAR => {
                     if self.env.consumed_gas + gas_cost::SAR > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let shift = current_call_frame.stack.pop().unwrap();
-                    let value = current_call_frame.stack.pop().unwrap();
+                    let shift = current_call_frame.stack.pop()?;
+                    let value = current_call_frame.stack.pop()?;
                     let res = if shift < U256::from(256) {
                         arithmetic_shift_right(value, shift)
                     } else if value.bit(255) {
@@ -901,38 +1110,46 @@ impl VM {
                     } else {
                         U256::zero()
                     };
-                    current_call_frame.stack.push(res);
+                    current_call_frame.stack.push(res)?;
                     self.env.consumed_gas += gas_cost::SAR
                 }
                 // DUPn
                 op if (Opcode::DUP1..=Opcode::DUP16).contains(&op) => {
                     if self.env.consumed_gas + gas_cost::DUPN > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let depth = (op as u8) - (Opcode::DUP1 as u8) + 1;
-                    assert!(
-                        current_call_frame.stack.len().ge(&(depth as usize)),
-                        "stack underflow: not enough values on the stack"
-                    );
+
+                    if current_call_frame.stack.len() < depth as usize {
+                        return Err(VMError::StackUnderflow);
+                    }
+
                     let value_at_depth = current_call_frame
                         .stack
-                        .get(current_call_frame.stack.len() - depth as usize)
-                        .unwrap();
-                    current_call_frame.stack.push(*value_at_depth);
+                        .get(current_call_frame.stack.len() - depth as usize)?;
+                    current_call_frame.stack.push(*value_at_depth)?;
                     self.env.consumed_gas += gas_cost::DUPN
                 }
                 // SWAPn
                 op if (Opcode::SWAP1..=Opcode::SWAP16).contains(&op) => {
                     if self.env.consumed_gas + gas_cost::SWAPN > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let depth = (op as u8) - (Opcode::SWAP1 as u8) + 1;
-                    assert!(
-                        current_call_frame.stack.len().ge(&(depth as usize)),
-                        "stack underflow: not enough values on the stack"
-                    );
+
+                    if current_call_frame.stack.len() < depth as usize {
+                        return Err(VMError::StackUnderflow);
+                    }
                     let stack_top_index = current_call_frame.stack.len();
-                    let to_swap_index = stack_top_index.checked_sub(depth as usize).unwrap();
+                    let to_swap_index = stack_top_index
+                        .checked_sub(depth as usize)
+                        .ok_or(VMError::StackUnderflow)?;
                     current_call_frame
                         .stack
                         .swap(stack_top_index - 1, to_swap_index - 1);
@@ -940,34 +1157,47 @@ impl VM {
                 }
                 Opcode::POP => {
                     if self.env.consumed_gas + gas_cost::POP > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    current_call_frame.stack.pop().unwrap();
+                    current_call_frame.stack.pop()?;
                     self.env.consumed_gas += gas_cost::POP
                 }
                 op if (Opcode::LOG0..=Opcode::LOG4).contains(&op) => {
                     if current_call_frame.is_static {
-                        panic!("Cannot create log in static context"); // should return an error and halt
+                        return Err(VMError::OpcodeNotAllowedInStaticContext);
                     }
 
-                    let topic_count = (op as u8) - (Opcode::LOG0 as u8);
-                    let offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let size = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let topics = (0..topic_count)
-                        .map(|_| {
-                            let topic = current_call_frame.stack.pop().unwrap().as_u32();
-                            H32::from_slice(topic.to_be_bytes().as_ref())
-                        })
-                        .collect();
+                    let number_of_topics = (op as u8) - (Opcode::LOG0 as u8);
+                    let offset = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let size = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let mut topics = Vec::new();
+                    for _ in 0..number_of_topics {
+                        let topic = current_call_frame.stack.pop()?.as_u32();
+                        topics.push(H32::from_slice(topic.to_be_bytes().as_ref()));
+                    }
 
                     let memory_expansion_cost =
                         current_call_frame.memory.expansion_cost(offset + size) as u64;
                     let gas_cost = gas_cost::LOGN_STATIC
-                        + gas_cost::LOGN_DYNAMIC_BASE * topic_count as u64
+                        + gas_cost::LOGN_DYNAMIC_BASE * number_of_topics as u64
                         + gas_cost::LOGN_DYNAMIC_BYTE_BASE * size as u64
                         + memory_expansion_cost;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
 
                     let data = current_call_frame.memory.load_range(offset, size);
@@ -980,28 +1210,38 @@ impl VM {
                     self.env.consumed_gas += gas_cost
                 }
                 Opcode::MLOAD => {
-                    let offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                    let offset = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
                     let memory_expansion_cost =
                         current_call_frame.memory.expansion_cost(offset + WORD_SIZE);
                     let gas_cost = gas_cost::MLOAD_STATIC + memory_expansion_cost as u64;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
 
                     let value = current_call_frame.memory.load(offset);
-                    current_call_frame.stack.push(value);
+                    current_call_frame.stack.push(value)?;
                     self.env.consumed_gas += gas_cost
                 }
                 Opcode::MSTORE => {
-                    let offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                    let offset = current_call_frame.stack.pop()?.try_into().unwrap();
                     let memory_expansion_cost =
                         current_call_frame.memory.expansion_cost(offset + WORD_SIZE);
                     let gas_cost = gas_cost::MSTORE_STATIC + memory_expansion_cost as u64;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
 
-                    let value = current_call_frame.stack.pop().unwrap();
+                    let value = current_call_frame.stack.pop()?;
                     let mut value_bytes = [0u8; WORD_SIZE];
                     value.to_big_endian(&mut value_bytes);
 
@@ -1009,15 +1249,18 @@ impl VM {
                     self.env.consumed_gas += gas_cost
                 }
                 Opcode::MSTORE8 => {
-                    let offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                    let offset = current_call_frame.stack.pop()?.try_into().unwrap();
                     let memory_expansion_cost =
                         current_call_frame.memory.expansion_cost(offset + 1);
                     let gas_cost = gas_cost::MSTORE8_STATIC + memory_expansion_cost as u64;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
 
-                    let value = current_call_frame.stack.pop().unwrap();
+                    let value = current_call_frame.stack.pop()?;
                     let mut value_bytes = [0u8; WORD_SIZE];
                     value.to_big_endian(&mut value_bytes);
 
@@ -1027,7 +1270,7 @@ impl VM {
                     self.env.consumed_gas += gas_cost
                 }
                 Opcode::SLOAD => {
-                    let key = current_call_frame.stack.pop().unwrap();
+                    let key = current_call_frame.stack.pop()?;
                     let address = if let Some(delegate) = current_call_frame.delegate {
                         delegate
                     } else {
@@ -1039,15 +1282,15 @@ impl VM {
                         .read_account_storage(&address, &key)
                         .unwrap_or_default()
                         .current_value;
-                    current_call_frame.stack.push(current_value);
+                    current_call_frame.stack.push(current_value)?;
                 }
                 Opcode::SSTORE => {
                     if current_call_frame.is_static {
                         panic!("Cannot write to storage in a static context");
                     }
 
-                    let key = current_call_frame.stack.pop().unwrap();
-                    let value = current_call_frame.stack.pop().unwrap();
+                    let key = current_call_frame.stack.pop()?;
+                    let value = current_call_frame.stack.pop()?;
                     // maybe we need the journal struct as accessing the Db could be slow, with the journal
                     // we can have prefetched values directly in memory and only commits the values to the db once everything is done
 
@@ -1074,26 +1317,43 @@ impl VM {
                 }
                 Opcode::MSIZE => {
                     if self.env.consumed_gas + gas_cost::MSIZE > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     current_call_frame
                         .stack
-                        .push(current_call_frame.memory.size());
+                        .push(current_call_frame.memory.size())?;
                     self.env.consumed_gas += gas_cost::MSIZE
                 }
                 Opcode::GAS => {
                     if self.env.consumed_gas + gas_cost::GAS > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     let remaining_gas = self.env.gas_limit - self.env.consumed_gas - gas_cost::GAS;
-                    current_call_frame.stack.push(remaining_gas.into());
+                    current_call_frame.stack.push(remaining_gas.into())?;
                     self.env.consumed_gas += gas_cost::GAS
                 }
                 Opcode::MCOPY => {
-                    let dest_offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let src_offset: usize =
-                        current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let size: usize = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                    let dest_offset = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let src_offset: usize = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let size: usize = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
 
                     let words_copied = (size + WORD_SIZE - 1) / WORD_SIZE;
                     let memory_byte_size = (src_offset + size).max(dest_offset + size);
@@ -1112,16 +1372,30 @@ impl VM {
                         .copy(src_offset, dest_offset, size);
                 }
                 Opcode::CALL => {
-                    let gas = current_call_frame.stack.pop().unwrap();
+                    let gas = current_call_frame.stack.pop()?;
                     let code_address =
-                        Address::from_low_u64_be(current_call_frame.stack.pop().unwrap().low_u64());
-                    let value = current_call_frame.stack.pop().unwrap();
-                    let args_offset: usize =
-                        current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let args_size: usize =
-                        current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let ret_offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let ret_size = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                        Address::from_low_u64_be(current_call_frame.stack.pop()?.low_u64());
+                    let value = current_call_frame.stack.pop()?;
+                    let args_offset = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let args_size = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let ret_offset = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let ret_size = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
 
                     let memory_byte_size = (args_offset + args_size).max(ret_offset + ret_size);
                     let memory_expansion_cost =
@@ -1152,7 +1426,10 @@ impl VM {
                         + positive_value_cost
                         + value_to_empty_account_cost;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
 
                     self.accrued_substate.warm_addresses.insert(code_address);
@@ -1175,18 +1452,18 @@ impl VM {
                         args_size,
                         ret_offset,
                         ret_size,
-                    );
+                    )?;
                 }
                 Opcode::CALLCODE => {
                     // Creates a new sub context as if calling itself, but with the code of the given account. In particular the storage remains the same. Note that an account with no code will return success as true.
-                    let gas = current_call_frame.stack.pop().unwrap();
+                    let gas = current_call_frame.stack.pop()?;
                     let code_address =
-                        Address::from_low_u64_be(current_call_frame.stack.pop().unwrap().low_u64());
-                    let value = current_call_frame.stack.pop().unwrap();
-                    let args_offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let args_size = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let ret_offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let ret_size = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                        Address::from_low_u64_be(current_call_frame.stack.pop()?.low_u64());
+                    let value = current_call_frame.stack.pop()?;
+                    let args_offset = current_call_frame.stack.pop()?.try_into().unwrap();
+                    let args_size = current_call_frame.stack.pop()?.try_into().unwrap();
+                    let ret_offset = current_call_frame.stack.pop()?.try_into().unwrap();
+                    let ret_size = current_call_frame.stack.pop()?.try_into().unwrap();
 
                     let msg_sender = current_call_frame.msg_sender; // msg_sender is changed to the proxy's address
                     let to = current_call_frame.to; // to remains the same
@@ -1206,47 +1483,50 @@ impl VM {
                         args_size,
                         ret_offset,
                         ret_size,
-                    );
+                    )?;
                 }
                 Opcode::RETURN => {
-                    let offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let size = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                    let offset = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
+                    let size = current_call_frame
+                        .stack
+                        .pop()?
+                        .try_into()
+                        .unwrap_or(usize::MAX);
 
                     let gas_cost = current_call_frame.memory.expansion_cost(offset + size) as u64;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
-                        break; // should revert the tx
-                    }
-                    let return_data = current_call_frame.memory.load_range(offset, size).into();
-                    if let Some(mut parent_call_frame) = self.call_frames.pop() {
-                        if let (Some(_ret_offset), Some(_ret_size)) = (
-                            parent_call_frame.return_data_offset,
-                            parent_call_frame.return_data_size,
-                        ) {
-                            parent_call_frame.returndata = return_data;
-                        }
-                        parent_call_frame.stack.push(U256::from(SUCCESS_FOR_RETURN));
-                        parent_call_frame.return_data_offset = None;
-                        parent_call_frame.return_data_size = None;
-                        current_call_frame = parent_call_frame.clone();
-                    } else {
-                        // excecution completed (?)
-                        current_call_frame
-                            .stack
-                            .push(U256::from(SUCCESS_FOR_RETURN));
-                        break;
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
                     self.env.consumed_gas += gas_cost;
+                    let return_data = current_call_frame.memory.load_range(offset, size).into();
+
+                    current_call_frame.returndata = return_data;
+                    current_call_frame
+                        .stack
+                        .push(U256::from(SUCCESS_FOR_RETURN))?;
+
+                    return Ok(Self::write_success_result(
+                        current_call_frame,
+                        ResultReason::Return,
+                    ));
                 }
                 Opcode::DELEGATECALL => {
                     // The delegatecall executes the setVars(uint256) code from Contract B but updates Contract A’s storage. The execution has the same storage, msg.sender & msg.value as its parent call setVarsDelegateCall.
                     // Creates a new sub context as if calling itself, but with the code of the given account. In particular the storage, the current sender and the current value remain the same. Note that an account with no code will return success as true.
-                    let gas = current_call_frame.stack.pop().unwrap();
+                    let gas = current_call_frame.stack.pop()?;
                     let code_address =
-                        Address::from_low_u64_be(current_call_frame.stack.pop().unwrap().low_u64());
-                    let args_offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let args_size = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let ret_offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let ret_size = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                        Address::from_low_u64_be(current_call_frame.stack.pop()?.low_u64());
+                    let args_offset = current_call_frame.stack.pop()?.try_into().unwrap();
+                    let args_size = current_call_frame.stack.pop()?.try_into().unwrap();
+                    let ret_offset = current_call_frame.stack.pop()?.try_into().unwrap();
+                    let ret_size = current_call_frame.stack.pop()?.try_into().unwrap();
 
                     let value = current_call_frame.msg_value; // value remains the same
                     let msg_sender = current_call_frame.msg_sender; // caller remains the msg_sender
@@ -1267,17 +1547,17 @@ impl VM {
                         args_size,
                         ret_offset,
                         ret_size,
-                    );
+                    )?;
                 }
                 Opcode::STATICCALL => {
                     // it cannot be used to transfer Ether
-                    let gas = current_call_frame.stack.pop().unwrap();
+                    let gas = current_call_frame.stack.pop()?;
                     let code_address =
-                        Address::from_low_u64_be(current_call_frame.stack.pop().unwrap().low_u64());
-                    let args_offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let args_size = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let ret_offset = current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let ret_size = current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                        Address::from_low_u64_be(current_call_frame.stack.pop()?.low_u64());
+                    let args_offset = current_call_frame.stack.pop()?.try_into().unwrap();
+                    let args_size = current_call_frame.stack.pop()?.try_into().unwrap();
+                    let ret_offset = current_call_frame.stack.pop()?.try_into().unwrap();
+                    let ret_size = current_call_frame.stack.pop()?.try_into().unwrap();
 
                     let msg_sender = current_call_frame.msg_sender; // caller remains the msg_sender
                     let value = current_call_frame.msg_value;
@@ -1296,14 +1576,12 @@ impl VM {
                         args_size,
                         ret_offset,
                         ret_size,
-                    );
+                    )?;
                 }
                 Opcode::CREATE => {
-                    let value_in_wei_to_send = current_call_frame.stack.pop().unwrap();
-                    let code_offset_in_memory =
-                        current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let code_size_in_memory =
-                        current_call_frame.stack.pop().unwrap().try_into().unwrap();
+                    let value_in_wei_to_send = current_call_frame.stack.pop()?;
+                    let code_offset_in_memory = current_call_frame.stack.pop()?.try_into().unwrap();
+                    let code_size_in_memory = current_call_frame.stack.pop()?.try_into().unwrap();
 
                     self.create(
                         value_in_wei_to_send,
@@ -1311,15 +1589,13 @@ impl VM {
                         code_size_in_memory,
                         None,
                         &mut current_call_frame,
-                    );
+                    )?;
                 }
                 Opcode::CREATE2 => {
-                    let value_in_wei_to_send = current_call_frame.stack.pop().unwrap();
-                    let code_offset_in_memory =
-                        current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let code_size_in_memory =
-                        current_call_frame.stack.pop().unwrap().try_into().unwrap();
-                    let salt = current_call_frame.stack.pop().unwrap();
+                    let value_in_wei_to_send = current_call_frame.stack.pop()?;
+                    let code_offset_in_memory = current_call_frame.stack.pop()?.try_into().unwrap();
+                    let code_size_in_memory = current_call_frame.stack.pop()?.try_into().unwrap();
+                    let salt = current_call_frame.stack.pop()?;
 
                     self.create(
                         value_in_wei_to_send,
@@ -1327,39 +1603,43 @@ impl VM {
                         code_size_in_memory,
                         Some(salt),
                         &mut current_call_frame,
-                    );
+                    )?;
                 }
                 Opcode::TLOAD => {
                     if self.env.consumed_gas + gas_cost::TLOAD > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let key = current_call_frame.stack.pop().unwrap();
+                    let key = current_call_frame.stack.pop()?;
                     let value = current_call_frame
                         .transient_storage
                         .get(&(current_call_frame.msg_sender, key))
                         .cloned()
                         .unwrap_or(U256::zero());
 
-                    current_call_frame.stack.push(value);
+                    current_call_frame.stack.push(value)?;
                     self.env.consumed_gas += gas_cost::TLOAD
                 }
                 Opcode::TSTORE => {
                     if self.env.consumed_gas + gas_cost::TSTORE > self.env.gas_limit {
-                        break; // should revert the tx
+                        return Ok(ExecutionResult::Revert {
+                            gas_used: self.env.consumed_gas,
+                            output: current_call_frame.returndata,
+                        }); // should revert the tx
                     }
-                    let key = current_call_frame.stack.pop().unwrap();
-                    let value = current_call_frame.stack.pop().unwrap();
+                    let key = current_call_frame.stack.pop()?;
+                    let value = current_call_frame.stack.pop()?;
 
                     current_call_frame
                         .transient_storage
                         .insert((current_call_frame.msg_sender, key), value);
                     self.env.consumed_gas += gas_cost::TSTORE
                 }
-                _ => unimplemented!(),
+                _ => return Err(VMError::OpcodeNotFound),
             }
         }
-        // self.consumed_gas = tx_env.consumed_gas;
-        self.call_frames.push(current_call_frame);
     }
 
     pub fn current_call_frame_mut(&mut self) -> &mut CallFrame {
@@ -1386,22 +1666,25 @@ impl VM {
         args_size: usize,
         ret_offset: usize,
         ret_size: usize,
-    ) {
+    ) -> Result<(), VMError> {
         // check balance
         if self.db.balance(&current_call_frame.msg_sender) < value {
-            current_call_frame.stack.push(U256::from(REVERT_FOR_CALL));
-            return;
+            current_call_frame.stack.push(U256::from(REVERT_FOR_CALL))?;
+            return Ok(());
         }
 
         // transfer value
         // transfer(&current_call_frame.msg_sender, &address, value);
 
-        let callee_bytecode = self.db.get_account_bytecode(&code_address);
-
-        if callee_bytecode.is_empty() {
-            current_call_frame.stack.push(U256::from(SUCCESS_FOR_CALL));
-            return;
+        let code_address_bytecode = self.db.get_account_bytecode(&code_address);
+        if code_address_bytecode.is_empty() {
+            current_call_frame
+                .stack
+                .push(U256::from(SUCCESS_FOR_CALL))?;
+            return Ok(());
         }
+
+        self.db.increment_account_nonce(&code_address);
 
         let calldata = current_call_frame
             .memory
@@ -1409,22 +1692,52 @@ impl VM {
             .into();
 
         let new_call_frame = CallFrame::new(
-            gas,
             msg_sender,
             to,
             code_address,
             delegate,
-            callee_bytecode,
+            code_address_bytecode,
             value,
             calldata,
             is_static,
+            gas,
+            current_call_frame.depth + 1,
         );
 
         current_call_frame.return_data_offset = Some(ret_offset);
         current_call_frame.return_data_size = Some(ret_size);
 
-        self.call_frames.push(current_call_frame.clone());
-        *current_call_frame = new_call_frame;
+        self.call_frames.push(new_call_frame.clone());
+        let result = self.execute();
+
+        match result {
+            Ok(ExecutionResult::Success {
+                logs, return_data, ..
+            }) => {
+                current_call_frame.logs.extend(logs);
+                current_call_frame
+                    .memory
+                    .store_bytes(ret_offset, &return_data);
+                current_call_frame.returndata = return_data;
+                current_call_frame
+                    .stack
+                    .push(U256::from(SUCCESS_FOR_CALL))?;
+            }
+            Ok(ExecutionResult::Revert { gas_used, output }) => {
+                current_call_frame.memory.store_bytes(ret_offset, &output);
+                current_call_frame.returndata = output;
+                current_call_frame.stack.push(U256::from(REVERT_FOR_CALL))?;
+                current_call_frame.gas -= U256::from(gas_used);
+            }
+            Ok(ExecutionResult::Halt { reason, gas_used }) => {
+                current_call_frame.stack.push(U256::from(reason as u8))?;
+                current_call_frame.gas -= U256::from(gas_used);
+            }
+            Err(_) => {
+                current_call_frame.stack.push(U256::from(HALT_FOR_CALL))?;
+            }
+        };
+        Ok(())
     }
 
     /// Calculates the address of a new conctract using the CREATE opcode as follow
@@ -1472,14 +1785,18 @@ impl VM {
         code_size_in_memory: usize,
         salt: Option<U256>,
         current_call_frame: &mut CallFrame,
-    ) {
+    ) -> Result<(), VMError> {
         if code_size_in_memory > MAX_CODE_SIZE * 2 {
-            current_call_frame.stack.push(U256::from(REVERT_FOR_CREATE));
-            return;
+            current_call_frame
+                .stack
+                .push(U256::from(REVERT_FOR_CREATE))?;
+            return Ok(());
         }
         if current_call_frame.is_static {
-            current_call_frame.stack.push(U256::from(REVERT_FOR_CREATE));
-            return;
+            current_call_frame
+                .stack
+                .push(U256::from(REVERT_FOR_CREATE))?;
+            return Ok(());
         }
 
         let sender_account = self
@@ -1489,13 +1806,17 @@ impl VM {
             .unwrap();
 
         if sender_account.balance < value_in_wei_to_send {
-            current_call_frame.stack.push(U256::from(REVERT_FOR_CREATE));
-            return;
+            current_call_frame
+                .stack
+                .push(U256::from(REVERT_FOR_CREATE))?;
+            return Ok(());
         }
 
         let Some(new_nonce) = sender_account.nonce.checked_add(1) else {
-            current_call_frame.stack.push(U256::from(REVERT_FOR_CREATE));
-            return;
+            current_call_frame
+                .stack
+                .push(U256::from(REVERT_FOR_CREATE))?;
+            return Ok(());
         };
         sender_account.nonce = new_nonce;
         sender_account.balance -= value_in_wei_to_send;
@@ -1515,36 +1836,63 @@ impl VM {
         };
 
         if self.db.accounts.contains_key(&new_address) {
-            current_call_frame.stack.push(U256::from(REVERT_FOR_CREATE));
-            return;
+            current_call_frame
+                .stack
+                .push(U256::from(REVERT_FOR_CREATE))?;
+            return Ok(());
         }
-        // nonce == 1, as we will execute this contract right now
-        let new_account = Account::new(value_in_wei_to_send, code.clone(), 1, Default::default());
+
+        let new_account = Account::new(
+            new_address,
+            value_in_wei_to_send,
+            code.clone(),
+            0,
+            Default::default(),
+        );
         self.db.add_account(new_address, new_account);
 
         let mut gas = current_call_frame.gas;
         gas -= gas / 64; // 63/64 of the gas to the call
         current_call_frame.gas -= gas; // leaves 1/64  of the gas to current call frame
 
-        let new_call_frame = CallFrame::new(
+        // let new_call_frame = CallFrame::new(
+        //     current_call_frame.msg_sender,
+        //     new_address,
+        //     new_address,
+        //     None,
+        //     code,
+        //     value_in_wei_to_send,
+        //     Bytes::new(),
+        //     false,
+        //     gas,
+        //     0,
+        // );
+
+        // current_call_frame.return_data_offset = Some(code_offset_in_memory);
+        // current_call_frame.return_data_size = Some(code_size_in_memory);
+
+        current_call_frame
+            .stack
+            .push(address_to_word(new_address))?;
+
+        // self.call_frames.push(current_call_frame.clone());
+        // *current_call_frame = new_call_frame;
+        // Ok(())
+        self.generic_call(
+            current_call_frame,
             gas,
+            value_in_wei_to_send,
             current_call_frame.msg_sender,
             new_address,
             new_address,
             None,
-            code,
-            value_in_wei_to_send,
-            Bytes::new(),
+            true,
             false,
-        );
-
-        current_call_frame.return_data_offset = Some(code_offset_in_memory);
-        current_call_frame.return_data_size = Some(code_size_in_memory);
-
-        current_call_frame.stack.push(address_to_word(new_address));
-
-        self.call_frames.push(current_call_frame.clone());
-        *current_call_frame = new_call_frame;
+            code_offset_in_memory,
+            code_size_in_memory,
+            code_offset_in_memory,
+            code_size_in_memory,
+        )
     }
 }
 

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -1861,29 +1861,10 @@ impl VM {
         gas -= gas / 64; // 63/64 of the gas to the call
         current_call_frame.gas -= gas; // leaves 1/64  of the gas to current call frame
 
-        // let new_call_frame = CallFrame::new(
-        //     current_call_frame.msg_sender,
-        //     new_address,
-        //     new_address,
-        //     None,
-        //     code,
-        //     value_in_wei_to_send,
-        //     Bytes::new(),
-        //     false,
-        //     gas,
-        //     0,
-        // );
-
-        // current_call_frame.return_data_offset = Some(code_offset_in_memory);
-        // current_call_frame.return_data_size = Some(code_size_in_memory);
-
         current_call_frame
             .stack
             .push(address_to_word(new_address))?;
 
-        // self.call_frames.push(current_call_frame.clone());
-        // *current_call_frame = new_call_frame;
-        // Ok(())
         self.generic_call(
             current_call_frame,
             gas,

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -774,7 +774,10 @@ impl VM {
 
                     if !current_call_frame.jump(jump_address) {
                         self.env.consumed_gas = self.env.gas_limit;
-                        return Err(VMError::InvalidJump);
+                        return Ok(ExecutionResult::Halt {
+                            reason: VMError::InvalidJump,
+                            gas_used: self.env.consumed_gas,
+                        }); // halt
                     }
                     self.env.consumed_gas += gas_cost::JUMP;
                 }
@@ -783,7 +786,10 @@ impl VM {
                     let condition = current_call_frame.stack.pop()?;
                     if condition != U256::zero() && !current_call_frame.jump(jump_address) {
                         self.env.consumed_gas = self.env.gas_limit;
-                        return Err(VMError::InvalidJump);
+                        return Ok(ExecutionResult::Halt {
+                            reason: VMError::InvalidJump,
+                            gas_used: self.env.consumed_gas,
+                        }); // halt
                     }
                     self.env.consumed_gas += gas_cost::JUMPI
                 }

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -249,6 +249,7 @@ impl VM {
                 Opcode::ADD => {
                     if self.env.consumed_gas + gas_cost::ADD > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -262,6 +263,7 @@ impl VM {
                 Opcode::MUL => {
                     if self.env.consumed_gas + gas_cost::MUL > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -275,6 +277,7 @@ impl VM {
                 Opcode::SUB => {
                     if self.env.consumed_gas + gas_cost::SUB > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -288,6 +291,7 @@ impl VM {
                 Opcode::DIV => {
                     if self.env.consumed_gas + gas_cost::DIV > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -305,6 +309,7 @@ impl VM {
                 Opcode::SDIV => {
                     if self.env.consumed_gas + gas_cost::SDIV > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -342,6 +347,7 @@ impl VM {
                 Opcode::MOD => {
                     if self.env.consumed_gas + gas_cost::MOD > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -359,6 +365,7 @@ impl VM {
                 Opcode::SMOD => {
                     if self.env.consumed_gas + gas_cost::SMOD > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -396,6 +403,7 @@ impl VM {
                 Opcode::ADDMOD => {
                     if self.env.consumed_gas + gas_cost::ADDMOD > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -419,6 +427,7 @@ impl VM {
                 Opcode::MULMOD => {
                     if self.env.consumed_gas + gas_cost::MULMOD > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -457,6 +466,7 @@ impl VM {
                         gas_cost::EXP_STATIC + gas_cost::EXP_DYNAMIC_BASE * exponent_byte_size;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -469,6 +479,7 @@ impl VM {
                 Opcode::SIGNEXTEND => {
                     if self.env.consumed_gas + gas_cost::SIGNEXTEND > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -495,6 +506,7 @@ impl VM {
                 Opcode::LT => {
                     if self.env.consumed_gas + gas_cost::LT > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -508,6 +520,7 @@ impl VM {
                 Opcode::GT => {
                     if self.env.consumed_gas + gas_cost::GT > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -521,6 +534,7 @@ impl VM {
                 Opcode::SLT => {
                     if self.env.consumed_gas + gas_cost::SLT > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -550,6 +564,7 @@ impl VM {
                 Opcode::SGT => {
                     if self.env.consumed_gas + gas_cost::SGT > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -579,6 +594,7 @@ impl VM {
                 Opcode::EQ => {
                     if self.env.consumed_gas + gas_cost::EQ > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -596,6 +612,7 @@ impl VM {
                 Opcode::ISZERO => {
                     if self.env.consumed_gas + gas_cost::ISZERO > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -629,6 +646,7 @@ impl VM {
                         + memory_expansion_cost as u64;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -647,6 +665,7 @@ impl VM {
                 Opcode::CALLDATALOAD => {
                     if self.env.consumed_gas + gas_cost::CALLDATALOAD > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -665,6 +684,7 @@ impl VM {
                 Opcode::CALLDATASIZE => {
                     if self.env.consumed_gas + gas_cost::CALLDATASIZE > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -699,6 +719,7 @@ impl VM {
                         + memory_expansion_cost;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -716,6 +737,7 @@ impl VM {
                 Opcode::RETURNDATASIZE => {
                     if self.env.consumed_gas + gas_cost::RETURNDATASIZE > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -750,6 +772,7 @@ impl VM {
                         + memory_expansion_cost;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -766,6 +789,7 @@ impl VM {
                 Opcode::JUMP => {
                     if self.env.consumed_gas + gas_cost::JUMP > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -797,6 +821,7 @@ impl VM {
                     // just consume some gas, jumptable written at the start
                     if self.env.consumed_gas + gas_cost::JUMPDEST > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -806,6 +831,7 @@ impl VM {
                 Opcode::PC => {
                     if self.env.consumed_gas + gas_cost::PC > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -818,6 +844,7 @@ impl VM {
                 Opcode::BLOCKHASH => {
                     if self.env.consumed_gas + gas_cost::BLOCKHASH > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -849,6 +876,7 @@ impl VM {
                 Opcode::COINBASE => {
                     if self.env.consumed_gas + gas_cost::COINBASE > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -860,6 +888,7 @@ impl VM {
                 Opcode::TIMESTAMP => {
                     if self.env.consumed_gas + gas_cost::TIMESTAMP > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -871,6 +900,7 @@ impl VM {
                 Opcode::NUMBER => {
                     if self.env.consumed_gas + gas_cost::NUMBER > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -882,6 +912,7 @@ impl VM {
                 Opcode::PREVRANDAO => {
                     if self.env.consumed_gas + gas_cost::PREVRANDAO > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -895,6 +926,7 @@ impl VM {
                 Opcode::GASLIMIT => {
                     if self.env.consumed_gas + gas_cost::GASLIMIT > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -906,6 +938,7 @@ impl VM {
                 Opcode::CHAINID => {
                     if self.env.consumed_gas + gas_cost::CHAINID > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -917,6 +950,7 @@ impl VM {
                 Opcode::SELFBALANCE => {
                     if self.env.consumed_gas + gas_cost::SELFBALANCE > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -927,6 +961,7 @@ impl VM {
                 Opcode::BASEFEE => {
                     if self.env.consumed_gas + gas_cost::BASEFEE > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -938,6 +973,7 @@ impl VM {
                 Opcode::BLOBHASH => {
                     if self.env.consumed_gas + gas_cost::BLOBHASH > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -948,6 +984,7 @@ impl VM {
                 Opcode::BLOBBASEFEE => {
                     if self.env.consumed_gas + gas_cost::BLOBBASEFEE > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -959,6 +996,7 @@ impl VM {
                 Opcode::PUSH0 => {
                     if self.env.consumed_gas + gas_cost::PUSH0 > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -970,6 +1008,7 @@ impl VM {
                 op if (Opcode::PUSH1..Opcode::PUSH32).contains(&op) => {
                     if self.env.consumed_gas + gas_cost::PUSHN > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -987,6 +1026,7 @@ impl VM {
                 Opcode::PUSH32 => {
                     if self.env.consumed_gas + gas_cost::PUSHN > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1003,6 +1043,7 @@ impl VM {
                 Opcode::AND => {
                     if self.env.consumed_gas + gas_cost::AND > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1015,6 +1056,7 @@ impl VM {
                 Opcode::OR => {
                     if self.env.consumed_gas + gas_cost::OR > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1027,6 +1069,7 @@ impl VM {
                 Opcode::XOR => {
                     if self.env.consumed_gas + gas_cost::XOR > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1039,6 +1082,7 @@ impl VM {
                 Opcode::NOT => {
                     if self.env.consumed_gas + gas_cost::NOT > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1050,6 +1094,7 @@ impl VM {
                 Opcode::BYTE => {
                     if self.env.consumed_gas + gas_cost::BYTE > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1071,6 +1116,7 @@ impl VM {
                 Opcode::SHL => {
                     if self.env.consumed_gas + gas_cost::SHL > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1087,6 +1133,7 @@ impl VM {
                 Opcode::SHR => {
                     if self.env.consumed_gas + gas_cost::SHR > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1103,6 +1150,7 @@ impl VM {
                 Opcode::SAR => {
                     if self.env.consumed_gas + gas_cost::SAR > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1123,6 +1171,7 @@ impl VM {
                 op if (Opcode::DUP1..=Opcode::DUP16).contains(&op) => {
                     if self.env.consumed_gas + gas_cost::DUPN > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1143,6 +1192,7 @@ impl VM {
                 op if (Opcode::SWAP1..=Opcode::SWAP16).contains(&op) => {
                     if self.env.consumed_gas + gas_cost::SWAPN > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1164,6 +1214,7 @@ impl VM {
                 Opcode::POP => {
                     if self.env.consumed_gas + gas_cost::POP > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1201,6 +1252,7 @@ impl VM {
                         + memory_expansion_cost;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1226,6 +1278,7 @@ impl VM {
                     let gas_cost = gas_cost::MLOAD_STATIC + memory_expansion_cost as u64;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1242,6 +1295,7 @@ impl VM {
                     let gas_cost = gas_cost::MSTORE_STATIC + memory_expansion_cost as u64;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1261,6 +1315,7 @@ impl VM {
                     let gas_cost = gas_cost::MSTORE8_STATIC + memory_expansion_cost as u64;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1324,6 +1379,7 @@ impl VM {
                 Opcode::MSIZE => {
                     if self.env.consumed_gas + gas_cost::MSIZE > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1336,6 +1392,7 @@ impl VM {
                 Opcode::GAS => {
                     if self.env.consumed_gas + gas_cost::GAS > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1433,6 +1490,7 @@ impl VM {
                         + value_to_empty_account_cost;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1506,6 +1564,7 @@ impl VM {
                     let gas_cost = current_call_frame.memory.expansion_cost(offset + size) as u64;
                     if self.env.consumed_gas + gas_cost > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1614,6 +1673,7 @@ impl VM {
                 Opcode::TLOAD => {
                     if self.env.consumed_gas + gas_cost::TLOAD > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1631,6 +1691,7 @@ impl VM {
                 Opcode::TSTORE => {
                     if self.env.consumed_gas + gas_cost::TSTORE > self.env.gas_limit {
                         return Ok(ExecutionResult::Revert {
+                            reason: VMError::OutOfGas,
                             gas_used: self.env.consumed_gas,
                             output: current_call_frame.returndata,
                         }); // should revert the tx
@@ -1729,7 +1790,11 @@ impl VM {
                     .stack
                     .push(U256::from(SUCCESS_FOR_CALL))?;
             }
-            Ok(ExecutionResult::Revert { gas_used, output }) => {
+            Ok(ExecutionResult::Revert {
+                reason: _,
+                gas_used,
+                output,
+            }) => {
                 current_call_frame.memory.store_bytes(ret_offset, &output);
                 current_call_frame.returndata = output;
                 current_call_frame.stack.push(U256::from(REVERT_FOR_CALL))?;

--- a/crates/vm/levm/src/vm_result.rs
+++ b/crates/vm/levm/src/vm_result.rs
@@ -11,6 +11,7 @@ pub enum VMError {
     OpcodeNotAllowedInStaticContext,
     OpcodeNotFound,
     InvalidBytecode,
+    OutOfGas,
     FatalError, // this should never really happen
 }
 
@@ -29,7 +30,11 @@ pub enum ExecutionResult {
         return_data: Bytes,
     },
     /// Reverted by `REVERT` opcode that doesn't spend all gas.
-    Revert { gas_used: u64, output: Bytes },
+    Revert {
+        reason: VMError,
+        gas_used: u64,
+        output: Bytes,
+    },
     /// Reverted for various reasons and spend all gas.
     Halt {
         reason: VMError,

--- a/crates/vm/levm/src/vm_result.rs
+++ b/crates/vm/levm/src/vm_result.rs
@@ -1,0 +1,49 @@
+use bytes::Bytes;
+
+use crate::call_frame::Log;
+
+/// Errors that halts the program
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum VMError {
+    StackUnderflow,
+    StackOverflow,
+    InvalidJump,
+    OpcodeNotAllowedInStaticContext,
+    OpcodeNotFound,
+    InvalidBytecode,
+    FatalError, // this should never really happen
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ResultReason {
+    Stop,
+    Return,
+}
+
+/// Result of a transaction execution.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ExecutionResult {
+    Success {
+        reason: ResultReason,
+        logs: Vec<Log>,
+        return_data: Bytes,
+    },
+    /// Reverted by `REVERT` opcode that doesn't spend all gas.
+    Revert { gas_used: u64, output: Bytes },
+    /// Reverted for various reasons and spend all gas.
+    Halt {
+        reason: VMError,
+        /// Halting will spend all the gas, and will be equal to gas_limit.
+        gas_used: u64,
+    },
+}
+
+impl ExecutionResult {
+    pub fn logs(&self) -> &[Log] {
+        match self {
+            ExecutionResult::Success { logs, .. } => logs,
+            ExecutionResult::Revert { .. } => &[],
+            ExecutionResult::Halt { .. } => &[],
+        }
+    }
+}

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -8,6 +8,7 @@ use levm::{
     primitives::{Address, Bytes, H256, U256},
     transaction::{TransactTo, TxEnv},
     vm::{Account, Db, Storage, StorageSlot, VM},
+    vm_result::{ExecutionResult, VMError},
 };
 
 // cargo test -p 'levm'
@@ -1792,7 +1793,13 @@ fn jump_position_bigger_than_program_bytecode_size() {
     let mut vm = new_vm_with_ops(&operations);
 
     let result = vm.execute();
-    assert!(result.is_err());
+    assert_eq!(
+        result,
+        Ok(ExecutionResult::Halt {
+            reason: VMError::InvalidJump,
+            gas_used: vm.env.consumed_gas,
+        })
+    );
 }
 
 #[test]
@@ -2358,7 +2365,13 @@ fn jump_not_jumpdest_position() {
     let mut vm = new_vm_with_ops(&operations);
 
     let result = vm.execute();
-    assert!(result.is_err());
+    assert_eq!(
+        result,
+        Ok(ExecutionResult::Halt {
+            reason: VMError::InvalidJump,
+            gas_used: vm.env.consumed_gas,
+        })
+    );
 }
 
 #[test]

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use ethereum_types::H32;
 use levm::{
     block::{BlockEnv, TARGET_BLOB_GAS_PER_BLOCK},
-    constants::{MAX_CODE_SIZE, REVERT_FOR_CREATE, SUCCESS_FOR_RETURN, TX_BASE_COST},
+    constants::*,
     operations::Operation,
     primitives::{Address, Bytes, H256, U256},
     transaction::{TransactTo, TxEnv},
@@ -56,6 +56,7 @@ pub fn new_vm_with_ops_addr_bal(operations: &[Operation], address: Address, bala
         (
             Address::from_low_u64_be(42),
             Account {
+                address: Address::from_low_u64_be(42),
                 balance: U256::MAX,
                 bytecode,
                 storage: HashMap::new(),
@@ -65,6 +66,7 @@ pub fn new_vm_with_ops_addr_bal(operations: &[Operation], address: Address, bala
         (
             address,
             Account {
+                address,
                 balance,
                 bytecode: Bytes::default(),
                 storage: HashMap::new(),
@@ -134,7 +136,7 @@ fn add_op() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert!(vm.current_call_frame_mut().stack.pop().unwrap() == U256::one());
     assert!(vm.current_call_frame_mut().pc() == 68);
@@ -149,7 +151,7 @@ fn and_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0b1000));
@@ -165,7 +167,7 @@ fn and_binary_with_zero() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::zero());
@@ -181,7 +183,7 @@ fn and_with_hex_numbers() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xF0F0));
@@ -194,7 +196,7 @@ fn and_with_hex_numbers() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xF000));
@@ -207,7 +209,7 @@ fn and_with_hex_numbers() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0b1000000000000));
@@ -223,7 +225,7 @@ fn or_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0b1110));
@@ -236,7 +238,7 @@ fn or_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0b1010));
@@ -249,7 +251,7 @@ fn or_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xFFFFFFFFFFFFFFFF_u64));
@@ -265,7 +267,7 @@ fn or_with_hex_numbers() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xFFFF));
@@ -278,7 +280,7 @@ fn or_with_hex_numbers() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xF0F0));
@@ -291,7 +293,7 @@ fn or_with_hex_numbers() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0b1011111100101111));
@@ -307,7 +309,7 @@ fn xor_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0b110));
@@ -320,7 +322,7 @@ fn xor_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0b1010));
@@ -333,7 +335,7 @@ fn xor_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(u64::MAX));
@@ -346,7 +348,7 @@ fn xor_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::zero());
@@ -362,7 +364,7 @@ fn xor_with_hex_numbers() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xFF));
@@ -375,7 +377,7 @@ fn xor_with_hex_numbers() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::zero());
@@ -388,7 +390,7 @@ fn xor_with_hex_numbers() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xF0F));
@@ -401,7 +403,7 @@ fn xor_with_hex_numbers() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xF0));
@@ -414,7 +416,7 @@ fn xor_with_hex_numbers() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0b111011001000100));
@@ -429,7 +431,7 @@ fn not() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     let expected = !U256::from(0b1010);
@@ -442,7 +444,7 @@ fn not() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::zero());
@@ -454,7 +456,7 @@ fn not() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::MAX);
@@ -466,7 +468,7 @@ fn not() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::MAX - 1);
@@ -482,7 +484,7 @@ fn byte_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xF1));
@@ -495,7 +497,7 @@ fn byte_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0x33));
@@ -511,7 +513,7 @@ fn byte_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xFF));
@@ -524,7 +526,7 @@ fn byte_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xFF));
@@ -537,7 +539,7 @@ fn byte_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0x0D));
@@ -550,7 +552,7 @@ fn byte_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::zero());
@@ -563,7 +565,7 @@ fn byte_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::zero());
@@ -576,7 +578,7 @@ fn byte_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::zero());
@@ -595,7 +597,7 @@ fn byte_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0x90));
@@ -608,7 +610,7 @@ fn byte_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0x57));
@@ -621,7 +623,7 @@ fn byte_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xDD));
@@ -634,7 +636,7 @@ fn byte_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0x40));
@@ -650,7 +652,7 @@ fn shl_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xDDDD));
@@ -663,7 +665,7 @@ fn shl_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0x2468acf0));
@@ -676,7 +678,7 @@ fn shl_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(4886718336_u64));
@@ -689,7 +691,7 @@ fn shl_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xFF << 4));
@@ -705,7 +707,7 @@ fn shl_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::zero());
@@ -718,7 +720,7 @@ fn shl_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::zero());
@@ -731,7 +733,7 @@ fn shl_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::MAX - 1);
@@ -747,7 +749,7 @@ fn shr_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xDDDD));
@@ -760,7 +762,7 @@ fn shr_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0x91a2b3c));
@@ -773,7 +775,7 @@ fn shr_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0x1234567));
@@ -786,7 +788,7 @@ fn shr_basic() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0xF));
@@ -802,7 +804,7 @@ fn shr_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::zero());
@@ -815,7 +817,7 @@ fn shr_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::zero());
@@ -828,7 +830,7 @@ fn shr_edge_cases() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::MAX >> 1);
@@ -844,7 +846,7 @@ fn sar_shift_by_0() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0x12345678));
@@ -866,7 +868,7 @@ fn sar_shifting_large_value_with_all_bits_set() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     let expected = U256::from_big_endian(&[
@@ -893,7 +895,7 @@ fn sar_shifting_negative_value_and_small_shift() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     let expected = U256::from_big_endian(&[
@@ -914,7 +916,7 @@ fn sar_shift_positive_value() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(result, U256::from(0x07FFFF));
@@ -936,7 +938,7 @@ fn sar_shift_negative_value() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let result = vm.current_call_frame_mut().stack.pop().unwrap();
     let expected = U256::from_big_endian(&[
@@ -967,7 +969,7 @@ fn keccak256_zero_offset_size_four() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -995,7 +997,7 @@ fn keccak256_zero_offset_size_bigger_than_actual_memory() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert!(
         vm.current_call_frame_mut().stack.pop().unwrap()
@@ -1016,7 +1018,7 @@ fn keccak256_zero_offset_zero_size() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -1044,7 +1046,7 @@ fn keccak256_offset_four_size_four() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -1064,7 +1066,7 @@ fn mstore() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -1084,7 +1086,7 @@ fn mstore_saves_correct_value() {
         Operation::Stop,
     ]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let stored_value = vm.current_call_frame_mut().memory.load(0);
 
@@ -1106,7 +1108,7 @@ fn mstore8() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let stored_value = vm.current_call_frame_mut().memory.load(0);
 
@@ -1133,7 +1135,7 @@ fn mcopy() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let copied_value = vm.current_call_frame_mut().memory.load(64);
     assert_eq!(copied_value, U256::from(0x33333));
@@ -1156,7 +1158,7 @@ fn mload() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let loaded_value = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(loaded_value, U256::from(0x33333));
@@ -1169,7 +1171,7 @@ fn msize() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let initial_size = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(initial_size, U256::from(0));
@@ -1185,7 +1187,7 @@ fn msize() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let after_store_size = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(after_store_size, U256::from(32));
@@ -1201,7 +1203,7 @@ fn msize() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let final_size = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(final_size, U256::from(96));
@@ -1222,7 +1224,7 @@ fn mstore_mload_offset_not_multiple_of_32() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let memory_size = vm.current_call_frame_mut().stack.pop().unwrap();
     let loaded_value = vm.current_call_frame_mut().stack.pop().unwrap();
@@ -1245,7 +1247,7 @@ fn mstore_mload_offset_not_multiple_of_32() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let memory_size = vm.current_call_frame_mut().stack.pop().unwrap();
     let loaded_value = vm.current_call_frame_mut().stack.pop().unwrap();
@@ -1266,7 +1268,7 @@ fn mload_uninitialized_memory() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let memory_size = vm.current_call_frame_mut().stack.pop().unwrap();
     let loaded_value = vm.current_call_frame_mut().stack.pop().unwrap();
@@ -1306,7 +1308,7 @@ fn call_returns_if_bytecode_empty() {
     );
 
     vm.db.add_account(callee_address, callee_account);
-    vm.execute();
+    vm.execute().unwrap();
 
     let success = vm.current_call_frame_mut().stack.pop().unwrap();
     assert_eq!(success, U256::one());
@@ -1342,7 +1344,7 @@ fn call_changes_callframe_and_stores() {
 
     vm.db.add_account(callee_address, callee_account);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let current_call_frame = vm.current_call_frame_mut();
 
@@ -1428,7 +1430,7 @@ fn nested_calls() {
     vm.db.add_account(callee2_address, callee2_account);
     vm.db.add_account(callee3_address, callee3_account);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let current_call_frame = vm.current_call_frame_mut();
 
@@ -1495,9 +1497,9 @@ fn staticcall_changes_callframe_is_static() {
 
     vm.db.add_account(callee_address, callee_account);
 
-    vm.execute();
+    vm.execute().unwrap();
 
-    let current_call_frame = vm.current_call_frame_mut();
+    let mut current_call_frame = vm.call_frames[0].clone();
 
     let ret_offset = 0;
     let ret_size = 32;
@@ -1505,6 +1507,50 @@ fn staticcall_changes_callframe_is_static() {
 
     assert_eq!(U256::from_big_endian(&return_data), U256::from(0xAAAAAAA));
     assert!(current_call_frame.is_static);
+}
+
+#[test]
+fn pop_on_empty_stack() {
+    let operations = [Operation::Pop, Operation::Stop];
+
+    let mut vm = new_vm_with_ops(&operations);
+
+    let result = vm.execute();
+
+    assert!(result.is_err())
+}
+
+#[test]
+fn pc_op() {
+    let operations = [Operation::PC, Operation::Stop];
+    let mut vm = new_vm_with_ops(&operations);
+
+    vm.execute().unwrap();
+
+    assert_eq!(
+        vm.current_call_frame_mut().stack.pop().unwrap(),
+        U256::from(0)
+    );
+    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 2);
+}
+
+#[test]
+fn pc_op_with_push_offset() {
+    let operations = [
+        Operation::Push32(U256::one()),
+        Operation::PC,
+        Operation::Stop,
+    ];
+
+    let mut vm = new_vm_with_ops(&operations);
+
+    vm.execute().unwrap();
+
+    assert_eq!(
+        vm.current_call_frame_mut().stack.pop().unwrap(),
+        U256::from(33)
+    );
+    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 5);
 }
 
 #[test]
@@ -1551,7 +1597,7 @@ fn delegatecall_changes_own_storage_and_regular_call_doesnt() {
     current_call_frame.msg_sender = Address::from_low_u64_be(U256::from(1).low_u64());
     current_call_frame.to = Address::from_low_u64_be(U256::from(5).low_u64());
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let storage_slot = vm.db.read_account_storage(
         &Address::from_low_u64_be(U256::from(1).low_u64()),
@@ -1608,7 +1654,7 @@ fn delegatecall_changes_own_storage_and_regular_call_doesnt() {
     current_call_frame.msg_sender = Address::from_low_u64_be(U256::from(1).low_u64());
     current_call_frame.to = Address::from_low_u64_be(U256::from(5).low_u64());
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let storage_slot = vm.db.read_account_storage(&callee_address, &U256::zero());
     let slot = StorageSlot {
@@ -1663,7 +1709,7 @@ fn delegatecall_and_callcode_differ_on_value_and_msg_sender() {
     current_call_frame.msg_sender = Address::from_low_u64_be(U256::from(1).low_u64());
     current_call_frame.to = Address::from_low_u64_be(U256::from(5).low_u64());
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let current_call_frame = vm.current_call_frame_mut();
 
@@ -1703,7 +1749,6 @@ fn delegatecall_and_callcode_differ_on_value_and_msg_sender() {
         Operation::Push32(callee_address_u256), // address
         Operation::Push32(U256::from(100_000)), // gas
         Operation::CallCode,
-        Operation::Stop,
     ];
 
     let mut vm = new_vm_with_ops_addr_bal(
@@ -1714,14 +1759,9 @@ fn delegatecall_and_callcode_differ_on_value_and_msg_sender() {
 
     vm.db.add_account(callee_address, callee_account);
 
-    let current_call_frame = vm.current_call_frame_mut();
-    current_call_frame.msg_sender = Address::from_low_u64_be(U256::from(1).low_u64());
-    current_call_frame.to = Address::from_low_u64_be(U256::from(5).low_u64());
-    current_call_frame.code_address = Address::from_low_u64_be(U256::from(2).low_u64());
+    vm.execute().unwrap();
 
-    vm.execute();
-
-    let current_call_frame = vm.current_call_frame_mut().clone();
+    let current_call_frame = vm.call_frames[0].clone();
 
     let storage_slot = vm.db.read_account_storage(
         &Address::from_low_u64_be(U256::from(1).low_u64()),
@@ -1740,6 +1780,68 @@ fn delegatecall_and_callcode_differ_on_value_and_msg_sender() {
 }
 
 #[test]
+fn jump_position_bigger_than_program_bytecode_size() {
+    let operations = [
+        Operation::Push32(U256::from(5000)),
+        Operation::Jump,
+        Operation::Stop,
+        Operation::Push32(U256::from(10)),
+        Operation::Stop,
+    ];
+
+    let mut vm = new_vm_with_ops(&operations);
+
+    let result = vm.execute();
+    assert!(result.is_err());
+}
+
+#[test]
+fn jumpi_not_zero() {
+    let operations = [
+        Operation::Push32(U256::one()),
+        Operation::Push32(U256::from(68)),
+        Operation::Jumpi,
+        Operation::Stop, // should skip this one
+        Operation::Jumpdest,
+        Operation::Push32(U256::from(10)),
+        Operation::Stop,
+    ];
+    let mut vm = new_vm_with_ops(&operations);
+
+    vm.execute().unwrap();
+
+    assert_eq!(
+        vm.current_call_frame_mut().stack.pop().unwrap(),
+        U256::from(10)
+    );
+    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 19);
+}
+
+#[test]
+fn jumpi_for_zero() {
+    let operations = [
+        Operation::Push32(U256::from(100)),
+        Operation::Push32(U256::zero()),
+        Operation::Push32(U256::from(100)),
+        Operation::Jumpi,
+        Operation::Stop,
+        Operation::Jumpdest,
+        Operation::Push32(U256::from(10)),
+        Operation::Stop,
+    ];
+
+    let mut vm = new_vm_with_ops(&operations);
+
+    vm.execute().unwrap();
+
+    assert_eq!(
+        vm.current_call_frame_mut().stack.pop().unwrap(),
+        U256::from(100)
+    );
+    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 19);
+}
+
+#[test]
 fn calldataload() {
     let calldata = vec![
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
@@ -1755,7 +1857,7 @@ fn calldataload() {
     let mut vm = new_vm_with_ops(&ops);
 
     vm.current_call_frame_mut().calldata = calldata;
-    vm.execute();
+    vm.execute().unwrap();
 
     let current_call_frame = vm.current_call_frame_mut();
 
@@ -1823,7 +1925,7 @@ fn calldataload_being_set_by_parent() {
 
     vm.db.add_account(callee_address, callee_account);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let current_call_frame = vm.current_call_frame_mut();
 
@@ -1846,7 +1948,7 @@ fn calldatasize() {
 
     vm.current_call_frame_mut().calldata = calldata;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let current_call_frame = vm.current_call_frame_mut();
     let top_of_stack = current_call_frame.stack.pop().unwrap();
@@ -1868,7 +1970,7 @@ fn calldatacopy() {
 
     vm.current_call_frame_mut().calldata = calldata;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let current_call_frame = vm.current_call_frame_mut();
     let memory = current_call_frame.memory.load_range(0, 2);
@@ -1884,7 +1986,7 @@ fn returndatasize() {
 
     vm.current_call_frame_mut().returndata = returndata;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let current_call_frame = vm.current_call_frame_mut();
     let top_of_stack = current_call_frame.stack.pop().unwrap();
@@ -1906,7 +2008,7 @@ fn returndatacopy() {
 
     vm.current_call_frame_mut().returndata = returndata;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let current_call_frame = vm.current_call_frame_mut();
     let memory = current_call_frame.memory.load_range(0, 2);
@@ -1947,7 +2049,7 @@ fn returndatacopy_being_set_by_parent() {
 
     vm.db.add_account(callee_address, callee_account);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let current_call_frame = vm.current_call_frame_mut();
 
@@ -1975,7 +2077,7 @@ fn blockhash_op() {
         .insert(U256::from(block_number), H256::from_low_u64_be(block_hash));
     vm.env.block.number = U256::from(current_block_number);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -2006,7 +2108,7 @@ fn blockhash_same_block_number() {
     // );
     vm.env.block.number = U256::from(current_block_number);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -2034,7 +2136,7 @@ fn blockhash_block_number_not_from_recent_256() {
         .insert(U256::from(block_number), H256::from_low_u64_be(block_hash));
     vm.env.block.number = U256::from(current_block_number);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -2052,7 +2154,7 @@ fn coinbase_op() {
     let mut vm = new_vm_with_ops(&operations);
     vm.env.block.coinbase = Address::from_low_u64_be(coinbase_address);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -2070,7 +2172,7 @@ fn timestamp_op() {
     let mut vm = new_vm_with_ops(&operations);
     vm.env.block.timestamp = timestamp;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(vm.current_call_frame_mut().stack.pop().unwrap(), timestamp);
     assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 2);
@@ -2085,7 +2187,7 @@ fn number_op() {
     let mut vm = new_vm_with_ops(&operations);
     vm.env.block.number = block_number;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -2103,7 +2205,7 @@ fn prevrandao_op() {
     let mut vm = new_vm_with_ops(&operations);
     vm.env.block.prev_randao = Some(prevrandao);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -2121,7 +2223,7 @@ fn gaslimit_op() {
     let mut vm = new_vm_with_ops(&operations);
     vm.env.block.gas_limit = gas_limit;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -2139,7 +2241,7 @@ fn chain_id_op() {
     let mut vm = new_vm_with_ops(&operations);
     vm.env.block.chain_id = chain_id;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -2157,7 +2259,7 @@ fn basefee_op() {
     let mut vm = new_vm_with_ops(&operations);
     vm.env.block.base_fee_per_gas = base_fee_per_gas;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -2174,7 +2276,7 @@ fn blobbasefee_op() {
     vm.env.block.excess_blob_gas = Some(TARGET_BLOB_GAS_PER_BLOCK * 8);
     vm.env.block.blob_gas_used = Some(0);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -2191,7 +2293,7 @@ fn blobbasefee_minimum_cost() {
     vm.env.block.excess_blob_gas = Some(0);
     vm.env.block.blob_gas_used = Some(0);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
@@ -2211,62 +2313,13 @@ fn pop_op() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
         U256::one()
     );
     assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 8);
-}
-
-// TODO: when adding error handling this should return an error, not panic
-#[test]
-#[should_panic]
-fn pop_on_empty_stack() {
-    let operations = [Operation::Pop, Operation::Stop];
-
-    let mut vm = new_vm_with_ops(&operations);
-
-    vm.execute();
-
-    assert_eq!(
-        vm.current_call_frame_mut().stack.pop().unwrap(),
-        U256::one()
-    );
-}
-
-#[test]
-fn pc_op() {
-    let operations = [Operation::PC, Operation::Stop];
-    let mut vm = new_vm_with_ops(&operations);
-
-    vm.execute();
-
-    assert_eq!(
-        vm.current_call_frame_mut().stack.pop().unwrap(),
-        U256::from(0)
-    );
-    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 2);
-}
-
-#[test]
-fn pc_op_with_push_offset() {
-    let operations = [
-        Operation::Push32(U256::one()),
-        Operation::PC,
-        Operation::Stop,
-    ];
-
-    let mut vm = new_vm_with_ops(&operations);
-
-    vm.execute();
-
-    assert_eq!(
-        vm.current_call_frame_mut().stack.pop().unwrap(),
-        U256::from(33)
-    );
-    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 5);
 }
 
 #[test]
@@ -2282,18 +2335,17 @@ fn jump_op() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         vm.current_call_frame_mut().stack.pop().unwrap(),
         U256::from(10)
     );
     assert_eq!(vm.current_call_frame_mut().pc(), 70);
-    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 15);
+    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 14);
 }
 
 #[test]
-#[should_panic]
 fn jump_not_jumpdest_position() {
     let operations = [
         Operation::Push32(U256::from(36)),
@@ -2305,71 +2357,8 @@ fn jump_not_jumpdest_position() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
-    assert_eq!(vm.current_call_frame_mut().pc, 35);
-}
-
-#[test]
-#[should_panic]
-fn jump_position_bigger_than_program_bytecode_size() {
-    let operations = [
-        Operation::Push32(U256::from(5000)),
-        Operation::Jump,
-        Operation::Stop,
-        Operation::Push32(U256::from(10)),
-        Operation::Stop,
-    ];
-
-    let mut vm = new_vm_with_ops(&operations);
-
-    vm.execute();
-    assert_eq!(vm.current_call_frame_mut().pc(), 35);
-}
-
-#[test]
-fn jumpi_not_zero() {
-    let operations = [
-        Operation::Push32(U256::one()),
-        Operation::Push32(U256::from(68)),
-        Operation::Jumpi,
-        Operation::Stop, // should skip this one
-        Operation::Jumpdest,
-        Operation::Push32(U256::from(10)),
-        Operation::Stop,
-    ];
-    let mut vm = new_vm_with_ops(&operations);
-
-    vm.execute();
-
-    assert_eq!(
-        vm.current_call_frame_mut().stack.pop().unwrap(),
-        U256::from(10)
-    );
-    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 20);
-}
-
-#[test]
-fn jumpi_for_zero() {
-    let operations = [
-        Operation::Push32(U256::from(100)),
-        Operation::Push32(U256::zero()),
-        Operation::Push32(U256::from(100)),
-        Operation::Jumpi,
-        Operation::Stop,
-        Operation::Jumpdest,
-        Operation::Push32(U256::from(10)),
-        Operation::Stop,
-    ];
-
-    let mut vm = new_vm_with_ops(&operations);
-
-    vm.execute();
-
-    assert_eq!(
-        vm.current_call_frame_mut().stack.pop().unwrap(),
-        U256::from(100)
-    );
-    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 19);
+    let result = vm.execute();
+    assert!(result.is_err());
 }
 
 #[test]
@@ -2388,7 +2377,7 @@ fn sstore_op() {
     vm.current_call_frame_mut().code_address = sender_address;
     vm.db.accounts.insert(sender_address, Account::default());
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let account = vm.db.accounts.get(&sender_address).unwrap();
     let stored_value = account.storage.get(&key).unwrap();
@@ -2409,7 +2398,7 @@ fn sstore_reverts_when_called_in_static() {
 
     let mut vm = new_vm_with_ops(&operations);
     vm.current_call_frame_mut().is_static = true;
-    vm.execute();
+    vm.execute().unwrap();
 }
 
 #[test]
@@ -2430,7 +2419,7 @@ fn sload_op() {
     vm.current_call_frame_mut().msg_sender = sender_address;
     vm.db.accounts.insert(sender_address, Account::default());
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(value, vm.current_call_frame_mut().stack.pop().unwrap());
 }
@@ -2445,7 +2434,7 @@ fn sload_untouched_key_of_storage() {
     vm.current_call_frame_mut().msg_sender = sender_address;
     vm.db.accounts.insert(sender_address, Account::default());
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         U256::zero(),
@@ -2462,7 +2451,7 @@ fn sload_on_not_existing_account() {
     let mut vm = new_vm_with_ops(&operations);
     vm.current_call_frame_mut().msg_sender = sender_address;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(
         U256::zero(),
@@ -2485,7 +2474,7 @@ fn log0() {
     operations.append(&mut log_operations);
 
     let mut vm = new_vm_with_ops(&operations);
-    vm.execute();
+    vm.execute().unwrap();
 
     let logs = &vm.current_call_frame_mut().logs;
     let data = [0xff_u8; 32].as_slice();
@@ -2514,7 +2503,7 @@ fn log1() {
     operations.append(&mut log_operations);
 
     let mut vm = new_vm_with_ops(&operations);
-    vm.execute();
+    vm.execute().unwrap();
 
     let logs = &vm.current_call_frame_mut().logs;
     let data = [0xff_u8; 32].as_slice();
@@ -2546,7 +2535,7 @@ fn log2() {
     operations.append(&mut log_operations);
 
     let mut vm = new_vm_with_ops(&operations);
-    vm.execute();
+    vm.execute().unwrap();
 
     let logs = &vm.current_call_frame_mut().logs;
     let data = [0xff_u8; 32].as_slice();
@@ -2584,7 +2573,7 @@ fn log3() {
     operations.append(&mut log_operations);
 
     let mut vm = new_vm_with_ops(&operations);
-    vm.execute();
+    vm.execute().unwrap();
 
     let logs = &vm.current_call_frame_mut().logs;
     let data = [0xff_u8; 32].as_slice();
@@ -2629,7 +2618,7 @@ fn log4() {
     operations.append(&mut log_operations);
 
     let mut vm = new_vm_with_ops(&operations);
-    vm.execute();
+    vm.execute().unwrap();
 
     let logs = &vm.current_call_frame_mut().logs;
     let data = [0xff_u8; 32].as_slice();
@@ -2662,7 +2651,7 @@ fn log_with_0_data_size() {
     operations.append(&mut log_operations);
 
     let mut vm = new_vm_with_ops(&operations);
-    vm.execute();
+    vm.execute().unwrap();
 
     let logs = &vm.current_call_frame_mut().logs;
     assert_eq!(logs.len(), 1);
@@ -2672,7 +2661,6 @@ fn log_with_0_data_size() {
 }
 
 #[test]
-#[should_panic]
 fn cant_create_log_in_static_context() {
     let data: [u8; 32] = [0xff; 32];
     let size = 0_u8;
@@ -2688,7 +2676,8 @@ fn cant_create_log_in_static_context() {
 
     let mut vm: VM = new_vm_with_ops(&operations);
     vm.current_call_frame_mut().is_static = true;
-    vm.execute();
+    let result = vm.execute();
+    assert!(result.is_err());
 }
 
 #[test]
@@ -2706,7 +2695,7 @@ fn log_with_data_in_memory_smaller_than_size() {
     operations.append(&mut log_operations);
 
     let mut vm = new_vm_with_ops(&operations);
-    vm.execute();
+    vm.execute().unwrap();
 
     let logs = &vm.current_call_frame_mut().logs;
     let mut data = vec![0_u8; 16];
@@ -2740,7 +2729,7 @@ fn multiple_logs_of_different_types() {
     operations.append(&mut log_operations);
 
     let mut vm = new_vm_with_ops(&operations);
-    vm.execute();
+    vm.execute().unwrap();
 
     let logs = &vm.current_call_frame_mut().logs;
     let data = [0xff_u8; 32].as_slice();
@@ -2752,71 +2741,168 @@ fn multiple_logs_of_different_types() {
 }
 
 #[test]
+fn logs_from_multiple_callers() {
+    let callee_address = Address::from_low_u64_be(U256::from(2).low_u64());
+    let callee_address_u256 = U256::from(2);
+
+    let data: [u8; 32] = [0xff; 32];
+    let size = 32_u8;
+    let memory_offset = 0;
+    let mut operations = store_data_in_memory_operations(&data, memory_offset);
+    let mut log_operations = vec![
+        Operation::Push((1_u8, U256::from(size))),
+        Operation::Push((1_u8, U256::from(memory_offset))),
+        Operation::Log(0),
+        Operation::Stop,
+    ];
+    operations.append(&mut log_operations);
+    let callee_bytecode = operations
+        .clone()
+        .iter()
+        .flat_map(Operation::to_bytecode)
+        .collect::<Bytes>();
+    let callee_account = Account::new(
+        callee_address,
+        U256::from(500000),
+        callee_bytecode,
+        0,
+        HashMap::new(),
+    );
+
+    let mut caller_ops = vec![
+        Operation::Push32(U256::from(32)),      // ret_size
+        Operation::Push32(U256::from(0)),       // ret_offset
+        Operation::Push32(U256::from(0)),       // args_size
+        Operation::Push32(U256::from(0)),       // args_offset
+        Operation::Push32(U256::zero()),        // value
+        Operation::Push32(callee_address_u256), // address
+        Operation::Push32(U256::from(100_000)), // gas
+        Operation::Call,
+    ];
+
+    caller_ops.append(&mut operations);
+
+    let mut vm = new_vm_with_ops_addr_bal(
+        &caller_ops,
+        Address::from_low_u64_be(U256::from(1).low_u64()),
+        U256::zero(),
+    );
+
+    vm.db.add_account(callee_address, callee_account);
+
+    let result = vm.execute().unwrap();
+
+    assert_eq!(result.logs().len(), 2)
+}
+
+#[test]
+fn call_return_success_but_caller_halts() {
+    let callee_address = Address::from_low_u64_be(U256::from(2).low_u64());
+    let callee_address_u256 = U256::from(2);
+
+    let operations = vec![Operation::Pop, Operation::Stop];
+    let callee_bytecode = operations
+        .clone()
+        .iter()
+        .flat_map(Operation::to_bytecode)
+        .collect::<Bytes>();
+    let callee_account = Account::new(
+        callee_address,
+        U256::from(500000),
+        callee_bytecode,
+        0,
+        HashMap::new(),
+    );
+
+    let caller_ops = vec![
+        Operation::Push32(U256::from(32)),      // ret_size
+        Operation::Push32(U256::from(0)),       // ret_offset
+        Operation::Push32(U256::from(0)),       // args_size
+        Operation::Push32(U256::from(0)),       // args_offset
+        Operation::Push32(U256::zero()),        // value
+        Operation::Push32(callee_address_u256), // address
+        Operation::Push32(U256::from(100_000)), // gas
+        Operation::Call,
+        Operation::Stop,
+    ];
+
+    let mut vm = new_vm_with_ops_addr_bal(
+        &caller_ops,
+        Address::from_low_u64_be(U256::from(1).low_u64()),
+        U256::zero(),
+    );
+
+    vm.db.add_account(callee_address, callee_account);
+
+    vm.execute().unwrap();
+
+    assert_eq!(
+        vm.current_call_frame_mut().stack.pop().unwrap(),
+        U256::from(HALT_FOR_CALL)
+    );
+}
+
+#[test]
 fn push0_ok() {
     let mut vm = new_vm_with_ops(&[Operation::Push0, Operation::Stop]);
 
-    vm.execute();
+    vm.execute().unwrap();
 
-    assert_eq!(vm.current_call_frame_mut().stack[0], U256::zero());
+    assert_eq!(vm.current_call_frame_mut().stack.stack[0], U256::zero());
     assert_eq!(vm.current_call_frame_mut().pc(), 2);
 }
 
 #[test]
 fn push1_ok() {
     let to_push = U256::from_big_endian(&[0xff]);
-
     let operations = [Operation::Push((1, to_push)), Operation::Stop];
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
-    assert_eq!(vm.current_call_frame_mut().stack[0], to_push);
+    assert_eq!(vm.current_call_frame_mut().stack.stack[0], to_push);
     assert_eq!(vm.current_call_frame_mut().pc(), 3);
 }
 
 #[test]
 fn push5_ok() {
     let to_push = U256::from_big_endian(&[0xff, 0xff, 0xff, 0xff, 0xff]);
-
     let operations = [Operation::Push((5, to_push)), Operation::Stop];
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
-    assert_eq!(vm.current_call_frame_mut().stack[0], to_push);
+    assert_eq!(vm.current_call_frame_mut().stack.stack[0], to_push);
     assert_eq!(vm.current_call_frame_mut().pc(), 7);
 }
 
 #[test]
 fn push31_ok() {
     let to_push = U256::from_big_endian(&[0xff; 31]);
-
     let operations = [Operation::Push((31, to_push)), Operation::Stop];
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
-    assert_eq!(vm.current_call_frame_mut().stack[0], to_push);
+    assert_eq!(vm.current_call_frame_mut().stack.stack[0], to_push);
     assert_eq!(vm.current_call_frame_mut().pc(), 33);
 }
 
 #[test]
 fn push32_ok() {
     let to_push = U256::from_big_endian(&[0xff; 32]);
-
     let operations = [Operation::Push32(to_push), Operation::Stop];
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
-    assert_eq!(vm.current_call_frame_mut().stack[0], to_push);
+    assert_eq!(vm.current_call_frame_mut().stack.stack[0], to_push);
     assert_eq!(vm.current_call_frame_mut().pc(), 34);
 }
 
 #[test]
 fn dup1_ok() {
     let value = U256::one();
-
     let operations = [
         Operation::Push((1, value)),
         Operation::Dup(1),
@@ -2824,50 +2910,60 @@ fn dup1_ok() {
     ];
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let stack_len = vm.current_call_frame_mut().stack.len();
 
     assert_eq!(stack_len, 2);
     assert_eq!(vm.current_call_frame_mut().pc(), 4);
-    assert_eq!(vm.current_call_frame_mut().stack[stack_len - 1], value);
-    assert_eq!(vm.current_call_frame_mut().stack[stack_len - 2], value);
+    assert_eq!(
+        vm.current_call_frame_mut().stack.stack[stack_len - 1],
+        value
+    );
+    assert_eq!(
+        vm.current_call_frame_mut().stack.stack[stack_len - 2],
+        value
+    );
 }
 
 #[test]
 fn dup16_ok() {
     let value = U256::one();
-
     let mut operations = vec![Operation::Push((1, value))];
     operations.extend(vec![Operation::Push0; 15]);
     operations.extend(vec![Operation::Dup(16), Operation::Stop]);
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let stack_len = vm.current_call_frame_mut().stack.len();
 
     assert_eq!(stack_len, 17);
     assert_eq!(vm.current_call_frame_mut().pc, 19);
-    assert_eq!(vm.current_call_frame_mut().stack[stack_len - 1], value);
-    assert_eq!(vm.current_call_frame_mut().stack[stack_len - 17], value);
+    assert_eq!(
+        vm.current_call_frame_mut().stack.stack[stack_len - 1],
+        value
+    );
+    assert_eq!(
+        vm.current_call_frame_mut().stack.stack[stack_len - 17],
+        value
+    );
 }
 
 #[test]
-#[should_panic]
-fn dup_panics_if_stack_underflow() {
+fn dup_halts_if_stack_underflow() {
     let operations = [Operation::Dup(5), Operation::Stop];
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    let result = vm.execute();
+    assert!(result.is_err())
 }
 
 #[test]
 fn swap1_ok() {
     let bottom = U256::from_big_endian(&[0xff]);
     let top = U256::from_big_endian(&[0xee]);
-
     let operations = [
         Operation::Push((1, bottom)),
         Operation::Push((1, top)),
@@ -2875,19 +2971,18 @@ fn swap1_ok() {
         Operation::Stop,
     ];
     let mut vm = new_vm_with_ops(&operations);
-    vm.execute();
+    vm.execute().unwrap();
 
     assert_eq!(vm.current_call_frame_mut().stack.len(), 2);
     assert_eq!(vm.current_call_frame_mut().pc(), 6);
-    assert_eq!(vm.current_call_frame_mut().stack[0], top);
-    assert_eq!(vm.current_call_frame_mut().stack[1], bottom);
+    assert_eq!(vm.current_call_frame_mut().stack.stack[0], top);
+    assert_eq!(vm.current_call_frame_mut().stack.stack[1], bottom);
 }
 
 #[test]
 fn swap16_ok() {
     let bottom = U256::from_big_endian(&[0xff]);
     let top = U256::from_big_endian(&[0xee]);
-
     let mut operations = vec![Operation::Push((1, bottom))];
     operations.extend(vec![Operation::Push0; 15]);
     operations.extend(vec![Operation::Push((1, top))]);
@@ -2895,22 +2990,28 @@ fn swap16_ok() {
 
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    vm.execute().unwrap();
     let stack_len = vm.current_call_frame_mut().stack.len();
 
     assert_eq!(stack_len, 17);
     assert_eq!(vm.current_call_frame_mut().pc(), 21);
-    assert_eq!(vm.current_call_frame_mut().stack[stack_len - 1], bottom);
-    assert_eq!(vm.current_call_frame_mut().stack[stack_len - 1 - 16], top);
+    assert_eq!(
+        vm.current_call_frame_mut().stack.stack[stack_len - 1],
+        bottom
+    );
+    assert_eq!(
+        vm.current_call_frame_mut().stack.stack[stack_len - 1 - 16],
+        top
+    );
 }
 
 #[test]
-#[should_panic]
-fn swap_panics_if_stack_underflow() {
+fn swap_halts_if_stack_underflow() {
     let operations = [Operation::Swap(5), Operation::Stop];
     let mut vm = new_vm_with_ops(&operations);
 
-    vm.execute();
+    let result = vm.execute();
+    assert!(result.is_err())
 }
 
 #[test]
@@ -2931,7 +3032,7 @@ fn transient_store() {
 
     assert!(current_call_frame.transient_storage.is_empty());
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let current_call_frame = vm.current_call_frame_mut();
 
@@ -2952,7 +3053,7 @@ fn transient_store_no_values_panics() {
     let mut vm = new_vm_with_ops(&operations);
     assert!(vm.current_call_frame_mut().transient_storage.is_empty());
 
-    vm.execute();
+    vm.execute().unwrap();
 }
 
 #[test]
@@ -2970,9 +3071,12 @@ fn transient_load() {
         .transient_storage
         .insert((caller, key), value);
 
-    vm.execute();
+    vm.execute().unwrap();
 
-    assert_eq!(*vm.current_call_frame_mut().stack.last().unwrap(), value)
+    assert_eq!(
+        *vm.current_call_frame_mut().stack.stack.last().unwrap(),
+        value
+    )
 }
 
 #[test]
@@ -3000,7 +3104,7 @@ fn create_happy_path() {
     let mut vm = new_vm_with_ops_addr_bal(&operations, sender_addr, sender_balance);
     vm.current_call_frame_mut().msg_sender = sender_addr;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let call_frame = vm.current_call_frame_mut();
     let return_of_created_callframe = call_frame.stack.pop().unwrap();
@@ -3031,7 +3135,7 @@ fn cant_create_with_size_longer_than_max_code_size() {
     let mut vm = new_vm_with_ops_addr_bal(&operations, sender_addr, sender_balance);
     vm.current_call_frame_mut().msg_sender = sender_addr;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let call_frame = vm.current_call_frame_mut();
     let create_return_value = call_frame.stack.pop().unwrap();
@@ -3058,7 +3162,7 @@ fn cant_create_on_static_contexts() {
     vm.current_call_frame_mut().msg_sender = sender_addr;
     vm.current_call_frame_mut().is_static = true;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let call_frame = vm.current_call_frame_mut();
     let create_return_value = call_frame.stack.pop().unwrap();
@@ -3084,7 +3188,7 @@ fn cant_create_if_transfer_value_bigger_than_balance() {
     let mut vm = new_vm_with_ops_addr_bal(&operations, sender_addr, sender_balance);
     vm.current_call_frame_mut().msg_sender = sender_addr;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let call_frame = vm.current_call_frame_mut();
     let create_return_value = call_frame.stack.pop().unwrap();
@@ -3110,11 +3214,17 @@ fn cant_create_if_sender_nonce_would_overflow() {
     let mut vm = new_vm_with_ops(&operations);
     vm.db.accounts.insert(
         sender_addr,
-        Account::new(sender_balance, Bytes::new(), sender_nonce, HashMap::new()),
+        Account::new(
+            sender_addr,
+            sender_balance,
+            Bytes::new(),
+            sender_nonce,
+            HashMap::new(),
+        ),
     );
     vm.current_call_frame_mut().msg_sender = sender_addr;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let call_frame = vm.current_call_frame_mut();
     let create_return_value = call_frame.stack.pop().unwrap();
@@ -3157,11 +3267,14 @@ fn cant_create_accounts_with_same_address() {
     );
     vm.current_call_frame_mut().msg_sender = sender_addr;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let call_frame = vm.current_call_frame_mut();
+
     let return_of_created_callframe = call_frame.stack.pop().unwrap();
+
     assert_eq!(return_of_created_callframe, U256::from(SUCCESS_FOR_RETURN));
+
     let returned_addr = call_frame.stack.pop().unwrap();
     // check the created account is correct
     let new_account = vm.db.accounts.get(&word_to_address(returned_addr)).unwrap();
@@ -3181,7 +3294,7 @@ fn cant_create_accounts_with_same_address() {
     new_vm.db.accounts = vm.db.accounts.clone();
     new_vm.current_call_frame_mut().msg_sender = sender_addr;
 
-    new_vm.execute();
+    new_vm.execute().unwrap();
     let call_frame = new_vm.current_call_frame_mut();
     let return_of_created_callframe = call_frame.stack.pop().unwrap();
     assert_eq!(return_of_created_callframe, U256::from(REVERT_FOR_CREATE));
@@ -3222,7 +3335,7 @@ fn create2_happy_path() {
     let mut vm = new_vm_with_ops_addr_bal(&operations, sender_addr, sender_balance);
     vm.current_call_frame_mut().msg_sender = sender_addr;
 
-    vm.execute();
+    vm.execute().unwrap();
 
     let call_frame = vm.current_call_frame_mut();
     let return_of_created_callframe = call_frame.stack.pop().unwrap();
@@ -3265,6 +3378,6 @@ fn create_on_create() {
 
     vm.current_call_frame_mut().msg_sender = sender_addr;
 
-    vm.execute();
+    vm.execute().unwrap();
     assert_eq!(vm.db.accounts.len(), 4);
 }

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -1821,7 +1821,7 @@ fn jumpi_not_zero() {
         vm.current_call_frame_mut().stack.pop().unwrap(),
         U256::from(10)
     );
-    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 19);
+    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 20);
 }
 
 #[test]
@@ -2349,7 +2349,7 @@ fn jump_op() {
         U256::from(10)
     );
     assert_eq!(vm.current_call_frame_mut().pc(), 70);
-    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 14);
+    assert_eq!(vm.env.consumed_gas, TX_BASE_COST + 15);
 }
 
 #[test]


### PR DESCRIPTION
**Summary**

Delete the unwraps/expects from the `VM` execution of bytecode.
We previously handled the moving between calls with `callframes` by just changing the current callframe being executed. 
Now we have added the `ExecutionResult` to be returned by `execute`, this adds the possibility to obtain the specifics of what happened during the execution of a certain callframe. This affects mainly the way `CALL` and `CREATE` functions work. With this PR we start calling into new callframes in a recursive way to better handle the result of each execution.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- Adds the `Stack` struct for handling the pop/push errors
- Returns `Halts` as error
- Changed the `CALL` and `CREATE` opcode to do a recursive call to execute
- Execute returns a `ExecutionResult` with information
- Added the types `Success`, `Revert` and `Halt` for `ExecutionResult`. 
- Added support for the revert function in `generic_call`.
- Added a revert if an opcode passes the gas limit.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #539 
Closes #556 

