### PR TITLE
fix: implementation of `TxKind::deserialize`

### DIFF
--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -791,16 +791,21 @@ mod serde_impl {
         where
             D: serde::Deserializer<'de>,
         {
-            let str = String::deserialize(deserializer)?;
-            Ok(if str.is_empty() {
-                TxKind::Create
-            } else {
-                TxKind::Call(
-                    Address::from_str(str.trim_start_matches("0x")).map_err(|_| {
-                        serde::de::Error::custom(format!("Failed to deserialize hex value {str}"))
-                    })?,
-                )
-            })
+            let str_option = Option::<String>::deserialize(deserializer)?;
+            match str_option {
+                Some(str) => Ok(if str.is_empty() {
+                    TxKind::Create
+                } else {
+                    TxKind::Call(
+                        Address::from_str(str.trim_start_matches("0x")).map_err(|_| {
+                            serde::de::Error::custom(format!(
+                                "Failed to deserialize hex value {str}"
+                            ))
+                        })?,
+                    )
+                }),
+                None => Ok(TxKind::Create),
+            }
         }
     }
 

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -793,15 +793,11 @@ mod serde_impl {
         {
             let str_option = Option::<String>::deserialize(deserializer)?;
             match str_option {
-                Some(str) if !str.is_empty() => Ok(
-                    TxKind::Call(
-                        Address::from_str(str.trim_start_matches("0x")).map_err(|_| {
-                            serde::de::Error::custom(format!(
-                                "Failed to deserialize hex value {str}"
-                            ))
-                        })?,
-                    )
-                ),
+                Some(str) if !str.is_empty() => Ok(TxKind::Call(
+                    Address::from_str(str.trim_start_matches("0x")).map_err(|_| {
+                        serde::de::Error::custom(format!("Failed to deserialize hex value {str}"))
+                    })?,
+                )),
                 _ => Ok(TxKind::Create),
             }
         }

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -793,9 +793,7 @@ mod serde_impl {
         {
             let str_option = Option::<String>::deserialize(deserializer)?;
             match str_option {
-                Some(str) => Ok(if str.is_empty() {
-                    TxKind::Create
-                } else {
+                Some(str) if !str.is_empty() => Ok(
                     TxKind::Call(
                         Address::from_str(str.trim_start_matches("0x")).map_err(|_| {
                             serde::de::Error::custom(format!(
@@ -803,8 +801,8 @@ mod serde_impl {
                             ))
                         })?,
                     )
-                }),
-                None => Ok(TxKind::Create),
+                ),
+                _ => Ok(TxKind::Create),
             }
         }
     }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

The actual implementation of `TxKind` (the field `to` of a transaction) expects a `String`. But this field's value can be `null` which does not match with the `String` type and breaks the deserialization.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

This PR fixes the `TxKind` deserialization by expecting an `Option<String>` instead of a `String` and the deserialized value will be `TxKind::Create` if there's an empty `String` or a `null` and `Call` if the incoming `String` can be parsed as an `Address`.

