### PR TITLE
refactor(`RpcErr`): add context to RPC errors

### DIFF
--- a/crates/networking/rpc/admin/mod.rs
+++ b/crates/networking/rpc/admin/mod.rs
@@ -33,7 +33,7 @@ pub fn node_info(storage: Store, local_node: Node) -> Result<Value, RpcErr> {
     let enode_url = local_node.enode_url();
     let mut protocols = HashMap::new();
 
-    let chain_config = storage.get_chain_config().map_err(|_| RpcErr::Internal)?;
+    let chain_config = storage.get_chain_config().map_err(|error| RpcErr::Internal(error.to_string()))?;
     protocols.insert("eth".to_string(), Protocol::Eth(chain_config));
 
     let node_info = NodeInfo {
@@ -47,5 +47,5 @@ pub fn node_info(storage: Store, local_node: Node) -> Result<Value, RpcErr> {
         },
         protocols,
     };
-    serde_json::to_value(node_info).map_err(|_| RpcErr::Internal)
+    serde_json::to_value(node_info).map_err(|error| RpcErr::Internal(error.to_string()))
 }

--- a/crates/networking/rpc/engine/exchange_transition_config.rs
+++ b/crates/networking/rpc/engine/exchange_transition_config.rs
@@ -35,9 +35,11 @@ impl std::fmt::Display for ExchangeTransitionConfigV1Req {
 
 impl RpcHandler for ExchangeTransitionConfigV1Req {
     fn parse(params: &Option<Vec<Value>>) -> Result<ExchangeTransitionConfigV1Req, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 1 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 1 param".to_owned()));
         };
         let payload: ExchangeTransitionConfigPayload = serde_json::from_value(params[0].clone())?;
         Ok(ExchangeTransitionConfigV1Req { payload })

--- a/crates/networking/rpc/engine/exchange_transition_config.rs
+++ b/crates/networking/rpc/engine/exchange_transition_config.rs
@@ -67,6 +67,6 @@ impl RpcHandler for ExchangeTransitionConfigV1Req {
             terminal_block_number: payload.terminal_block_number,
             terminal_total_difficulty: terminal_total_difficulty.unwrap_or_default(),
         })
-        .map_err(|_| RpcErr::Internal)
+        .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -41,7 +41,7 @@ impl RpcHandler for ForkChoiceUpdatedV3 {
             serde_json::to_value(ForkChoiceResponse::from(PayloadStatus::invalid_with_err(
                 err_msg,
             )))
-            .map_err(|_| RpcErr::Internal)
+            .map_err(|error| RpcErr::Internal(error.to_string()))
         };
 
         if self.fork_choice_state.head_block_hash.is_zero() {
@@ -53,7 +53,7 @@ impl RpcHandler for ForkChoiceUpdatedV3 {
         else {
             // TODO: We don't yet support syncing
             warn!("[Engine - ForkChoiceUpdatedV3] Fork choice head block not found in store (hash {}).", self.fork_choice_state.head_block_hash);
-            return Err(RpcErr::Internal);
+            return Err(RpcErr::Internal("We don't yet support syncing".to_owned()));
         };
         // Check that we are not being pushed pre-merge
         if let Some(error) = total_difficulty_check(
@@ -65,8 +65,9 @@ impl RpcHandler for ForkChoiceUpdatedV3 {
         }
         let canonical_block = storage.get_canonical_block_hash(head_block.number)?;
         let current_block_hash = {
-            let current_block_number =
-                storage.get_latest_block_number()?.ok_or(RpcErr::Internal)?;
+            let current_block_number = storage.get_latest_block_number()?.ok_or(
+                RpcErr::Internal("Could not get latest block number".to_owned()),
+            )?;
             storage.get_canonical_block_hash(current_block_number)?
         };
         if canonical_block.is_some_and(|h| h != self.fork_choice_state.head_block_hash) {
@@ -85,7 +86,8 @@ impl RpcHandler for ForkChoiceUpdatedV3 {
         } else if current_block_hash.is_some_and(|h| h != self.fork_choice_state.head_block_hash) {
             // If the head block is already in our canonical chain, the beacon client is
             // probably resyncing. Ignore the update.
-            return serde_json::to_value(PayloadStatus::valid()).map_err(|_| RpcErr::Internal);
+            return serde_json::to_value(PayloadStatus::valid())
+                .map_err(|error| RpcErr::Internal(error.to_string()));
         }
 
         // Set finalized & safe blocks
@@ -114,12 +116,12 @@ impl RpcHandler for ForkChoiceUpdatedV3 {
                 Err(ChainError::EvmError(error)) => return Err(error.into()),
                 // Parent block is guaranteed to be present at this point,
                 // so the only errors that may be returned are internal storage errors
-                _ => return Err(RpcErr::Internal),
+                Err(error) => return Err(RpcErr::Internal(error.to_string())),
             };
             storage.add_payload(payload_id, payload)?;
         }
 
-        serde_json::to_value(response).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(response).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -24,9 +24,11 @@ pub struct ForkChoiceUpdatedV3 {
 
 impl RpcHandler for ForkChoiceUpdatedV3 {
     fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 2 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 2 params".to_owned()));
         }
         Ok(ForkChoiceUpdatedV3 {
             fork_choice_state: serde_json::from_value(params[0].clone())?,

--- a/crates/networking/rpc/engine/mod.rs
+++ b/crates/networking/rpc/engine/mod.rs
@@ -11,10 +11,13 @@ impl RpcHandler for ExchangeCapabilitiesRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
         params
             .as_ref()
-            .ok_or(RpcErr::BadParams)?
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?
             .first()
-            .ok_or(RpcErr::BadParams)
-            .and_then(|v| serde_json::from_value(v.clone()).map_err(|_| RpcErr::BadParams))
+            .ok_or(RpcErr::BadParams("Expected 1 param".to_owned()))
+            .and_then(|v| {
+                serde_json::from_value(v.clone())
+                    .map_err(|error| RpcErr::BadParams(error.to_string()))
+            })
     }
 
     fn handle(&self, _storage: Store) -> Result<Value, RpcErr> {

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -25,9 +25,11 @@ pub struct GetPayloadV3Request {
 
 impl RpcHandler for NewPayloadV3Request {
     fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 3 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 3 params".to_owned()));
         }
         Ok(NewPayloadV3Request {
             payload: serde_json::from_value(params[0].clone())?,
@@ -132,12 +134,16 @@ impl RpcHandler for NewPayloadV3Request {
 
 impl RpcHandler for GetPayloadV3Request {
     fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 1 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 1 param".to_owned()));
         };
         let Ok(hex_str) = serde_json::from_value::<String>(params[0].clone()) else {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams(
+                "Expected param to be a string".to_owned(),
+            ));
         };
         // Check that the hex string is 0x prefixed
         let Some(hex_str) = hex_str.strip_prefix("0x") else {

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -59,8 +59,9 @@ impl RpcHandler for NewPayloadV3Request {
 
         // Check timestamp does not fall within the time frame of the Cancun fork
         let chain_config = storage.get_chain_config()?;
-        if chain_config.get_fork(block.header.timestamp) < Fork::Cancun {
-            return Err(RpcErr::UnsuportedFork);
+        let current_fork = chain_config.get_fork(block.header.timestamp);
+        if current_fork < Fork::Cancun {
+            return Err(RpcErr::UnsuportedFork(format!("{current_fork:?}")));
         }
 
         // Check that block_hash is valid

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -170,7 +170,10 @@ impl RpcHandler for GetPayloadV3Request {
     fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
         info!("Requested payload with id: {:#018x}", self.payload_id);
         let Some(mut payload) = storage.get_payload(self.payload_id)? else {
-            return Err(RpcErr::UnknownPayload);
+            return Err(RpcErr::UnknownPayload(format!(
+                "Payload with id {:#018x} not found",
+                self.payload_id
+            )));
         };
         let block_value = build_payload(&mut payload, &storage)
             .map_err(|error| RpcErr::Internal(error.to_string()))?;

--- a/crates/networking/rpc/eth/account.rs
+++ b/crates/networking/rpc/eth/account.rs
@@ -54,13 +54,16 @@ impl RpcHandler for GetBalanceRequest {
         );
 
         let Some(block_number) = self.block.resolve_block_number(&storage)? else {
-            return Err(RpcErr::Internal); // Should we return Null here?
+            return Err(RpcErr::Internal(
+                "Could not resolve block number".to_owned(),
+            )); // Should we return Null here?
         };
 
         let account = storage.get_account_info(block_number, self.address)?;
         let balance = account.map(|acc| acc.balance).unwrap_or_default();
 
-        serde_json::to_value(format!("{:#x}", balance)).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(format!("{:#x}", balance))
+            .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -84,14 +87,17 @@ impl RpcHandler for GetCodeRequest {
         );
 
         let Some(block_number) = self.block.resolve_block_number(&storage)? else {
-            return Err(RpcErr::Internal); // Should we return Null here?
+            return Err(RpcErr::Internal(
+                "Could not resolve block number".to_owned(),
+            )); // Should we return Null here?
         };
 
         let code = storage
             .get_code_by_account_address(block_number, self.address)?
             .unwrap_or_default();
 
-        serde_json::to_value(format!("0x{:x}", code)).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(format!("0x{:x}", code))
+            .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -116,14 +122,17 @@ impl RpcHandler for GetStorageAtRequest {
         );
 
         let Some(block_number) = self.block.resolve_block_number(&storage)? else {
-            return Err(RpcErr::Internal); // Should we return Null here?
+            return Err(RpcErr::Internal(
+                "Could not resolve block number".to_owned(),
+            )); // Should we return Null here?
         };
 
         let storage_value = storage
             .get_storage_at(block_number, self.address, self.storage_slot)?
             .unwrap_or_default();
         let storage_value = H256::from_uint(&storage_value);
-        serde_json::to_value(format!("{:#x}", storage_value)).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(format!("{:#x}", storage_value))
+            .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -147,14 +156,17 @@ impl RpcHandler for GetTransactionCountRequest {
         );
 
         let Some(block_number) = self.block.resolve_block_number(&storage)? else {
-            return Err(RpcErr::Internal); // Should we return Null here?
+            return Err(RpcErr::Internal(
+                "Could not resolve block number".to_owned(),
+            )); // Should we return Null here?
         };
 
         let nonce = storage
             .get_nonce_by_account_address(block_number, self.address)?
             .unwrap_or_default();
 
-        serde_json::to_value(format!("0x{:x}", nonce)).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(format!("0x{:x}", nonce))
+            .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -188,7 +200,7 @@ impl RpcHandler for GetProofRequest {
             return Ok(Value::Null);
         };
         let Some(account_proof) = storage.get_account_proof(block_number, &self.address)? else {
-            return Err(RpcErr::Internal);
+            return Err(RpcErr::Internal("Could not get account proof".to_owned()));
         };
         // Create storage proofs for all provided storage keys
         let mut storage_proofs = Vec::new();
@@ -214,6 +226,6 @@ impl RpcHandler for GetProofRequest {
             storage_hash: account.storage_root,
             storage_proof: storage_proofs,
         };
-        serde_json::to_value(account_proof).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(account_proof).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }

--- a/crates/networking/rpc/eth/account.rs
+++ b/crates/networking/rpc/eth/account.rs
@@ -36,9 +36,11 @@ pub struct GetProofRequest {
 
 impl RpcHandler for GetBalanceRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetBalanceRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 2 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 2 params".to_owned()));
         };
         Ok(GetBalanceRequest {
             address: serde_json::from_value(params[0].clone())?,
@@ -64,9 +66,11 @@ impl RpcHandler for GetBalanceRequest {
 
 impl RpcHandler for GetCodeRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetCodeRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 2 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 2 params".to_owned()));
         };
         Ok(GetCodeRequest {
             address: serde_json::from_value(params[0].clone())?,
@@ -93,9 +97,11 @@ impl RpcHandler for GetCodeRequest {
 
 impl RpcHandler for GetStorageAtRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetStorageAtRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 3 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 3 params".to_owned()));
         };
         Ok(GetStorageAtRequest {
             address: serde_json::from_value(params[0].clone())?,
@@ -123,9 +129,11 @@ impl RpcHandler for GetStorageAtRequest {
 
 impl RpcHandler for GetTransactionCountRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetTransactionCountRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 2 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 2 params".to_owned()));
         };
         Ok(GetTransactionCountRequest {
             address: serde_json::from_value(params[0].clone())?,
@@ -152,9 +160,11 @@ impl RpcHandler for GetTransactionCountRequest {
 
 impl RpcHandler for GetProofRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 3 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 3 params".to_owned()));
         };
         let storage_keys: Vec<U256> = serde_json::from_value(params[1].clone())?;
         let storage_keys = storage_keys.iter().map(H256::from_uint).collect();

--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -57,9 +57,11 @@ pub struct GetBlobBaseFee;
 
 impl RpcHandler for GetBlockByNumberRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetBlockByNumberRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 2 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 2 params".to_owned()));
         };
         Ok(GetBlockByNumberRequest {
             block: BlockIdentifier::parse(params[0].clone(), 0)?,
@@ -96,9 +98,11 @@ impl RpcHandler for GetBlockByNumberRequest {
 
 impl RpcHandler for GetBlockByHashRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetBlockByHashRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 2 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 2 params".to_owned()));
         };
         Ok(GetBlockByHashRequest {
             block: serde_json::from_value(params[0].clone())?,
@@ -134,9 +138,11 @@ impl RpcHandler for GetBlockByHashRequest {
 
 impl RpcHandler for GetBlockTransactionCountRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetBlockTransactionCountRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 1 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 1 param".to_owned()));
         };
         Ok(GetBlockTransactionCountRequest {
             block: BlockIdentifierOrHash::parse(params[0].clone(), 0)?,
@@ -164,9 +170,11 @@ impl RpcHandler for GetBlockTransactionCountRequest {
 
 impl RpcHandler for GetBlockReceiptsRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetBlockReceiptsRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 1 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 1 param".to_owned()));
         };
         Ok(GetBlockReceiptsRequest {
             block: BlockIdentifierOrHash::parse(params[0].clone(), 0)?,
@@ -194,9 +202,11 @@ impl RpcHandler for GetBlockReceiptsRequest {
 
 impl RpcHandler for GetRawHeaderRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetRawHeaderRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 1 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 1 param".to_owned()));
         };
         Ok(GetRawHeaderRequest {
             block: BlockIdentifier::parse(params[0].clone(), 0)?,
@@ -214,7 +224,7 @@ impl RpcHandler for GetRawHeaderRequest {
         };
         let header = storage
             .get_block_header(block_number)?
-            .ok_or(RpcErr::BadParams)?;
+            .ok_or(RpcErr::BadParams("Header not found".to_owned()))?;
 
         let str_encoded = format!("0x{}", hex::encode(header.encode_to_vec()));
         Ok(Value::String(str_encoded))
@@ -223,9 +233,11 @@ impl RpcHandler for GetRawHeaderRequest {
 
 impl RpcHandler for GetRawBlockRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetRawBlockRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 1 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 1 param".to_owned()));
         };
 
         Ok(GetRawBlockRequest {
@@ -253,9 +265,11 @@ impl RpcHandler for GetRawBlockRequest {
 
 impl RpcHandler for GetRawReceipts {
     fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 1 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Expected 1 param".to_owned()));
         };
 
         Ok(GetRawReceipts {

--- a/crates/networking/rpc/eth/client.rs
+++ b/crates/networking/rpc/eth/client.rs
@@ -13,8 +13,8 @@ impl RpcHandler for ChainId {
 
     fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
         info!("Requested chain id");
-        let chain_spec = storage.get_chain_config().map_err(|_| RpcErr::Internal)?;
-        serde_json::to_value(format!("{:#x}", chain_spec.chain_id)).map_err(|_| RpcErr::Internal)
+        let chain_spec = storage.get_chain_config().map_err(|error| RpcErr::Internal(error.to_string()))?;
+        serde_json::to_value(format!("{:#x}", chain_spec.chain_id)).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 

--- a/crates/networking/rpc/eth/fee_market.rs
+++ b/crates/networking/rpc/eth/fee_market.rs
@@ -75,7 +75,7 @@ impl RpcHandler for FeeHistoryRequest {
 
         if self.block_count == 0 {
             return serde_json::to_value(FeeHistoryResponse::default())
-                .map_err(|_| RpcErr::Internal);
+                .map_err(|error| RpcErr::Internal(error.to_string()));
         }
 
         let (start_block, end_block) =
@@ -91,10 +91,14 @@ impl RpcHandler for FeeHistoryRequest {
         for block_number in start_block..end_block {
             let header = storage
                 .get_block_header(block_number)?
-                .ok_or(RpcErr::Internal)?;
+                .ok_or(RpcErr::Internal(format!(
+                    "Could not get header for block {block_number}"
+                )))?;
             let body = storage
                 .get_block_body(block_number)?
-                .ok_or(RpcErr::Internal)?;
+                .ok_or(RpcErr::Internal(format!(
+                    "Could not get body for block {block_number}"
+                )))?;
             let blob_base_fee =
                 calculate_base_fee_per_blob_gas(header.excess_blob_gas.unwrap_or_default());
 
@@ -114,7 +118,9 @@ impl RpcHandler for FeeHistoryRequest {
         // Now we project base_fee_per_gas and base_fee_per_blob_gas from last block
         let header = storage
             .get_block_header(end_block)?
-            .ok_or(RpcErr::Internal)?;
+            .ok_or(RpcErr::Internal(format!(
+                "Could not get header for block {end_block}"
+            )))?;
 
         let blob_base_fee =
             calculate_base_fee_per_blob_gas(header.excess_blob_gas.unwrap_or_default());
@@ -137,7 +143,7 @@ impl RpcHandler for FeeHistoryRequest {
                 .collect(),
         };
 
-        serde_json::to_value(response).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(response).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -152,15 +158,21 @@ impl FeeHistoryRequest {
         // Get earliest block
         let earliest_block_num = storage
             .get_earliest_block_number()?
-            .ok_or(RpcErr::Internal)?;
+            .ok_or(RpcErr::Internal(
+                "Could not get earliest block number".to_owned(),
+            ))?;
 
         // Get latest block
-        let latest_block_num = storage.get_latest_block_number()?.ok_or(RpcErr::Internal)?;
+        let latest_block_num = storage.get_latest_block_number()?.ok_or(RpcErr::Internal(
+            "Could not get latest block number".to_owned(),
+        ))?;
 
         // Get finish_block number
         let finish_block = finish_block
             .resolve_block_number(storage)?
-            .ok_or(RpcErr::Internal)?;
+            .ok_or(RpcErr::Internal(
+                "Could not resolve block number".to_owned(),
+            ))?;
 
         // finish block has to be included in the range
         let finish_block = finish_block + 1;

--- a/crates/networking/rpc/eth/filter.rs
+++ b/crates/networking/rpc/eth/filter.rs
@@ -46,7 +46,7 @@ impl FilterRequest {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|unix_time| unix_time.as_secs())
-            .map_err(|_err| RpcErr::Internal)?;
+            .map_err(|error| RpcErr::Internal(error.to_string()))?;
         let mut active_filters_guard = filters.lock().unwrap_or_else(|mut poisoned_guard| {
             error!("THREAD CRASHED WITH MUTEX TAKEN; SYSTEM MIGHT BE UNSTABLE");
             **poisoned_guard.get_mut() = HashMap::new();

--- a/crates/networking/rpc/eth/filter.rs
+++ b/crates/networking/rpc/eth/filter.rs
@@ -39,7 +39,7 @@ impl FilterRequest {
             .ok_or(RpcErr::WrongParam("toBlock".to_string()))?;
 
         if (from..=to).is_empty() {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Invalid block range".to_string()));
         }
 
         let id: u64 = random();

--- a/crates/networking/rpc/eth/logs.rs
+++ b/crates/networking/rpc/eth/logs.rs
@@ -39,7 +39,9 @@ impl RpcHandler for LogsFilter {
     fn parse(params: &Option<Vec<Value>>) -> Result<LogsFilter, RpcErr> {
         match params.as_deref() {
             Some([param]) => {
-                let param = param.as_object().ok_or(RpcErr::BadParams)?;
+                let param = param
+                    .as_object()
+                    .ok_or(RpcErr::BadParams("Param is not a object".to_owned()))?;
                 let from_block = param
                     .get("fromBlock")
                     .ok_or_else(|| RpcErr::MissingParam("fromBlock".to_string()))
@@ -73,7 +75,9 @@ impl RpcHandler for LogsFilter {
                     topics: topics_filters.unwrap_or_else(Vec::new),
                 })
             }
-            _ => Err(RpcErr::BadParams),
+            _ => Err(RpcErr::BadParams(
+                "Params are not an array of one element".to_owned(),
+            )),
         }
     }
     // TODO: This is longer than it has the right to be, maybe we should refactor it.
@@ -95,7 +99,7 @@ impl RpcHandler for LogsFilter {
             .ok_or(RpcErr::WrongParam("toBlock".to_string()))?;
 
         if (from..=to).is_empty() {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams("Empty range".to_string()));
         }
 
         let address_filter: HashSet<_> = match &self.address_filters {

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -74,9 +74,14 @@ pub struct AccessListResult {
 
 impl RpcHandler for CallRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<CallRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
-        if params.is_empty() || params.len() > 2 {
-            return Err(RpcErr::BadParams);
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 1 {
+            return Err(RpcErr::BadParams(format!(
+                "Expected one param and {} were provided",
+                params.len()
+            )));
         };
         let block = match params.get(1) {
             // Differentiate between missing and bad block param
@@ -106,15 +111,20 @@ impl RpcHandler for GetTransactionByBlockNumberAndIndexRequest {
     fn parse(
         params: &Option<Vec<Value>>,
     ) -> Result<GetTransactionByBlockNumberAndIndexRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 2 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams(format!(
+                "Expected two params and {} were provided",
+                params.len()
+            )));
         };
         let index_as_string: String = serde_json::from_value(params[1].clone())?;
         Ok(GetTransactionByBlockNumberAndIndexRequest {
             block: BlockIdentifier::parse(params[0].clone(), 0)?,
             transaction_index: usize::from_str_radix(index_as_string.trim_start_matches("0x"), 16)
-                .map_err(|_| RpcErr::BadParams)?,
+                .map_err(|error| RpcErr::BadParams(error.to_string()))?,
         })
     }
 
@@ -153,15 +163,20 @@ impl RpcHandler for GetTransactionByBlockHashAndIndexRequest {
     fn parse(
         params: &Option<Vec<Value>>,
     ) -> Result<GetTransactionByBlockHashAndIndexRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 2 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams(format!(
+                "Expected two param and {} were provided",
+                params.len()
+            )));
         };
         let index_as_string: String = serde_json::from_value(params[1].clone())?;
         Ok(GetTransactionByBlockHashAndIndexRequest {
             block: serde_json::from_value(params[0].clone())?,
             transaction_index: usize::from_str_radix(index_as_string.trim_start_matches("0x"), 16)
-                .map_err(|_| RpcErr::BadParams)?,
+                .map_err(|error| RpcErr::BadParams(error.to_string()))?,
         })
     }
     fn handle(&self, storage: Store) -> Result<Value, RpcErr> {
@@ -189,9 +204,14 @@ impl RpcHandler for GetTransactionByBlockHashAndIndexRequest {
 
 impl RpcHandler for GetTransactionByHashRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetTransactionByHashRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 1 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams(format!(
+                "Expected one param and {} were provided",
+                params.len()
+            )));
         };
         Ok(GetTransactionByHashRequest {
             transaction_hash: serde_json::from_value(params[0].clone())?,
@@ -219,9 +239,14 @@ impl RpcHandler for GetTransactionByHashRequest {
 
 impl RpcHandler for GetTransactionReceiptRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<GetTransactionReceiptRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 1 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams(format!(
+                "Expected one param and {} were provided",
+                params.len()
+            )));
         };
         Ok(GetTransactionReceiptRequest {
             transaction_hash: serde_json::from_value(params[0].clone())?,
@@ -249,9 +274,14 @@ impl RpcHandler for GetTransactionReceiptRequest {
 
 impl RpcHandler for CreateAccessListRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<CreateAccessListRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
-        if params.is_empty() || params.len() > 2 {
-            return Err(RpcErr::BadParams);
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 1 {
+            return Err(RpcErr::BadParams(format!(
+                "Expected one param and {} were provided",
+                params.len()
+            )));
         };
         let block = match params.get(1) {
             // Differentiate between missing and bad block param
@@ -325,9 +355,14 @@ impl RpcHandler for CreateAccessListRequest {
 
 impl RpcHandler for GetRawTransaction {
     fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 1 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams(format!(
+                "Expected one param and {} were provided",
+                params.len()
+            )));
         };
 
         let transaction_str: String = serde_json::from_value(params[0].clone())?;
@@ -355,9 +390,14 @@ impl RpcHandler for GetRawTransaction {
 
 impl RpcHandler for EstimateGasRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<EstimateGasRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
-        if params.is_empty() || params.len() > 2 {
-            return Err(RpcErr::BadParams);
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 1 {
+            return Err(RpcErr::BadParams(format!(
+                "Expected one param and {} were provided",
+                params.len()
+            )));
         };
         let block = match params.get(1) {
             // Differentiate between missing and bad block param
@@ -493,17 +533,24 @@ fn simulate_tx(
 
 impl RpcHandler for SendRawTransactionRequest {
     fn parse(params: &Option<Vec<Value>>) -> Result<SendRawTransactionRequest, RpcErr> {
-        let params = params.as_ref().ok_or(RpcErr::BadParams)?;
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 1 {
-            return Err(RpcErr::BadParams);
+            return Err(RpcErr::BadParams(format!(
+                "Expected one param and {} were provided",
+                params.len()
+            )));
         };
 
         let str_data = serde_json::from_value::<String>(params[0].clone())?;
-        let str_data = str_data.strip_prefix("0x").ok_or(RpcErr::BadParams)?;
-        let data = hex::decode(str_data).map_err(|_| RpcErr::BadParams)?;
+        let str_data = str_data
+            .strip_prefix("0x")
+            .ok_or(RpcErr::BadParams("Params are note 0x prefixed".to_owned()))?;
+        let data = hex::decode(str_data).map_err(|error| RpcErr::BadParams(error.to_string()))?;
 
-        let transaction =
-            SendRawTransactionRequest::decode_canonical(&data).map_err(|_| RpcErr::BadParams)?;
+        let transaction = SendRawTransactionRequest::decode_canonical(&data)
+            .map_err(|error| RpcErr::BadParams(error.to_string()))?;
 
         Ok(transaction)
     }

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -103,7 +103,8 @@ impl RpcHandler for CallRequest {
         };
         // Run transaction
         let result = simulate_tx(&self.transaction, &header, storage, SpecId::CANCUN)?;
-        serde_json::to_value(format!("0x{:#x}", result.output())).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(format!("0x{:#x}", result.output()))
+            .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -155,7 +156,7 @@ impl RpcHandler for GetTransactionByBlockNumberAndIndexRequest {
             block_header.compute_block_hash(),
             self.transaction_index,
         );
-        serde_json::to_value(tx).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(tx).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -198,7 +199,7 @@ impl RpcHandler for GetTransactionByBlockHashAndIndexRequest {
         };
         let tx =
             RpcTransaction::build(tx.clone(), block_number, self.block, self.transaction_index);
-        serde_json::to_value(tx).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(tx).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -233,7 +234,7 @@ impl RpcHandler for GetTransactionByHashRequest {
 
         let transaction =
             RpcTransaction::build(transaction, block_number, block_hash, index as usize);
-        serde_json::to_value(transaction).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(transaction).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -268,7 +269,8 @@ impl RpcHandler for GetTransactionReceiptRequest {
         };
         let receipts =
             block::get_all_block_rpc_receipts(block_number, block.header, block.body, &storage)?;
-        serde_json::to_value(receipts.get(index as usize)).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(receipts.get(index as usize))
+            .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -349,7 +351,7 @@ impl RpcHandler for CreateAccessListRequest {
             gas_used,
         };
 
-        serde_json::to_value(result).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(result).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -384,7 +386,7 @@ impl RpcHandler for GetRawTransaction {
         };
 
         serde_json::to_value(format!("0x{}", &hex::encode(tx.encode_to_vec())))
-            .map_err(|_| RpcErr::Internal)
+            .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -434,7 +436,7 @@ impl RpcHandler for EstimateGasRequest {
                 );
                 if let Ok(ExecutionResult::Success { .. }) = result {
                     return serde_json::to_value(format!("{:#x}", TRANSACTION_GAS))
-                        .map_err(|_| RpcErr::Internal);
+                        .map_err(|error| RpcErr::Internal(error.to_string()));
                 }
             }
         }
@@ -489,7 +491,8 @@ impl RpcHandler for EstimateGasRequest {
             middle_gas_limit = (highest_gas_limit + lowest_gas_limit) / 2;
         }
 
-        serde_json::to_value(format!("{:#x}", highest_gas_limit)).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(format!("{:#x}", highest_gas_limit))
+            .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -561,6 +564,7 @@ impl RpcHandler for SendRawTransactionRequest {
         let tx = self.to_transaction();
 
         let hash = mempool::add_transaction(tx, storage)?;
-        serde_json::to_value(format!("{:#x}", hash)).map_err(|_| RpcErr::Internal)
+        serde_json::to_value(format!("{:#x}", hash))
+            .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -164,7 +164,7 @@ pub fn map_http_requests(
         Ok(RpcNamespace::Eth) => map_eth_requests(req, storage, filters),
         Ok(RpcNamespace::Admin) => map_admin_requests(req, storage, local_p2p_node),
         Ok(RpcNamespace::Debug) => map_debug_requests(req, storage),
-        _ => Err(RpcErr::MethodNotFound),
+        _ => Err(RpcErr::MethodNotFound(req.method.clone())),
     }
 }
 
@@ -177,7 +177,7 @@ pub fn map_authrpc_requests(
     match req.namespace() {
         Ok(RpcNamespace::Engine) => map_engine_requests(req, storage),
         Ok(RpcNamespace::Eth) => map_eth_requests(req, storage, active_filters),
-        _ => Err(RpcErr::MethodNotFound),
+        _ => Err(RpcErr::MethodNotFound(req.method.clone())),
     }
 }
 
@@ -218,7 +218,7 @@ pub fn map_eth_requests(
         "eth_newFilter" => FilterRequest::stateful_call(req, storage, filters),
         "eth_sendRawTransaction" => SendRawTransactionRequest::call(req, storage),
         "eth_getProof" => GetProofRequest::call(req, storage),
-        _ => Err(RpcErr::MethodNotFound),
+        unknown_eth_method => Err(RpcErr::MethodNotFound(unknown_eth_method.to_owned())),
     }
 }
 
@@ -228,7 +228,7 @@ pub fn map_debug_requests(req: &RpcRequest, storage: Store) -> Result<Value, Rpc
         "debug_getRawBlock" => GetRawBlockRequest::call(req, storage),
         "debug_getRawTransaction" => GetRawTransaction::call(req, storage),
         "debug_getRawReceipts" => GetRawReceipts::call(req, storage),
-        _ => Err(RpcErr::MethodNotFound),
+        unknown_debug_method => Err(RpcErr::MethodNotFound(unknown_debug_method.to_owned())),
     }
 }
 
@@ -241,7 +241,7 @@ pub fn map_engine_requests(req: &RpcRequest, storage: Store) -> Result<Value, Rp
             ExchangeTransitionConfigV1Req::call(req, storage)
         }
         "engine_getPayloadV3" => GetPayloadV3Request::call(req, storage),
-        _ => Err(RpcErr::MethodNotFound),
+        unknown_engine_method => Err(RpcErr::MethodNotFound(unknown_engine_method.to_owned())),
     }
 }
 
@@ -252,7 +252,7 @@ pub fn map_admin_requests(
 ) -> Result<Value, RpcErr> {
     match req.method.as_str() {
         "admin_nodeInfo" => admin::node_info(storage, local_p2p_node),
-        _ => Err(RpcErr::MethodNotFound),
+        unknown_admin_method => Err(RpcErr::MethodNotFound(unknown_admin_method.to_owned())),
     }
 }
 

--- a/crates/networking/rpc/types/block_identifier.rs
+++ b/crates/networking/rpc/types/block_identifier.rs
@@ -50,8 +50,9 @@ impl BlockIdentifier {
             return Ok(BlockIdentifier::Tag(tag));
         };
         // Parse BlockNumber
-        let Ok(hex_str) = serde_json::from_value::<String>(serde_value) else {
-            return Err(RpcErr::BadParams);
+        let hex_str = match serde_json::from_value::<String>(serde_value) {
+            Ok(hex_str) => hex_str,
+            Err(error) => return Err(RpcErr::BadParams(error.to_string())),
         };
         // Check that the BlockNumber is 0x prefixed
         let Some(hex_str) = hex_str.strip_prefix("0x") else {

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -8,7 +8,7 @@ use ethereum_rust_blockchain::error::MempoolError;
 
 #[derive(Debug, Deserialize)]
 pub enum RpcErr {
-    MethodNotFound,
+    MethodNotFound(String),
     WrongParam(String),
     BadParams,
     MissingParam(String),
@@ -26,10 +26,10 @@ pub enum RpcErr {
 impl From<RpcErr> for RpcErrorMetadata {
     fn from(value: RpcErr) -> Self {
         match value {
-            RpcErr::MethodNotFound => RpcErrorMetadata {
+            RpcErr::MethodNotFound(bad_method) => RpcErrorMetadata {
                 code: -32601,
                 data: None,
-                message: "Method not found".to_string(),
+                message: format!("Method not found: {bad_method}"),
             },
             RpcErr::WrongParam(field) => RpcErrorMetadata {
                 code: -32602,
@@ -159,10 +159,10 @@ impl RpcRequest {
                 "eth" => Ok(RpcNamespace::Eth),
                 "admin" => Ok(RpcNamespace::Admin),
                 "debug" => Ok(RpcNamespace::Debug),
-                _ => Err(RpcErr::MethodNotFound),
+                _ => Err(RpcErr::MethodNotFound(self.method.clone())),
             }
         } else {
-            Err(RpcErr::MethodNotFound)
+            Err(RpcErr::MethodNotFound(self.method.clone()))
         }
     }
 }

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -10,7 +10,7 @@ use ethereum_rust_blockchain::error::MempoolError;
 pub enum RpcErr {
     MethodNotFound(String),
     WrongParam(String),
-    BadParams,
+    BadParams(String),
     MissingParam(String),
     BadHexFormat(u64),
     UnsuportedFork,
@@ -36,10 +36,10 @@ impl From<RpcErr> for RpcErrorMetadata {
                 data: None,
                 message: format!("Field '{}' is incorrect or has an unknown format", field),
             },
-            RpcErr::BadParams => RpcErrorMetadata {
+            RpcErr::BadParams(context) => RpcErrorMetadata {
                 code: -32000,
                 data: None,
-                message: "Invalid params".to_string(),
+                message: format!("Invalid params: {context}"),
             },
             RpcErr::MissingParam(parameter_name) => RpcErrorMetadata {
                 code: -32000,
@@ -115,16 +115,16 @@ impl From<RpcErr> for RpcErrorMetadata {
 }
 
 impl From<serde_json::Error> for RpcErr {
-    fn from(_: serde_json::Error) -> Self {
-        Self::BadParams
+    fn from(error: serde_json::Error) -> Self {
+        Self::BadParams(error.to_string())
     }
 }
 
 // TODO: Actually return different errors for each case
 // here we are returning a BadParams error
 impl From<MempoolError> for RpcErr {
-    fn from(_: MempoolError) -> Self {
-        Self::BadParams
+    fn from(error: MempoolError) -> Self {
+        Self::BadParams(error.to_string())
     }
 }
 

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -14,7 +14,7 @@ pub enum RpcErr {
     MissingParam(String),
     BadHexFormat(u64),
     UnsuportedFork,
-    Internal,
+    Internal(String),
     Vm,
     Revert { data: String },
     Halt { reason: String, gas_used: u64 },
@@ -56,10 +56,10 @@ impl From<RpcErr> for RpcErrorMetadata {
                 data: None,
                 message: format!("invalid argument {arg_number} : hex string without 0x prefix"),
             },
-            RpcErr::Internal => RpcErrorMetadata {
+            RpcErr::Internal(context) => RpcErrorMetadata {
                 code: -32603,
                 data: None,
-                message: "Internal Error".to_string(),
+                message: format!("Internal Error: {context}"),
             },
             RpcErr::Vm => RpcErrorMetadata {
                 code: -32015,
@@ -191,8 +191,8 @@ pub struct RpcErrorResponse {
 
 /// Failure to read from DB will always constitute an internal error
 impl From<StoreError> for RpcErr {
-    fn from(_value: StoreError) -> Self {
-        RpcErr::Internal
+    fn from(value: StoreError) -> Self {
+        RpcErr::Internal(value.to_string())
     }
 }
 

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -13,7 +13,7 @@ pub enum RpcErr {
     BadParams(String),
     MissingParam(String),
     BadHexFormat(u64),
-    UnsuportedFork,
+    UnsuportedFork(String),
     Internal(String),
     Vm(String),
     Revert { data: String },
@@ -46,10 +46,10 @@ impl From<RpcErr> for RpcErrorMetadata {
                 data: None,
                 message: format!("Expected parameter: {parameter_name} is missing"),
             },
-            RpcErr::UnsuportedFork => RpcErrorMetadata {
+            RpcErr::UnsuportedFork(context) => RpcErrorMetadata {
                 code: -38005,
                 data: None,
-                message: "Unsupported fork".to_string(),
+                message: format!("Unsupported fork: {context}"),
             },
             RpcErr::BadHexFormat(arg_number) => RpcErrorMetadata {
                 code: -32602,

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -20,7 +20,7 @@ pub enum RpcErr {
     Halt { reason: String, gas_used: u64 },
     AuthenticationError(AuthenticationError),
     InvalidForkChoiceState(String),
-    UnknownPayload,
+    UnknownPayload(String),
 }
 
 impl From<RpcErr> for RpcErrorMetadata {
@@ -105,10 +105,10 @@ impl From<RpcErr> for RpcErrorMetadata {
                 data: Some(data),
                 message: "Invalid forkchoice state".to_string(),
             },
-            RpcErr::UnknownPayload => RpcErrorMetadata {
+            RpcErr::UnknownPayload(context) => RpcErrorMetadata {
                 code: -38001,
                 data: None,
-                message: "Unknown payload".to_string(),
+                message: format!("Unknown payload: {context}"),
             },
         }
     }

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -15,7 +15,7 @@ pub enum RpcErr {
     BadHexFormat(u64),
     UnsuportedFork,
     Internal(String),
-    Vm,
+    Vm(String),
     Revert { data: String },
     Halt { reason: String, gas_used: u64 },
     AuthenticationError(AuthenticationError),
@@ -61,10 +61,10 @@ impl From<RpcErr> for RpcErrorMetadata {
                 data: None,
                 message: format!("Internal Error: {context}"),
             },
-            RpcErr::Vm => RpcErrorMetadata {
+            RpcErr::Vm(context) => RpcErrorMetadata {
                 code: -32015,
                 data: None,
-                message: "Vm execution error".to_string(),
+                message: format!("Vm execution error: {context}"),
             },
             RpcErr::Revert { data } => RpcErrorMetadata {
                 // This code (3) was hand-picked to match hive tests.
@@ -197,8 +197,8 @@ impl From<StoreError> for RpcErr {
 }
 
 impl From<EvmError> for RpcErr {
-    fn from(_value: EvmError) -> Self {
-        RpcErr::Vm
+    fn from(value: EvmError) -> Self {
+        RpcErr::Vm(value.to_string())
     }
 }
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

RPC errors are usually inherited from other errors and during such mapping, the context of the original error is lost, making it difficult to debug, and impossible in some cases.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

In this PR I propose the addition of contexts as a `String`s to the RPC errors.

