### PR TITLE
fix: rename `log-level` to `log.level` for consistency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Ethereum Rust supports the following command line arguments:
 - `--discovery.addr <ADDRESS>`: UDP address for P2P discovery. Default value: 0.0.0.0.
 - `--discovery.port <PORT>`: UDP port for P2P discovery. Default value: 30303.
 - `--bootnodes <BOOTNODE_LIST>`: Comma separated enode URLs for P2P discovery bootstrap.
-- `--log-level <LOG_LEVEL>`: The verbosity level used for logs. Default value: info. possible values: info, debug, trace, warn, error
+- `--log.level <LOG_LEVEL>`: The verbosity level used for logs. Default value: info. possible values: info, debug, trace, warn, error
 
 # Crates documentation
 

--- a/cmd/ethereum_rust/cli.rs
+++ b/cmd/ethereum_rust/cli.rs
@@ -21,8 +21,8 @@ pub fn cli() -> Command {
                 .action(ArgAction::Set),
         )
         .arg(
-            Arg::new("log-level")
-                .long("log-level")
+            Arg::new("log.level")
+                .long("log.level")
                 .default_value(Level::INFO.as_str())
                 .value_name("LOG_LEVEL")
                 .required(false)

--- a/cmd/ethereum_rust/ethereum_rust.rs
+++ b/cmd/ethereum_rust/ethereum_rust.rs
@@ -41,8 +41,8 @@ async fn main() {
     }
 
     let log_level = matches
-        .get_one::<String>("log-level")
-        .expect("shouldn't happen, log-level is used with a default value");
+        .get_one::<String>("log.level")
+        .expect("shouldn't happen, log.level is used with a default value");
     let log_level = Level::from_str(log_level).expect("Not supported log level provided");
     let subscriber = FmtSubscriber::builder().with_max_level(log_level).finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");


### PR DESCRIPTION
**Motivation**
Make cli args consistent
