### PR TITLE
ci: make pr title scopes mandatory.

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,8 +7,6 @@ on:
       - opened
       - edited
       - synchronize
-      - labeled
-      - unlabeled
 
 jobs:
   main:
@@ -71,6 +69,6 @@ jobs:
           # validation is skipped. If you want to rerun the validation when
           # labels change, you might want to use the `labeled` and `unlabeled`
           # event triggers in your workflow.
-          ignoreLabels: |
-            bot
-            ignore-semantic-pull-request
+          # ignoreLabels: |
+          #   bot
+          #   ignore-semantic-pull-request

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -40,10 +40,14 @@ jobs:
 
           # Configure which scopes are allowed (newline-delimited).
           # These are regex patterns auto-wrapped in `^ $`.
-          #scopes: |
+          scopes: |
+            core
+            l1
+            l2
+            levm
 
           # Configure that a scope must always be provided.
-          requireScope: false
+          requireScope: true
 
           # Configure which scopes are disallowed in PR titles (newline-delimited).
           # For instance by setting the value below, `chore(release): ...` (lowercase)


### PR DESCRIPTION
**Motivation**
To be able to easily differentiate between PRs on different parts of the project and to make them consistent.
