### PR TITLE
feat(L2): update L2 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,15 +257,20 @@ Users can deposit Eth in the L1 (Ethereum) and receive the corresponding funds o
 
 |        | Name                           | Description                                                                 | Status |
 | --------- | ----------------------------- | --------------------------------------------------------------------------- | ------ |
-| Contracts | `CommonBridge`                | Deposit method implementation                                                         | 🏗️     |
+| Contracts | `CommonBridge`                | Deposit method implementation                                                         | ✅     |
 |           | `BlockExecutor`               | Commit and verify methods (placeholders for this stage)          | ✅     |
+| VM |     | Adapt EVM to handle deposits |   🏗️    |
 | Operator  | `Sequencer`                   | Proposes new blocks to be executed                                          | ✅     |
-|           | `L1Watcher`                   | Listens for and handles L1 deposits                                         | ✅     |
+|           | `L1Watcher`                   | Listens for and handles L1 deposits                                         | 🏗️     |
 |           | `L1TxSender`                  | commits new block proposals and sends block execution proofs to be verified | 🏗️     |
 |           | Deposit transactions handling | new transaction type for minting funds corresponding to deposits            | 🏗️     |
+| CLI | `stack` | Support commands for initializing the stack | ✅     |
+| CLI | `config` | Support commands for stack config management | ✅     |
+| CLI | `wallet deposit` | Support command por depositing funds on L2 | 🏗️     |
+| CLI | `wallet transfer` | Support command for transferring funds on L2   | 🏗️     |
 
 
-#### Milestone 1 (MVP)
+### Milestone 1 (MVP)
 
 The network supports basic L2 functionality, allowing users to deposit and withdraw funds to join and exit the network, while also interacting with the network as they do normally on the Ethereum network (deploying contracts, sending transactions, etc).
 
@@ -274,18 +279,53 @@ The network supports basic L2 functionality, allowing users to deposit and withd
 |        | Name                            | Description                                                                                                           | Status |
 | --------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------ |
 | Contracts | `CommonBridge`                 | Withdraw method implementation                                                                                        | ❌     |
-|           | `BlockExecutor`                | Commit and verify implementation                                                                                      | ❌     |
-|           | `Verifier`                     | Use Solidity verifier                                                                                                      | ❌     |
+|           | `BlockExecutor`                | Commit and verify implementation                                                                                      | 🏗️     |
+|           | `Verifier`                     | Use SP1 verifier                                                                                                      | 🏗️     |
 | Operator  | `ProofDataProvider`            | Feeds the `ProverDataClient` with block data to be proven and delivers proofs to the `L1TxSender` for L1 verification | 🏗️     |
-|           | Withdraw transactions handling |    New transaction type for burning funds on L2 and unlock funds on L1                                                                                                                   | ❌     |
+|           | Withdraw transactions handling |    New transaction type for burning funds on L2 and unlock funds on L1                                                                                                                   | 🏗️     |
 | Prover    | `ProofDataClient`              |  Asks for block execution data to prove, generates proofs of execution and submits proofs to the `ProofDataProvider`                                                                                                                     | 🏗️     |
 
-#### Future work
+### Milestone 2 (State diffs + blobs + base token)
 
-- Use Blobs (EIP 4844) for data availability on L1 instead of calldata and send state diffs instead of the entire state.
-- Support native account abstraction on the L2.
-- Base token, common bridge for multiple L2s
-- Validium support (i.e. other data availability solutions instead of Ethereum).
+The network now commits to state diffs instead of the full state, lowering the commit transactions costs and supports EIP4844.
+
+The L2 can be deployed using a custom native token, meaning that an ERC20 can be the common currency, with fees payed in that currency.
+
+#### Status
+
+|           | Name          | Description                                            | Status |
+| --------- | ------------- | ------------------------------------------------------ | ------ |
+| Contracts | BlockExecutor | Differentiate whether to execute in calldata or blobs mode                                                      |  ❌      |
+|  | CommonBridge | For base token deposits, msg.value = 0 and valueToMintOnL2 > 0 |  ❌      |
+|  |  | For base token withdrawals, we need to infer the base token  |  ❌      |
+|  |  | Add track of chain's base token |  ❌      |
+| VM        |               | The VM should return which storage slots were modified |   ❌     |
+| Operator  |  ProofDataProvider  |  Sends state diffs to the prover   |   ❌     |
+|   |  L1TxSender  |  Differentiate whether to send the commit transaction with calldata or blobs   |   ❌     |
+| Prover    | RiscV ZKVM program   | Adapt state proofs                                                       |    ❌    |
+|    |    | Add program for proving blobs                                                       |    ❌    |
+| CLI    | `reconstruct-state`   | Add a command for reconstructing the state                                                       |    ❌    |
+|     | `deposit`   | Handle base token deposits                                                       |    ❌    |
+|     | `withdraw`   | Handle base token withdrawals                                                       |    ❌    |
+|     | `init`   | Adapt stack initialization to either send blobs or calldata                                                       |    ❌    |
+|Misc  |    | Add a DA integration example for Validium mode                                                       |    ❌    |
+
+### Milestone 3 (Validium + Account Abstraction)
+
+The L2 can be initialized in Validium Mode, meaning the Data Availability layer is no longer the L1, but rather a DA layer of the user's choice.
+
+The L2 supports native account abstraction following EIP 4337, allowing for custom transaction validation logic and paymaster flows.
+
+#### Status
+
+|           | Name          | Description                                            | Status |
+| --------- | ------------- | ------------------------------------------------------ | ------ |
+| Contracts | BlockExecutor | Do no check data availability in Validium mode                                                      |  ❌      |
+| VM        |               | The VM should return which storage slots were modified |   ❌     |
+| Operator  |  L1TxSender  |  Do no send data in commit transactions   |   ❌     |
+| CLI    | `init`   | Adapt stack initialization to support Validium stacks                                                       |    ❌    |
+
+TODO: Expand on account abstraction tasks.
 
 # Crates documentation
 


### PR DESCRIPTION
# Ethereum Rust L2

Ethereum Rust L2 is a feature allowing you to run Ethereum Rust as a ZK-Rollup. The node has the same interface as regular Ethereum Rust, with the addition that blocks execution is proven and the proof is sent to an L1 network for verification, thus inheriting the L1's security.

The main diferences with regular Ethereum Rust are:

- There is no consensus, only one sequencer proposes blocks for the network.
- Block execution is proven using [SP1 ](https://docs.succinct.xyz/)and its proofs are sent to L1 for verification.
- A set of Solidity contracts to be deployed to the L1 are included as part of network initialization.
- Two new types of transactions are included 

## Roadmap

### Milestone 0

Users can deposit Eth in the L1 (Ethereum) and receive the corresponding funds on the L2.

#### Status

|        | Name                           | Description                                                                 | Status |
| --------- | ----------------------------- | --------------------------------------------------------------------------- | ------ |
| Contracts | `CommonBridge`                | Deposit method implementation                                                         | ✅     |
|           | `BlockExecutor`               | Commit and verify methods (placeholders for this stage)          | ✅     |
| VM |     | Adapt EVM to handle deposits |   🏗️    |
| Operator  | `Sequencer`                   | Proposes new blocks to be executed                                          | ✅     |
|           | `L1Watcher`                   | Listens for and handles L1 deposits                                         | 🏗️     |
|           | `L1TxSender`                  | commits new block proposals and sends block execution proofs to be verified | 🏗️     |
|           | Deposit transactions handling | new transaction type for minting funds corresponding to deposits            | 🏗️     |
| CLI | `stack` | Support commands for initializing the stack | ✅     |
| CLI | `config` | Support commands for stack config management | ✅     |
| CLI | `wallet deposit` | Support command por depositing funds on L2 | 🏗️     |
| CLI | `wallet transfer` | Support command for transferring funds on L2   | 🏗️     |


### Milestone 1 (MVP)

The network supports basic L2 functionality, allowing users to deposit and withdraw funds to join and exit the network, while also interacting with the network as they do normally on the Ethereum network (deploying contracts, sending transactions, etc).

#### Status

|        | Name                            | Description                                                                                                           | Status |
| --------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------ |
| Contracts | `CommonBridge`                 | Withdraw method implementation                                                                                        | ❌     |
|           | `BlockExecutor`                | Commit and verify implementation                                                                                      | 🏗️     |
|           | `Verifier`                     | Use SP1 verifier                                                                                                      | 🏗️     |
| Operator  | `ProofDataProvider`            | Feeds the `ProverDataClient` with block data to be proven and delivers proofs to the `L1TxSender` for L1 verification | 🏗️     |
|           | Withdraw transactions handling |    New transaction type for burning funds on L2 and unlock funds on L1                                                                                                                   | 🏗️     |
| Prover    | `ProofDataClient`              |  Asks for block execution data to prove, generates proofs of execution and submits proofs to the `ProofDataProvider`                                                                                                                     | 🏗️     |

### Milestone 2 (State diffs + blobs + base token)

The network now commits to state diffs instead of the full state, lowering the commit transactions costs and supports EIP4844.

The L2 can be deployed using a custom native token, meaning that an ERC20 can be the common currency, with fees payed in that currency.

#### Status

|           | Name          | Description                                            | Status |
| --------- | ------------- | ------------------------------------------------------ | ------ |
| Contracts | BlockExecutor | Differentiate whether to execute in calldata or blobs mode                                                      |  ❌      |
|  | CommonBridge | For base token deposits, msg.value = 0 and valueToMintOnL2 > 0 |  ❌      |
|  |  | For base token withdrawals, we need to infer the base token  |  ❌      |
|  |  | Add track of chain's base token |  ❌      |
| VM        |               | The VM should return which storage slots were modified |   ❌     |
| Operator  |  ProofDataProvider  |  Sends state diffs to the prover   |   ❌     |
|   |  L1TxSender  |  Differentiate whether to send the commit transaction with calldata or blobs   |   ❌     |
| Prover    | RiscV ZKVM program   | Adapt state proofs                                                       |    ❌    |
|    |    | Add program for proving blobs                                                       |    ❌    |
| CLI    | `reconstruct-state`   | Add a command for reconstructing the state                                                       |    ❌    |
|     | `depost`   | Handle base token desosits                                                       |    ❌    |
|     | `withdraw`   | Handle base token withdrawals                                                       |    ❌    |
|     | `init`   | Adapt stack initialization to either send blobs or calldata                                                       |    ❌    |
|Misc  |    | Add a DA integration example for Validium mode                                                       |    ❌    |

### Milestone 3 (Validium + Account Abstraction)

The L2 can be initialized in Validium Mode, meaning the Data Availability layer is no longer the L1, but rather a DA layer of the user's choice.

The L2 supports native account abstraction following EIP 4337, allowing for custom transaction validation logic and paymaster flows.

#### Status

|           | Name          | Description                                            | Status |
| --------- | ------------- | ------------------------------------------------------ | ------ |
| Contracts | BlockExecutor | Do no check data availability in Validium mode                                                      |  ❌      |
| VM        |               | The VM should return which storage slots were modified |   ❌     |
| Operator  |  L1TxSender  |  Do no send data in commit transactions   |   ❌     |
| CLI    | `init`   | Adapt stack initialization to support Validium stacks                                                       |    ❌    |

TODO: Expand on account abstraction tasks.